### PR TITLE
Allow referees to state they do not know the applicant

### DIFF
--- a/app/Console/Commands/TestEmails.php
+++ b/app/Console/Commands/TestEmails.php
@@ -21,9 +21,9 @@ use App\Notifications\ApplicationStatusChanged;
 use App\Notifications\ApplicationReferenceRequest;
 use App\Notifications\ApplicationReferenceAccepted;
 use App\Notifications\ApplicationReferenceRejected;
-use App\Notifications\ApplicationReferenceCancelled;
 use App\Notifications\ApplicationReferenceSubmitted;
 use App\Notifications\Mship\Security\TemporaryPassword;
+use App\Notifications\ApplicationReferenceNoLongerNeeded;
 use App\Notifications\Mship\Security\ForgottenPasswordLink;
 
 /**
@@ -139,7 +139,7 @@ class TestEmails extends Command
         // visiting/transfer
         $testAccount->notify(new ApplicationAccepted($testApplication));
         $testAccount->notify(new ApplicationReferenceAccepted($testReference));
-        $testReference->notify(new ApplicationReferenceCancelled($testReference));
+        $testReference->notify(new ApplicationReferenceNoLongerNeeded($testReference));
         $testAccount->notify(new ApplicationReferenceRejected($testReference));
         $testReference->notify(new ApplicationReferenceRequest($testReference));
         $testAccount->notify(new ApplicationReferenceSubmitted($testReference));

--- a/app/Events/VisitTransfer/ReferenceCancelled.php
+++ b/app/Events/VisitTransfer/ReferenceCancelled.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events\VisitTransfer;
+
+use App\Events\Event;
+use Illuminate\Queue\SerializesModels;
+use App\Models\VisitTransfer\Reference;
+
+class ReferenceCancelled
+{
+    use SerializesModels;
+
+    public $reference = null;
+
+    public function __construct(Reference $reference)
+    {
+        $this->reference = $reference;
+    }
+
+}

--- a/app/Http/Controllers/VisitTransfer/Site/Reference.php
+++ b/app/Http/Controllers/VisitTransfer/Site/Reference.php
@@ -38,4 +38,14 @@ class Reference extends BaseController
 
         return Redirect::route('visiting.landing')->withSuccess('You have successfully completed a reference for '.$reference->application->account->name.'.  Thank you.');
     }
+
+    public function postCancel(Token $token){
+        $reference = $token->related;
+        $reference->cancel();
+
+        $reference->application->markAsUnderReview();
+
+
+        return Redirect::route('visiting.landing')->withSuccess('You have canceled your reference for '.$reference->application->account->name.'.  Thank you.');
+    }
 }

--- a/app/Listeners/VisitTransfer/NotifyApplicantOfReferenceCancellation.php
+++ b/app/Listeners/VisitTransfer/NotifyApplicantOfReferenceCancellation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Listeners\VisitTransfer;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Events\VisitTransfer\ReferenceCancelled;
+use App\Notifications\ApplicationReferenceCancelled;
+
+class NotifyApplicantOfReferenceCancellation implements ShouldQueue
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function handle(ReferenceCancelled $event)
+    {
+        $reference = $event->reference;
+        $reference->application->account->notify(new ApplicationReferenceCancelled($reference));
+    }
+}

--- a/app/Listeners/VisitTransfer/NotifyApplicantOfStatusChange.php
+++ b/app/Listeners/VisitTransfer/NotifyApplicantOfStatusChange.php
@@ -3,7 +3,8 @@
 namespace App\Listeners\VisitTransfer;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
-use App\Events\VisitTransfer\ApplicationStatusChanged;
+use App\Events\VisitTransfer\ApplicationStatusChanged as ApplicationStatusChangedEvent;
+use App\Notifications\ApplicationStatusChanged;
 
 class NotifyApplicantOfStatusChange implements ShouldQueue
 {
@@ -12,7 +13,7 @@ class NotifyApplicantOfStatusChange implements ShouldQueue
         //
     }
 
-    public function handle(ApplicationStatusChanged $event)
+    public function handle(ApplicationStatusChangedEvent $event)
     {
         $application = $event->application;
         $application->account->notify(new ApplicationStatusChanged($application));

--- a/app/Listeners/VisitTransfer/NotifyRefereeOfReferenceDeletion.php
+++ b/app/Listeners/VisitTransfer/NotifyRefereeOfReferenceDeletion.php
@@ -4,7 +4,7 @@ namespace App\Listeners\VisitTransfer;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use App\Events\VisitTransfer\ReferenceDeleted;
-use App\Notifications\ApplicationReferenceCancelled;
+use App\Notifications\ApplicationReferenceNoLongerNeeded;
 
 class NotifyRefereeOfReferenceDeletion implements ShouldQueue
 {
@@ -15,6 +15,6 @@ class NotifyRefereeOfReferenceDeletion implements ShouldQueue
 
     public function handle(ReferenceDeleted $event)
     {
-        $event->reference->notify(new ApplicationReferenceCancelled($event->reference));
+        $event->reference->notify(new ApplicationReferenceNoLongerNeeded($event->reference));
     }
 }

--- a/app/Notifications/ApplicationReferenceNoLongerNeeded.php
+++ b/app/Notifications/ApplicationReferenceNoLongerNeeded.php
@@ -7,7 +7,7 @@ use App\Models\VisitTransfer\Reference;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 
-class ApplicationReferenceCancelled extends Notification implements ShouldQueue
+class ApplicationReferenceNoLongerNeeded extends Notification implements ShouldQueue
 {
     use Queueable;
 
@@ -46,12 +46,17 @@ class ApplicationReferenceCancelled extends Notification implements ShouldQueue
      */
     public function toMail($notifiable)
     {
-        $subject = "[{$this->application->public_id}] Reference from '{$this->reference->account->name}' was cancelled";
+        $subject = "[{$this->application->public_id}] Reference No Longer Required";
 
         return (new MailMessage)
             ->from('community@vatsim.uk', 'VATSIM UK - Community Department')
             ->subject($subject)
-            ->view('visit-transfer.emails.applicant.reference_cancelled', ['recipient' => $notifiable, 'subject' => $subject, 'reference' => $this->reference, 'application' => $this->application]);
+            ->view('visit-transfer.emails.reference.reference_not_required', [
+                'recipient' => $this->reference->account,
+                'subject' => $subject,
+                'reference' => $this->reference,
+                'application' => $this->application,
+            ]);
     }
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -56,6 +56,10 @@ class EventServiceProvider extends ServiceProvider
             \App\Listeners\VisitTransfer\NotifyApplicantOfStatusChange::class,
         ],
 
+        \App\Events\VisitTransfer\ReferenceCancelled::class => [
+            \App\Listeners\VisitTransfer\NotifyApplicantOfReferenceCancellation::class,
+        ],
+
         \App\Events\VisitTransfer\ReferenceUnderReview::class => [
             \App\Listeners\VisitTransfer\NotifyRefereeOfReferenceCompletion::class,
             \App\Listeners\VisitTransfer\NotifyApplicantOfReferenceCompletion::class,

--- a/resources/views/adm/mship/account/_note.blade.php
+++ b/resources/views/adm/mship/account/_note.blade.php
@@ -23,9 +23,14 @@
                     @endif
 
                     <i class="fa fa-user"></i>
-                    {{ $note->writer->name }}
-                    ({!! link_to_route("adm.mship.account.details", $note->writer_id, [$note->writer_id]) !!}
-                    )
+                    @if (is_null($note->writer))
+                      Unknown/System
+                    @else
+                      {{$note->writer->name}}
+                      ({!! link_to_route("adm.mship.account.details", $note->writer_id, [$note->writer_id]) !!}
+                      )
+                    @endif
+
 
                     &nbsp;&nbsp;&nbsp;
 

--- a/resources/views/visit-transfer/emails/applicant/reference_cancelled.blade.php
+++ b/resources/views/visit-transfer/emails/applicant/reference_cancelled.blade.php
@@ -2,7 +2,7 @@
 
 @section('email-content')
     <p>
-        Your reference from {{ $reference->account->name }} has been cancelled. This is most likely because they referee indicated that they did not know you.
+        Your reference from {{ $reference->account->name }} has been cancelled. This is most likely because the referee indicated that they do not know you.
     </p>
 
     <p>

--- a/resources/views/visit-transfer/emails/applicant/reference_cancelled.blade.php
+++ b/resources/views/visit-transfer/emails/applicant/reference_cancelled.blade.php
@@ -1,0 +1,11 @@
+@extends("visit-transfer.emails.applicant._layout")
+
+@section('email-content')
+    <p>
+        Your reference from {{ $reference->account->name }} has been cancelled. This is most likely because they referee indicated that they did not know you.
+    </p>
+
+    <p>
+        You application is now under review. You are not required to do anything at this stage.
+    </p>
+@stop

--- a/resources/views/visit-transfer/emails/reference/request.blade.php
+++ b/resources/views/visit-transfer/emails/reference/request.blade.php
@@ -6,7 +6,7 @@
 </p>
 
 <p>
-    In order for their application to proceed you must click the URL below and either complete the application, or refuse to provide a reference.  This request will expire
+    In order for their application to proceed you must click the URL below and complete the application. If you do not know the applicant, you are able to state so at the following link. This request will expire
     in 14 days and {{ $application->account->name }}'s application will be automatically rejected.
 </p>
 

--- a/resources/views/visit-transfer/site/reference/complete.blade.php
+++ b/resources/views/visit-transfer/site/reference/complete.blade.php
@@ -3,12 +3,24 @@
 @section('vt-content')
     <div class="row">
         <div class="col-md-12">
+            {!! HTML::panelOpen("Reference Relationship", ["type" => "fa", "key" => "question-circle"]) !!}
+            <div class="text-center">
+              <p class="text-center">
+                <b>Do you know {{ $application->account->name }}?</b></br>
+                If you don't know the applicant, please press the button below. This will cancel your reference, and the applicant will need to provide an alternative reference.</br>
+                {!! Form::open(["route" => ["visiting.reference.complete.cancel", $token->code], "method" => "POST"]) !!}
+
+                {{ Form::submit('I do not know the applicant', ["class" => "btn btn-danger"]) }}
+
+                {!! Form::close() !!}
+              </p>
+            </div>
+            {!! HTML::panelClose() !!}
             {!! HTML::panelOpen("Reference Content", ["type" => "fa", "key" => "list"]) !!}
             <div class="row hidden-xs">
                 <div class="col-md-10 col-md-offset-1">
-
                     <p>
-                        You are complete a reference for {{ $application->account->name }}'s {{ $application->type_string }} application for {{ $application->facility->name }}.
+                        You are completing a reference for {{ $application->account->name }}'s {{ $application->type_string }} application for {{ $application->facility->name }}.
                         This application is bound by the Visiting &amp; Transferring Controller Policy (VTCP).
                         <br />
                         {!! link_to("https://www.vatsim.net/documents/transfer-and-visiting-controller-policy", "The VTCP can be located on the VATSIM.net website", ["target" => "_blank"]) !!}

--- a/resources/views/visit-transfer/site/reference/complete.blade.php
+++ b/resources/views/visit-transfer/site/reference/complete.blade.php
@@ -7,7 +7,7 @@
             <div class="text-center">
               <p class="text-center">
                 <b>Do you know {{ $application->account->name }}?</b></br>
-                If you don't know the applicant, please press the button below. This will cancel your reference, and the applicant will need to provide an alternative reference.</br>
+                If you don't know the applicant, please press the button below. This will cancel your reference, and the application will be reviewed by Community staff.</br>
                 {!! Form::open(["route" => ["visiting.reference.complete.cancel", $token->code], "method" => "POST"]) !!}
 
                 {{ Form::submit('I do not know the applicant', ["class" => "btn btn-danger"]) }}

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -441,5 +441,12 @@ Route::group([
             'as' => 'complete.post',
             'uses' => 'Reference@postComplete',
         ]);
+
+
+
+        Route::post('/complete/{token}/cancel', [
+            'as' => 'complete.cancel',
+            'uses' => 'Reference@postCancel',
+        ]);
     });
 });


### PR DESCRIPTION
Gives referees an option at the start of the online form to mark that they do not know the applicant.

Once clicked, the application is moved to Under Review, the community is notified and the reference is marked as "Cancelled".

(Have also decided to pull #937 into here as it is slightly related)

Closes #565 