### PR TITLE
Fix note not being assigned correct type

### DIFF
--- a/app/Http/Controllers/Adm/Mship/Account.php
+++ b/app/Http/Controllers/Adm/Mship/Account.php
@@ -478,7 +478,7 @@ class Account extends AdmController
         }
 
         // Let's make a note and attach it to the user!
-        $account->addNote($noteType->id, Input::get('content'), Auth::user());
+        $account->addNote($noteType, Input::get('content'), Auth::user());
 
         return Redirect::route('adm.mship.account.details', [$account->id, 'notes'])
                        ->withSuccess('The note has been saved successfully!');


### PR DESCRIPTION
Notes added via ACP where not being assigned their correct note type. This is because of the following logic:
`
if (is_object($noteType) && $noteType->exists) {
            $noteType = $noteType->getKey();
} else {
            $noteType = Type::isDefault()->first()->getKey();
}
` from Models\Mship\Account@Line 1117
If a note type object is not passed, then it will default to system generated. In this case, the function was being sent an integer (the ID of the note type), and not the object.

Closes #855 