### PR TITLE
Overlapping texts

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -180,7 +180,7 @@ body, html {
   border-top-right-radius: 0px;
 }
 
-.panel-ukblue .panel-body .row-text-contain{
+.panel-ukblue .panel-body .row-text-contain {
   word-break: break-word;
 }
 

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -180,6 +180,10 @@ body, html {
   border-top-right-radius: 0px;
 }
 
+.panel-ukblue .panel-body .row-text-contain{
+  word-break: break-word;
+}
+
 /* Airfield Data CSS */
 
 .runway_container{

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -228,13 +228,13 @@
 
                             <div class="col-md-6">
                                 <div class="row">
-                                    <div class="col-md-6 row-text-contain">
+                                    <div class="col-xs-6 row-text-contain">
                                         <b>ATC QUALIFICATIONS</b>
                                         <br />
                                         <small>Showing all achieved</small>
                                     </div>
 
-                                    <div class="col-md-6">
+                                    <div class="col-xs-6">
 
                                         @foreach($_account->qualifications_atc as $qual)
                                             {{ $qual }}

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -142,17 +142,14 @@
 
                                 <div class="col-md-7">
                                     <div class="row">
-                                        <div class="col-xs-5 row-text-contain">
+                                        <div class="col-md-12">
                                             <p align="center">
                                                 <b>CURRENT MEMBERSHIP(S)</b>
                                             </p>
                                         </div>
 
-                                        <div class="col-xs-7">
-
-
-
-                                            <table class="table">
+                                        <div class="col-md-12">
+                                          <table class="table">
                                                 @forelse($_account->communityGroups as $cg)
                                                     <tr>
                                                         <th>{{ $cg->name }}</th>
@@ -192,13 +189,13 @@
 
                                 <div class="col-md-5">
                                     <div class="row">
-                                        <div class="col-xs-5">
+                                        <div class="col-md-12">
                                             <p align="center">
                                               <b>TOTAL POINTS</b>
                                             </p>
                                         </div>
 
-                                        <div class="col-xs-7 row-text-contain">
+                                        <div class="col-md-12">
                                             <table class="table">
                                                 <tr>
                                                     <th>Weekly</th>
@@ -231,13 +228,13 @@
 
                             <div class="col-md-6">
                                 <div class="row">
-                                    <div class="col-xs-5 row-text-contain">
+                                    <div class="col-md-6 row-text-contain">
                                         <b>ATC QUALIFICATIONS</b>
                                         <br />
                                         <small>Showing all achieved</small>
                                     </div>
 
-                                    <div class="col-xs-7">
+                                    <div class="col-md-6">
 
                                         @foreach($_account->qualifications_atc as $qual)
                                             {{ $qual }}
@@ -264,13 +261,13 @@
 
                             <div class="col-md-6">
                                 <div class="row">
-                                    <div class="col-xs-5 row-text-contain">
+                                    <div class="col-xs-6 row-text-contain">
                                         <b>PILOT QUALIFICATIONS</b>
                                         <br />
                                         <small>Showing all achieved</small>
                                     </div>
 
-                                    <div class="col-xs-7">
+                                    <div class="col-xs-6">
 
                                         @foreach($_account->qualifications_pilot as $qual)
                                             {{ $qual }}

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -228,14 +228,12 @@
 
                             <div class="col-md-6">
                                 <div class="row">
-                                    <div class="col-xs-6 row-text-contain">
+                                    <div class="col-xs-6 col-lg-6 col-md-12 row-text-contain text-center">
                                         <b>ATC QUALIFICATIONS</b>
                                         <br />
                                         <small>Showing all achieved</small>
                                     </div>
-
-                                    <div class="col-xs-6">
-
+                                    <div class="col-xs-6 col-lg-6 col-md-12 text-center">
                                         @foreach($_account->qualifications_atc as $qual)
                                             {{ $qual }}
                                             <a class="tooltip_displays" href="#" data-toggle="tooltip" title="{{ $qual->pivot->created_at }}">
@@ -261,13 +259,12 @@
 
                             <div class="col-md-6">
                                 <div class="row">
-                                    <div class="col-xs-6 row-text-contain">
+                                    <div class="col-xs-6 col-lg-6 col-md-12 row-text-contain text-center">
                                         <b>PILOT QUALIFICATIONS</b>
                                         <br />
                                         <small>Showing all achieved</small>
                                     </div>
-
-                                    <div class="col-xs-6">
+                                    <div class="col-xs-6 col-lg-6 col-md-12 text-center">
 
                                         @foreach($_account->qualifications_pilot as $qual)
                                             {{ $qual }}

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -140,9 +140,9 @@
                         <div class="panel-body">
                             <div class="row">
 
-                                <div class="col-md-6">
+                                <div class="col-md-7">
                                     <div class="row">
-                                        <div class="col-xs-5">
+                                        <div class="col-xs-5 row-text-contain">
                                             <p align="center">
                                                 <b>CURRENT MEMBERSHIP(S)</b>
                                             </p>
@@ -190,13 +190,15 @@
                                     </div>
                                 </div>
 
-                                <div class="col-md-6">
+                                <div class="col-md-5">
                                     <div class="row">
                                         <div class="col-xs-5">
-                                            <b>TOTAL POINTS</b>
+                                            <p align="center">
+                                              <b>TOTAL POINTS</b>
+                                            </p>
                                         </div>
 
-                                        <div class="col-xs-7">
+                                        <div class="col-xs-7 row-text-contain">
                                             <table class="table">
                                                 <tr>
                                                     <th>Weekly</th>
@@ -229,13 +231,13 @@
 
                             <div class="col-md-6">
                                 <div class="row">
-                                    <div class="col-xs-4">
+                                    <div class="col-xs-5 row-text-contain">
                                         <b>ATC QUALIFICATIONS</b>
                                         <br />
                                         <small>Showing all achieved</small>
                                     </div>
 
-                                    <div class="col-xs-8">
+                                    <div class="col-xs-7">
 
                                         @foreach($_account->qualifications_atc as $qual)
                                             {{ $qual }}
@@ -262,13 +264,13 @@
 
                             <div class="col-md-6">
                                 <div class="row">
-                                    <div class="col-xs-4">
+                                    <div class="col-xs-5 row-text-contain">
                                         <b>PILOT QUALIFICATIONS</b>
                                         <br />
                                         <small>Showing all achieved</small>
                                     </div>
 
-                                    <div class="col-xs-8">
+                                    <div class="col-xs-7">
 
                                         @foreach($_account->qualifications_pilot as $qual)
                                             {{ $qual }}
@@ -396,7 +398,7 @@
                                             No registrations found.
                                         @endif
                                         @foreach ($_account->teamspeakRegistrations as $tsreg)
-                                            <div class="col-xs-6">
+                                            <div class="col-xs-6 row-text-contain">
                                                 [ <strong>Registration #{{ $tsreg->id }}</strong> ]<br />
                                                 <strong>CREATED</strong>:
 


### PR DESCRIPTION
Added a new CSS class so that columns can, where necessary, break the text to fit within their bounds.

Implemented into the dashboard where needed (Community groups, TeamSpeak registrations and account qualifications).

![](https://img.cobaltgrid.com/9d5d53b2a0ef549523f6.png)

**Gulp will need to be run on deployment**

Closes #655
