### PR TITLE
Add admin mobile menu ability (+ fix some styling)

### DIFF
--- a/resources/assets/css/AdminLTE/AdminLTE.css
+++ b/resources/assets/css/AdminLTE/AdminLTE.css
@@ -603,7 +603,7 @@ body > .header .logo .icon {
     float: right;
   }
 }
-@media screen and (max-width: 560px) {
+@media screen and (max-width: 992px) {
   body > .header {
     position: relative;
   }

--- a/resources/views/adm/layout.blade.php
+++ b/resources/views/adm/layout.blade.php
@@ -62,8 +62,12 @@
         @if(!isset($shellOnly) OR !$shellOnly)
             <header class="header">
                 <a href="{{ URL::route("adm.dashboard") }}" class="logo">
-                    <!-- Add the class icon to your logo image or logo icon to add the margining -->
-                    VATSIM UK
+                  <!-- Add the class icon to your logo image or logo icon to add the margining -->
+                  <div class="hidden-md hidden-lg" style="float:left;">
+                    <span data-toggle="offcanvas">
+                      <i class="fa fa-bars" aria-hidden="true"></i>
+                    </span>
+                  </div> VATSIM UK
                 </a>
                 <!-- Header Navbar: style can be found in header.less -->
                 <nav class="navbar navbar-static-top" role="navigation">
@@ -177,7 +181,7 @@
                 singleton : true,
             });
         </script>
-        
+
         <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
1) Address issue #420 : Added in the sidebar toggle button, which will only be visible in the view widths where the sidebar is hidden. When clicked, it shows the sidebar, and again to close it.

2) Address some styling issues found:
In the SM stage, the "logo" section seems to continue the style that it had when the sidebar was below it. But, however, this sidebar is no longer there in the SM stage, and therefore it looks out of place:
![75fc4878d68963288dce](https://cloud.githubusercontent.com/assets/17804618/23137873/72899a10-f79c-11e6-9e45-d459211feda4.png)

Turned into this:
![a73d1ce3222b4d79855f](https://cloud.githubusercontent.com/assets/17804618/23137878/7983d70e-f79c-11e6-8591-8ece9db31d09.png)

Closes #420

