### PR TITLE
Allow members to join region, if part of UK

### DIFF
--- a/app/Modules/Community/Policies/MembershipPolicy.php
+++ b/app/Modules/Community/Policies/MembershipPolicy.php
@@ -12,6 +12,6 @@ class MembershipPolicy
 
     public function deploy(Account $user, Membership $membership)
     {
-        return $user->communityGroups()->count() == 0;
+        return $user->communityGroups()->notDefault()->count() == 0;
     }
 }


### PR DESCRIPTION
When members were trying to go back and join another region-based community, after selecting UK ONLY, they were told it was unauthorised.  Resolved by removing the default group from the count.