### PR TITLE
Temporary fix for deleted reference tokens

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -163,15 +163,6 @@
                             </a>
                         </li>
                     </ul>
-                    {!! Form::open(['route' => 'logout', 'id' => 'logout-form']) !!}
-                    <ul class="nav navbar-nav navcustom navbar-right">
-                        <li class="dropdown dropdown-large">
-                            <a href="{{ route('logout') }}"
-                               onclick="event.preventDefault(); document.getElementById('logout-form').submit();">Log
-                                Out</a>
-                        </li>
-                    </ul>
-                    {!! Form::close() !!}
                 @endif
 
             </div>

--- a/resources/views/visit-transfer/site/dashboard.blade.php
+++ b/resources/views/visit-transfer/site/dashboard.blade.php
@@ -251,7 +251,12 @@
                                                 UTC</span>
                                         </td>
                                         <td class="text-center">
-                                            {!! link_to_route("visiting.reference.complete", "Complete", [$reference->token->code]) !!}
+                                            @if ($reference->token)
+                                              {!! link_to_route("visiting.reference.complete", "Complete", [$reference->token->code]) !!}
+                                            @else
+                                              <i>This reference has expired</i>
+                                            @endif
+
                                         </td>
                                     </tr>
                                 @endforeach


### PR DESCRIPTION
Adds in a small check to see if the token actual exists before trying to display it. Does not fix the actual issue (#1023) because that it on hold until CERT v2, but this will do in the meantime so that people can still access V/T.

Also fixed a small oversight in having two logout buttons from previous PR...