### PR TITLE
Hotfix: Accommodate slugs in permissions

### DIFF
--- a/app/Models/Mship/Role.php
+++ b/app/Models/Mship/Role.php
@@ -138,6 +138,7 @@ class Role extends Model
             // Replace wildcard
             $perm_has = str_replace('*', '[A-Za-z0-9]+', $perm_has);
             $perm_has = '/^'.$perm_has.'$/';
+            
             return (boolean) preg_match($perm_has, $permission);
         })->isEmpty();
     }

--- a/app/Models/Mship/Role.php
+++ b/app/Models/Mship/Role.php
@@ -128,7 +128,21 @@ class Role extends Model
         return !$this->permissions->filter(function ($perm) use ($permission) {
             $stripped = preg_replace("/[^A-Za-z0-9\/]/i", '', $perm->name);
 
-            return strcasecmp($perm->name, $permission) == 0 || strcasecmp($stripped, $permission) == 0 || $perm->name == '*';
+            if(strcasecmp($perm->name, $permission) == 0 || strcasecmp($stripped, $permission) == 0 || $perm->name == '*'){
+              return true;
+            }
+
+            // Secondary fallback - Mainly for non-numeric slugs
+            // Add slashes
+            $perm_has = str_replace('/', '\/', $perm->name);
+            // Replace wildcard
+            $perm_has = str_replace('*', '[A-z0-9]+', $perm_has);
+            $perm_has = "/" . $perm_has . "$/";
+            if(preg_match($perm_has, $permission)){
+              return true;
+            }
+
+            return false;
         })->isEmpty();
     }
 

--- a/app/Models/Mship/Role.php
+++ b/app/Models/Mship/Role.php
@@ -138,7 +138,7 @@ class Role extends Model
             // Replace wildcard
             $perm_has = str_replace('*', '[A-Za-z0-9]+', $perm_has);
             $perm_has = '/^'.$perm_has.'$/';
-            
+
             return (boolean) preg_match($perm_has, $permission);
         })->isEmpty();
     }

--- a/app/Models/Mship/Role.php
+++ b/app/Models/Mship/Role.php
@@ -139,7 +139,7 @@ class Role extends Model
             $perm_has = str_replace('*', '[A-Za-z0-9]+', $perm_has);
             $perm_has = '/^'.$perm_has.'$/';
 
-            return (boolean) preg_match($perm_has, $permission);
+            return (bool) preg_match($perm_has, $permission);
         })->isEmpty();
     }
 

--- a/app/Models/Mship/Role.php
+++ b/app/Models/Mship/Role.php
@@ -137,7 +137,7 @@ class Role extends Model
             $perm_has = str_replace('/', '\/', $perm->name);
             // Replace wildcard
             $perm_has = str_replace('*', '[A-z0-9]+', $perm_has);
-            $perm_has = "/".$perm_has."$/";
+            $perm_has = '/'.$perm_has.'$/';
             if (preg_match($perm_has, $permission)) {
                 return true;
             }

--- a/app/Models/Mship/Role.php
+++ b/app/Models/Mship/Role.php
@@ -128,8 +128,8 @@ class Role extends Model
         return !$this->permissions->filter(function ($perm) use ($permission) {
             $stripped = preg_replace("/[^A-Za-z0-9\/]/i", '', $perm->name);
 
-            if(strcasecmp($perm->name, $permission) == 0 || strcasecmp($stripped, $permission) == 0 || $perm->name == '*'){
-              return true;
+            if (strcasecmp($perm->name, $permission) == 0 || strcasecmp($stripped, $permission) == 0 || $perm->name == '*') {
+                return true;
             }
 
             // Secondary fallback - Mainly for non-numeric slugs
@@ -137,9 +137,9 @@ class Role extends Model
             $perm_has = str_replace('/', '\/', $perm->name);
             // Replace wildcard
             $perm_has = str_replace('*', '[A-z0-9]+', $perm_has);
-            $perm_has = "/" . $perm_has . "$/";
-            if(preg_match($perm_has, $permission)){
-              return true;
+            $perm_has = "/".$perm_has."$/";
+            if (preg_match($perm_has, $permission)) {
+                return true;
             }
 
             return false;

--- a/app/Models/Mship/Role.php
+++ b/app/Models/Mship/Role.php
@@ -134,12 +134,12 @@ class Role extends Model
 
             // Secondary fallback - Mainly for non-numeric slugs
             // Add slashes
-            $perm_has = str_replace('/', '\/', $perm->name);
+            $perm_has = preg_quote($perm->name, '/');
             // Replace wildcard
             $perm_has = str_replace('*', '[A-Za-z0-9]+', $perm_has);
             $perm_has = '/^'.$perm_has.'$/';
 
-            return (bool) preg_match($perm_has, $permission);
+            return (boola) preg_match($perm_has, $permission);
         })->isEmpty();
     }
 

--- a/app/Models/Mship/Role.php
+++ b/app/Models/Mship/Role.php
@@ -136,13 +136,9 @@ class Role extends Model
             // Add slashes
             $perm_has = str_replace('/', '\/', $perm->name);
             // Replace wildcard
-            $perm_has = str_replace('*', '[A-z0-9]+', $perm_has);
-            $perm_has = '/'.$perm_has.'$/';
-            if (preg_match($perm_has, $permission)) {
-                return true;
-            }
-
-            return false;
+            $perm_has = str_replace('*', '[A-Za-z0-9]+', $perm_has);
+            $perm_has = '/^'.$perm_has.'$/';
+            return (boolean) preg_match($perm_has, $permission);
         })->isEmpty();
     }
 

--- a/app/Models/Mship/Role.php
+++ b/app/Models/Mship/Role.php
@@ -139,7 +139,7 @@ class Role extends Model
             $perm_has = str_replace('*', '[A-Za-z0-9]+', $perm_has);
             $perm_has = '/^'.$perm_has.'$/';
 
-            return (boola) preg_match($perm_has, $permission);
+            return (bool) preg_match($perm_has, $permission);
         })->isEmpty();
     }
 


### PR DESCRIPTION
Utilise regex to search for alphanumeric slugs. Will be redone later on during review of permissions logic and utilising policies, but until then this will suffice.