### PR TITLE
Hotfix: Error when trying to delete reference (referee)

### DIFF
--- a/app/Modules/Visittransfer/Http/Controllers/Site/Application.php
+++ b/app/Modules/Visittransfer/Http/Controllers/Site/Application.php
@@ -157,7 +157,7 @@ class Application extends BaseController
         return Redirect::route($redirectRoute, [$application->public_id])->withSuccess('Referee '.Input::get('referee_cid').' added successfully! They will not be contacted until you submit your application.');
     }
 
-    public function postRefereeDelete(ApplicationRefereeDeleteRequest $request, Reference $reference, \App\Modules\Visittransfer\Models\Application $application)
+    public function postRefereeDelete(ApplicationRefereeDeleteRequest $request, \App\Modules\Visittransfer\Models\Application $application, Reference $reference)
     {
         $reference->delete();
 


### PR DESCRIPTION
Re-arranged the order of `postRefereeDelete`'s parameters so that the `$reference` is in the right place (and converted to a model correctly) 

Closes #841  