### PR TITLE
Fix V/T "referee not in region"

### DIFF
--- a/app/Modules/Visittransfer/Http/Requests/ApplicationRefereeAddRequest.php
+++ b/app/Modules/Visittransfer/Http/Requests/ApplicationRefereeAddRequest.php
@@ -70,7 +70,7 @@ class ApplicationRefereeAddRequest extends FormRequest
         $referee = Account::findOrRetrieve(array_get($data, 'referee_cid', null));
 
         try {
-            if ($referee->primary_permanent_state->pivot->region == \Auth::user()->primary_state->pivot->region) {
+            if ($referee->primary_permanent_state->pivot->region == \Auth::user()->primary_permanent_state->pivot->region) {
                 $data['must_be_home_region'] = true;
             }
         } catch (ErrorException $e) { // If we don't have this data, we shouldn't penalise the applicant _at this point_.


### PR DESCRIPTION
There was a slight bug where the state used for comparison against the referee's was selected with `->primary_state` and not `->primary_permanent_state`, as is needed to ensure that temp states are not considered.


Closes #870 