### PR TITLE
Fix Ban Email Recipient

### DIFF
--- a/app/Http/Controllers/Adm/Mship/Account.php
+++ b/app/Http/Controllers/Adm/Mship/Account.php
@@ -334,7 +334,7 @@ class Account extends AdmController
             $this->account->id
         );
 
-        $this->account->notify(new BanCreated($ban));
+        $account->notify(new BanCreated($ban));
 
         return Redirect::route('adm.mship.account.details', [$account->id, 'bans', $ban->id])
                        ->withSuccess('You have successfully banned this member.');


### PR DESCRIPTION
Account being used for the ban notification was the current user, instead of the person being banned

Fixes #988