### PR TITLE
Patches/remove data restrictions from community group module

### DIFF
--- a/app/Modules/Community/Http/Controllers/Site/Membership.php
+++ b/app/Modules/Community/Http/Controllers/Site/Membership.php
@@ -10,10 +10,6 @@ class Membership extends BaseController
 {
     public function getDeploy()
     {
-        if (\Carbon\Carbon::now()->lt(\Carbon\Carbon::parse('15th December 2016 00:00:00 GMT'))) {
-            return redirect()->route('mship.manage.dashboard')->withError('The Community Groups feature is not yet enabled.');
-        }
-
         $this->authorize('deploy', new \App\Modules\Community\Models\Membership());
 
         $defaultGroup = Group::isDefault()->first();

--- a/app/Modules/Community/Http/Middleware/MustHaveCommunityGroup.php
+++ b/app/Modules/Community/Http/Middleware/MustHaveCommunityGroup.php
@@ -25,10 +25,6 @@ class MustHaveCommunityGroup
      */
     public function handle($request, Closure $next)
     {
-        if (\Carbon\Carbon::now()->lt(\Carbon\Carbon::parse('15th December 2016 00:00:00'))) {
-            return $next($request);
-        }
-
         if (in_array(\Route::current()->getName(), $this->excludedRoutes)) {
             return $next($request);
         }

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -126,7 +126,7 @@
                 </div>
             </div>
 
-            @if(($_account->hasState("DIVISION") || $_account->hasState("TRANSFERRING")) && \Carbon\Carbon::now()->gte(\Carbon\Carbon::parse("15th December 2016 00:00:00 GMT")))
+            @if($_account->hasState("DIVISION") || $_account->hasState("TRANSFERRING"))
                 <div class="col-md-12">
                     <div class="panel panel-ukblue">
                         <div class="panel-heading"><i class="fa fa-cogs"></i>


### PR DESCRIPTION
Date restrictions were in place to avoid member interaction prior to the 15th December.  These can now be removed.