### PR TITLE
Hotfix: Fixing V/T error from multiple reference requests

### DIFF
--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -372,8 +372,8 @@ class Account extends \App\Models\Model implements AuthenticatableContract
         return $this->visitTransferReferee->filter(function ($ref) {
             return $ref->is_requested;
         })->sortBy(function ($ref) {
-+            return $ref->application->submitted_at;
-         });
+            return $ref->application->submitted_at;
+        });
     }
 
     /**

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -371,9 +371,9 @@ class Account extends \App\Models\Model implements AuthenticatableContract
     {
         return $this->visitTransferReferee->filter(function ($ref) {
             return $ref->is_requested;
-        })->sort(function ($ref1, $ref2) {
-            return $ref1->application->submitted_at->lt($ref2->application->submitted_at);
-        });
+        })->sortBy(function ($ref) {
++            return $ref->application->submitted_at;
+         });
     }
 
     /**

--- a/app/Modules/Visittransfer/Resources/Views/site/reference/_layout.blade.php
+++ b/app/Modules/Visittransfer/Resources/Views/site/reference/_layout.blade.php
@@ -15,7 +15,7 @@
                         @foreach(Auth::user()->visit_transfer_referee_pending as $ref)
 
                             <li role="presentation" {!! (Route::is("visiting.reference.complete") && $reference->id == $ref->id ? "class='active'" : "") !!}>
-                                {{ link_to_route("visiting.reference.complete", $application->account->name." - ".$application->type_string." ".$application->facility->name, [$ref->token->code], ["class" => (Route::is("visiting.reference.complete")  && $reference->id == $ref->id ? "active" : "")]) }}
+                                {{ link_to_route("visiting.reference.complete", $ref->application->account->name." - ".$ref->application->type_string." ".$ref->application->facility->name, [$ref->token->code], ["class" => (Route::is("visiting.reference.complete")  && $reference->id == $ref->id ? "active" : "")]) }}
                             </li>
 
                         @endforeach


### PR DESCRIPTION
The sorting function currently is use throws a uasort() error (when the referee has multiple reference requests) as, even though it may be unmodified, if it is run through any debug function, it thinks it has been. It is a documented PHP bug.

Fixed that by using the sortBy function over sort, which produces the same results as if the code before had been used and worked.

Also, whilst investigating, found that if a referee has multiple reference requests, the applications are shown incorrectly in the "Pending Applications", as it only used the application that the referee was currently visiting to populate the foreach().

This fixes #750
