### PR TITLE
Hotfix: Member's States not being saved

### DIFF
--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -64,7 +64,6 @@ class UpdateMember extends Job implements ShouldQueue
             $member->cert_checked_at = Carbon::now();
             $member->is_inactive = (bool) ($this->data->rating < 0);
             $member->joined_at = $this->data->regdate;
-            $member->save();
 
             $state = determine_mship_state_from_vatsim($this->data->region, $this->data->division);
             $member->addState($state, $this->data->region, $this->data->division);

--- a/app/Models/Mship/Concerns/HasStates.php
+++ b/app/Models/Mship/Concerns/HasStates.php
@@ -117,7 +117,11 @@ trait HasStates
     public function addState(State $state, $region = null, $division = null)
     {
         if ($this->hasState($state)) {
-            return;
+            // Verify the same region/division information, else we want to update the state
+            $exisitingState = $this->states->where('id', $state->id)->first();
+            if($exisitingState->pivot->region == $region && $exisitingState->pivot->division == $division){
+              return;
+            };
         }
 
         if ($this->primary_state && $this->primary_state->is_permanent && $state->is_permanent) {


### PR DESCRIPTION
When a user changes their region/division outside of the UK, e.g they change from AFR ME to OCEN PAC the states are both classed as "International".

The previous logic made it so that in this situation, no update would propagate because it only checked for the state's type, and not the underlying region/division combination as well.