### PR TITLE
Member search in ATC/Pilot feedback forms

### DIFF
--- a/app/Http/Controllers/Mship/Feedback.php
+++ b/app/Http/Controllers/Mship/Feedback.php
@@ -142,10 +142,6 @@ class Feedback extends \App\Http\Controllers\BaseController
 
     public function getUserSearch($name, Request $request)
     {
-      $validator = Validator::make($request->all(), ['name' => 'required|alpha_dash']);
-      if ($validator->fails()) {
-          //return response()->json([]);
-      }
 
       $matches = Account::whereRaw("CONCAT(`name_first`, ' ',`name_last`) LIKE '%".$name."%'")->limit(5)->with(['states'])->get(['id', 'name_first', 'name_last']);
 
@@ -162,7 +158,7 @@ class Feedback extends \App\Http\Controllers\BaseController
               }
             }
           }
-          
+
           $this->returnList->push(collect([
             'cid' => $user->id,
             'name' => $user->real_name,

--- a/app/Http/Controllers/Mship/Feedback.php
+++ b/app/Http/Controllers/Mship/Feedback.php
@@ -12,6 +12,9 @@ use App\Events\Mship\Feedback\NewFeedbackEvent;
 
 class Feedback extends \App\Http\Controllers\BaseController
 {
+
+    private $returnList;
+
     public function getFeedbackFormSelect()
     {
         return view('mship.feedback.form');
@@ -135,5 +138,41 @@ class Feedback extends \App\Http\Controllers\BaseController
 
         return Redirect::route('mship.manage.dashboard')
                 ->withSuccess('Your feedback has been recorded. Thank you!');
+    }
+
+    public function getUserSearch($name, Request $request)
+    {
+      $validator = Validator::make($request->all(), ['name' => 'required|alpha_dash']);
+      if ($validator->fails()) {
+          //return response()->json([]);
+      }
+
+      $matches = Account::whereRaw("CONCAT(`name_first`, ' ',`name_last`) LIKE '%".$name."%'")->limit(5)->with(['states'])->get(['id', 'name_first', 'name_last']);
+
+      $this->returnList = collect();
+
+      $matches->transform(function($user, $key){
+
+          foreach ($user->states as $key => $state) {
+            if($state->is_permanent){
+              if($state->code = "INTERNATIONAL" && ($state->region->first() == "*" || $state->division->first() == "*")){
+                $user->state = "Intl.";
+              }else{
+                $user->state = $state->region->first() . '/' . $state->division->first();
+              }
+            }
+          }
+          
+          $this->returnList->push(collect([
+            'cid' => $user->id,
+            'name' => $user->real_name,
+            'status' => $user->state
+          ]));
+
+          return $user;
+      });
+      $matches = null;
+
+      return response()->json($this->returnList);
     }
 }

--- a/database/migrations/2017_03_31_211222_create_feedback_tables.php
+++ b/database/migrations/2017_03_31_211222_create_feedback_tables.php
@@ -293,7 +293,7 @@ class CreateFeedbackTables extends Migration
         DB::table('mship_feedback_question_types')->insert([
             [
               'name' => 'userlookup',
-              'code' => '<input class="form-control" name="%1$s" type="text" id="%1$s" value="%2$s" placeholder="Enter the user\'s CID e.g 1234567">',
+              'code' => '<input class="form-control" name="%1$s" type="text" id="%1$s" value="%2$s" placeholder="Enter the Users CID e.g 1234567">',
               'rules' => 'integer|exists:mship_account,id',
               'requires_value' => false,
               'max_uses' => 1,

--- a/database/migrations/2017_03_31_211222_create_feedback_tables.php
+++ b/database/migrations/2017_03_31_211222_create_feedback_tables.php
@@ -293,7 +293,7 @@ class CreateFeedbackTables extends Migration
         DB::table('mship_feedback_question_types')->insert([
             [
               'name' => 'userlookup',
-              'code' => '<input class="form-control" name="%1$s" type="text" id="%1$s" value="%2$s" placeholder="Enter the Users CID e.g 1234567">',
+              'code' => '<input class="form-control" name="%1$s" type="text" id="%1$s" value="%2$s" placeholder="Enter the user\'s CID e.g 1234567">',
               'rules' => 'integer|exists:mship_account,id',
               'requires_value' => false,
               'max_uses' => 1,

--- a/database/migrations/2017_07_01_152542_make_userid_input_placeholder_grammatically_correct.php
+++ b/database/migrations/2017_07_01_152542_make_userid_input_placeholder_grammatically_correct.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeUseridInputPlaceholderGrammaticallyCorrect extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('mship_feedback_question_types')->where('name', 'userlookup')->update([
+              'code' => '<input class="form-control" name="%1$s" type="text" id="%1$s" value="%2$s" placeholder="Enter the user\'s CID e.g 1234567">'
+            ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::table('mship_feedback_question_types')->where('name', 'userlookup')->update([
+              'code' => '<input class="form-control" name="%1$s" type="text" id="%1$s" value="%2$s" placeholder="Enter the Users CID e.g 1234567">'
+            ]);
+    }
+}

--- a/resources/views/mship/feedback/form.blade.php
+++ b/resources/views/mship/feedback/form.blade.php
@@ -5,15 +5,105 @@
 <script type="text/javascript">
   $(document).ready(function(){
     $('.datetimepickercustom').datetimepicker();
+
+    // Member search hook
+
+    var searchInput = $('#member-search-name');
+    var timeout;
+
+    // Bind input change for serch input
+    searchInput.bind("input", function(event){
+
+        $('#memberSearchSpinner').show();
+        $('#memberSearchNoResults').hide();
+        $('#memberSearchResults').hide();
+
+        clearTimeout(timeout);
+        timeout = window.setTimeout(function(){
+          $.get('{{route('mship.feedback.usersearch', null)}}/' + $('#member-search-name').val(), function(response){
+              $('#memberSearchSpinner').hide();
+              if(response == ""){
+                $('#memberSearchNoResults').show();
+                $('#memberSearchResults').html('<a href="https://stats.vatsim.net/search_name.php?name='+searchInput.val()+'" target="_blank">Search VATSIM Statistics for user</a>');
+                $('#memberSearchResults').show();
+              }else{
+                var htmlString;
+                htmlString = "<div class='row'>";
+                  htmlString += "<div class='col-md-12'><ul class='nav nav-pills nav-stacked'>";
+                  response.forEach( function(member){
+                    htmlString += "<li><a href='#' class='memberSearchMemberItem' data-cid='"+member.cid+"'><b>"+member.name+" ("+member.cid+")</b> - "+member.status+"</a></li>";
+                  });
+                  htmlString += "</ul></div>";
+                htmlString += "</div>";
+                $('#memberSearchResults').html(htmlString);
+                $('#memberSearchResults').show();
+              }
+
+              $('.memberSearchMemberItem').click(function(){
+                console.log("Click")
+                if(formUserSelectorInput){
+                  formUserSelectorInput.val($(this).data("cid"));
+                }
+                $('#memberSearchDialog').modal('toggle');
+              });
+          });
+        }, 2000);
+       }
+     );
+
+    var formUserSelectorInput;
+    if($('#formUserLookupFieldContainer').length){
+      formUserSelectorInput = $('#formUserLookupFieldContainer').find('input');
+    }
   });
 </script>
 @endsection
 
 @section('content')
+  <!-- Modal -->
+<div id="memberSearchDialog" class="modal fade" role="dialog">
+  <div class="modal-dialog">
+
+    <!-- Modal content-->
+    <div class="modal-content panel-ukblue">
+      <div class="modal-header panel-heading">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title">Search for a member</h4>
+      </div>
+      <div class="modal-body">
+        <div class="row">
+            <div class="col-md-12">
+              {{ Form::label('name', 'Member\'s Name') }}
+              {{ Form::text('name', null, ['id' => 'member-search-name']) }}
+            </div>
+        </div>
+        <hr>
+        <div class="row" style="margin-top:20px">
+            <div class="col-md-12 text-center">
+              <p id="memberSearchSpinner" style="display:none">
+                  <i class="fa fa-spinner fa-spin" style="font-size:24px"></i>
+              </p>
+              <p id="memberSearchNoResults" style="display:none">
+                  No Results Found. Try looking here:
+              </p>
+              <p id="memberSearchResults" style="display:none">
+              </p>
+            </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+
+  </div>
+</div>
+
 <div class="panel panel-ukblue">
 	<div class="panel-heading"> Submit Member Feedback</div>
 	<div class="panel-body">
 		<!-- Content Of Panel [START] -->
+
 		<p>
 			Here you can submit anonymous feedback about a <b>UK</b> division member. Please try to explain your answers fully. Your identity is kept anonymous to staff &amp; the subject of the feedback. However, senior staff will be able to discover your identity in the case of abuse of this system.
 		</p>
@@ -38,7 +128,17 @@
   				@foreach ($questions as $question)
             <div class="form-group{{ $errors->has($question->slug) ? " has-error" : "" }}">
               {{ Form::label($question->slug, $question->question . ($question->required ? "" : " (optional)")) }} </br>
-              {!! $question->form_html !!}
+              @if ($question->type->name == "userlookup")
+                <span id="formUserLookupFieldContainer">
+                  <div class="input-group">
+                    <span class="input-group-btn"><button type="button" class="btn btn-info" data-toggle="modal" data-target="#memberSearchDialog">Search <i class="fa fa-search"></i></button></span>
+                    {!! $question->form_html !!}
+                  </div>
+                </span>
+              @else
+                {!! $question->form_html !!}
+              @endif
+
             </div>
   				@endforeach
           <div class="form-group">

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -153,6 +153,8 @@ Route::group(['prefix' => 'mship', 'namespace' => 'Mship'], function () {
         Route::post('/new', ['as' => 'mship.feedback.new.post', 'uses' => 'Feedback@postFeedbackFormSelect']);
         Route::get('/new/{form}', ['as' => 'mship.feedback.new.form', 'uses' => 'Feedback@getFeedback']);
         Route::post('/new/{form}', ['as' => 'mship.feedback.new.form.post', 'uses' => 'Feedback@postFeedback']);
+
+        Route::get('/users/search/{name}',['as' => 'mship.feedback.usersearch', 'uses' => 'Feedback@getUserSearch']);
     });
 
     Route::group(['middleware' => ['auth_full_group']], function () {


### PR DESCRIPTION
Adds in a search button to allow searching for members. Once clicked, the selected member's CID will be automatically placed into the correct form field.

Worth mentioning that the exact name of the user they want to find is not required, and it will try to find a match from our database.
![image](https://user-images.githubusercontent.com/17804618/27557577-09383584-5ab2-11e7-8e14-7a941ee12b98.png)
![image](https://user-images.githubusercontent.com/17804618/27557595-17362f24-5ab2-11e7-9854-1852390be3c7.png)


Also fix a small grammatical error in the feedback migration