### PR TITLE
Various Feedback Fixes & Improvements

### DIFF
--- a/app/Console/Commands/Feedback/GenerateFeedbackSummary.php
+++ b/app/Console/Commands/Feedback/GenerateFeedbackSummary.php
@@ -53,7 +53,9 @@ class GenerateFeedbackSummary extends Command
 
         foreach ($groupedFeedback as $feedback) {
             $contact = $feedback->first()->form->contact;
-            $contact->notify(new FeedbackSummary($feedbackStart, $feedback));
+            if($contact){
+              $contact->notify(new FeedbackSummary($feedbackStart, $feedback));
+            }
         }
     }
 }

--- a/app/Http/Controllers/Adm/AdmController.php
+++ b/app/Http/Controllers/Adm/AdmController.php
@@ -2,8 +2,9 @@
 
 namespace App\Http\Controllers\Adm;
 
-use App\Models\Mship\Feedback\Form;
 use View;
+use Cache;
+use App\Models\Mship\Feedback\Form;
 
 class AdmController extends \App\Http\Controllers\BaseController
 {
@@ -33,6 +34,20 @@ class AdmController extends \App\Http\Controllers\BaseController
         $this->buildBreadcrumb('Administration Control Panel', '/adm/dashboard');
 
         $view->with('_breadcrumb', $this->breadcrumb);
+
+        $_account = $this->account;
+        $forms_with_unactioned = Cache::remember('adm.mship.unactioned-forms', 2, function () use($_account) {
+            $forms = Form::orderBy('id', 'asc')->get(['id']);
+            return $forms->filter(function ($form, $key) use ($_account) {
+                $hasWildcard = $_account->hasPermission("adm/mship/feedback/list/*") || $_account->hasPermission("adm/mship/feedback/configure/*");
+                $hasSpecific = $_account->hasPermission("adm/mship/feedback/list/".$form->slug) || $_account->hasPermission("adm/mship/feedback/configure/".$form->slug);
+                return ($hasWildcard || $hasSpecific) && $form->feedback()->unActioned()->count() > 0;
+            })->count();
+        });
+
+        if($forms_with_unactioned > 0){
+          $view->with('_unactioned_feedback', true);
+        }
 
         $view->with('_pageTitle', $this->getTitle());
         $view->with('_pageSubTitle', $this->getSubTitle());

--- a/app/Http/Controllers/Adm/AdmController.php
+++ b/app/Http/Controllers/Adm/AdmController.php
@@ -36,7 +36,7 @@ class AdmController extends \App\Http\Controllers\BaseController
         $view->with('_breadcrumb', $this->breadcrumb);
 
         $_account = $this->account;
-        $forms_with_unactioned = Cache::remember('adm.mship.unactioned-forms', 2, function () use($_account) {
+        $forms_with_unactioned = Cache::remember($_account->id.'.adm.mship.unactioned-forms', 2, function () use($_account) {
             $forms = Form::orderBy('id', 'asc')->get(['id']);
             return $forms->filter(function ($form, $key) use ($_account) {
                 $hasWildcard = $_account->hasPermission("adm/mship/feedback/list/*") || $_account->hasPermission("adm/mship/feedback/configure/*");

--- a/app/Http/Controllers/Adm/AdmController.php
+++ b/app/Http/Controllers/Adm/AdmController.php
@@ -28,8 +28,6 @@ class AdmController extends \App\Http\Controllers\BaseController
     {
         $view = View::make($view);
 
-        $view->with('_feedbackForms', Form::whereDeletedAt(null)->orderBy('id', 'asc')->getModels());
-
         $view->with('_account', $this->account);
 
         $this->buildBreadcrumb('Administration Control Panel', '/adm/dashboard');

--- a/app/Http/Controllers/Adm/Mship/Feedback.php
+++ b/app/Http/Controllers/Adm/Mship/Feedback.php
@@ -16,6 +16,19 @@ use App\Http\Requests\Mship\Feedback\UpdateFeedbackFormRequest;
 
 class Feedback extends \App\Http\Controllers\Adm\AdmController
 {
+    public function getListForms()
+    {
+      $forms = Form::orderBy('id', 'asc')->get();
+      $_account = $this->account;
+      $forms = $forms->filter(function ($form, $key) use ($_account) {
+          $hasWildcard = $_account->hasPermission("adm/mship/feedback/list/*") || $_account->hasPermission("adm/mship/feedback/configure/*");
+          $hasSpecific = $_account->hasPermission("adm/mship/feedback/list/".$form->slug) || $_account->hasPermission("adm/mship/feedback/configure/".$form->slug);
+          return $hasWildcard || $hasSpecific;
+      })->all();
+      return $this->viewMake('adm.mship.feedback.forms')
+          ->with('forms', $forms);
+    }
+
     public function getNewForm()
     {
         $question_types = Type::all();

--- a/app/Http/Controllers/Adm/Mship/Feedback.php
+++ b/app/Http/Controllers/Adm/Mship/Feedback.php
@@ -372,6 +372,7 @@ class Feedback extends \App\Http\Controllers\Adm\AdmController
         foreach ($conditions as $condition) {
             if ($condition) {
                 $feedback->markActioned(\Auth::user(), $request->input('comment'));
+                \Cache::forget($this->account->id.'.adm.mship.feedback.unactioned-count'); // Forget cached unactioned count
 
                 return Redirect::back()
                               ->withSuccess('Feedback marked as actioned!');

--- a/app/Http/Controllers/Adm/Mship/Feedback.php
+++ b/app/Http/Controllers/Adm/Mship/Feedback.php
@@ -93,7 +93,7 @@ class Feedback extends \App\Http\Controllers\Adm\AdmController
 
                 // We will update it instead
                 $exisiting_question->required = $question['required'];
-                $exisiting_question->slug = $question['slug'].$i;
+                $exisiting_question->slug = $question['slug'];
                 $exisiting_question->sequence = $i;
                 if (isset($question['options']['values'])) {
                     $question['options']['values'] = explode(',', $question['options']['values']);

--- a/app/Http/Requests/Mship/Feedback/NewFeedbackFormRequest.php
+++ b/app/Http/Requests/Mship/Feedback/NewFeedbackFormRequest.php
@@ -47,8 +47,8 @@ class NewFeedbackFormRequest extends Request
             'question.*.name.required' => 'Your question needs a question!',
             'question.*.name.min' => 'Your question must be more than 5 charecters long.',
 
-            'question.*.slug.required' => 'Please enter a short name for your question',
-            'question.*.slug.alpha_num' => "A question's short name can only be alphanumeric. (A-z0-9)",
+            'question.*.slug.required' => 'Please enter a slug for your question',
+            'question.*.slug.alpha_num' => "A question's slug can only be alphanumeric. (A-z0-9)",
 
             'question.*.type.required' => 'Your question needs a type!',
             'question.*.type.exists' => "Your question type doesn't seem to exist. Please try again.",

--- a/app/Http/Requests/Mship/Feedback/NewFeedbackFormRequest.php
+++ b/app/Http/Requests/Mship/Feedback/NewFeedbackFormRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\Mship\Feedback;
 
 use App\Http\Requests\Request;
-use App\Models\Mship\Note\Type;
+use App\Models\Mship\Feedback\Question\Type;
 
 class NewFeedbackFormRequest extends Request
 {

--- a/app/Http/Requests/Mship/Feedback/NewFeedbackFormRequest.php
+++ b/app/Http/Requests/Mship/Feedback/NewFeedbackFormRequest.php
@@ -60,6 +60,30 @@ class NewFeedbackFormRequest extends Request
         ];
     }
 
+    /**
+     * Configure the validator instance.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return void
+     */
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+
+            foreach ($this->input('question') as $question) {
+              // Ensure questions that require values have values supplied
+              if (Type::findByName($question['type'])->requires_value) {
+                if(isset($question['options']['values'])){
+                    if($question['options']['values'] != '' && count(explode(',', $question['options']['values'])) > 0){
+                      continue;
+                    }
+                }
+                $validator->errors()->add($question['name'], 'The question "'.$question['name'].'" requires values!');
+              }
+            }
+        });
+    }
+
     protected function getValidatorInstance()
     {
         $data = $this->all();

--- a/app/Http/Requests/Mship/Feedback/UpdateFeedbackFormRequest.php
+++ b/app/Http/Requests/Mship/Feedback/UpdateFeedbackFormRequest.php
@@ -44,8 +44,8 @@ class UpdateFeedbackFormRequest extends Request
             'question.*.name.required' => 'Your question needs a question!',
             'question.*.name.min' => 'Your question must be more than 5 charecters long.',
 
-            'question.*.slug.required' => 'Please enter a short name for your question',
-            'question.*.slug.alpha_num' => "A question's short name can only be alphanumeric. (A-z0-9)",
+            'question.*.slug.required' => 'Please enter a slug for your question',
+            'question.*.slug.alpha_num' => "A question's slug can only be alphanumeric. (A-z0-9)",
 
             'question.*.type.required' => 'Your question needs a type!',
             'question.*.type.exists' => "Your question type doesn't seem to exist. Please try again.",

--- a/app/Http/Requests/Mship/Feedback/UpdateFeedbackFormRequest.php
+++ b/app/Http/Requests/Mship/Feedback/UpdateFeedbackFormRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\Mship\Feedback;
 
 use App\Http\Requests\Request;
-use App\Models\Mship\Note\Type;
+use App\Models\Mship\Feedback\Question\Type;
 
 class UpdateFeedbackFormRequest extends Request
 {
@@ -55,6 +55,30 @@ class UpdateFeedbackFormRequest extends Request
             'question.*.required.required' => 'Please mark if this question is required or not.',
             'question.*.required.boolean' => 'There was an error with your question. Please try again.',
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return void
+     */
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+
+            foreach ($this->input('question') as $question) {
+              // Ensure questions that require values have values supplied
+              if (Type::findByName($question['type'])->requires_value) {
+                if(isset($question['options']['values'])){
+                    if($question['options']['values'] != '' && count(explode(',', $question['options']['values'])) > 0){
+                      continue;
+                    }
+                }
+                $validator->errors()->add($question['name'], 'The question "'.$question['name'].'" requires values!');
+              }
+            }
+        });
     }
 
     protected function getValidatorInstance()

--- a/app/Models/Mship/Feedback/Question.php
+++ b/app/Models/Mship/Feedback/Question.php
@@ -101,8 +101,4 @@ class Question extends Model
         return false;
     }
 
-    public function getSlugAttribute($value)
-    {
-        return substr($value, 0, -1);
-    }
 }

--- a/app/Models/Mship/Feedback/Question/Type.php
+++ b/app/Models/Mship/Feedback/Question/Type.php
@@ -40,6 +40,11 @@ class Type extends Model
      'requires_value' => 'boolean',
     ];
 
+    public function scopeFindByName($query, $name)
+    {
+      return $query->where('name', $name)->firstOrFail();
+    }
+
     public function questions()
     {
         return $this->hasMany(\App\Models\Mship\Feedback\Question::class);

--- a/database/migrations/2018_03_01_211706_feedback_slug_length_and_permission.php
+++ b/database/migrations/2018_03_01_211706_feedback_slug_length_and_permission.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class IncreaseFormQuestionSlugLength extends Migration
+class FeedbackSlugLengthAndPermission extends Migration
 {
     /**
      * Run the migrations.
@@ -16,6 +16,13 @@ class IncreaseFormQuestionSlugLength extends Migration
         Schema::table('mship_feedback_questions', function (Blueprint $table) {
           $table->string('slug')->change();
         });
+
+        DB::table('mship_permission')->insert([
+                'name' => 'adm/mship/feedback',
+                'display_name' => 'Admin / Membership / Feedback (Access)',
+                'created_at' => \Carbon\Carbon::now(),
+                'updated_at' => \Carbon\Carbon::now(),
+            ]);
     }
 
     /**

--- a/database/migrations/2018_03_01_211706_feedback_slug_length_and_permission.php
+++ b/database/migrations/2018_03_01_211706_feedback_slug_length_and_permission.php
@@ -16,13 +16,6 @@ class FeedbackSlugLengthAndPermission extends Migration
         Schema::table('mship_feedback_questions', function (Blueprint $table) {
           $table->string('slug')->change();
         });
-
-        DB::table('mship_permission')->insert([
-                'name' => 'adm/mship/feedback',
-                'display_name' => 'Admin / Membership / Feedback (Access)',
-                'created_at' => \Carbon\Carbon::now(),
-                'updated_at' => \Carbon\Carbon::now(),
-            ]);
     }
 
     /**

--- a/database/migrations/2018_03_01_211706_feedback_slug_length_and_permission.php
+++ b/database/migrations/2018_03_01_211706_feedback_slug_length_and_permission.php
@@ -16,6 +16,13 @@ class FeedbackSlugLengthAndPermission extends Migration
         Schema::table('mship_feedback_questions', function (Blueprint $table) {
           $table->string('slug')->change();
         });
+
+        DB::table('mship_permission')->insert([
+                'name' => 'adm/mship/feedback/new',
+                'display_name' => 'Admin / Membership / Feedback / Create Form',
+                'created_at' => \Carbon\Carbon::now(),
+                'updated_at' => \Carbon\Carbon::now(),
+            ]);
     }
 
     /**

--- a/database/migrations/2018_03_01_211706_increase_form_question_slug_length.php
+++ b/database/migrations/2018_03_01_211706_increase_form_question_slug_length.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class IncreaseFormQuestionSlugLength extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mship_feedback_questions', function (Blueprint $table) {
+          $table->string('slug')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mship_feedback_questions', function (Blueprint $table) {
+          $table->string('slug', 20)->change();
+        });
+    }
+}

--- a/resources/assets/less/admin.less
+++ b/resources/assets/less/admin.less
@@ -10,3 +10,41 @@
 @import "~admin-lte/build/less/skins/skin-black";
 
 @boxed-layout-bg-image-path: "../../dist/img/boxed-bg.jpg";
+
+.feedback-form-config {
+  body.dragging, body.dragging * {
+      cursor: move !important;
+  }
+
+  .dragged {
+      position: absolute;
+      opacity: 0.5;
+      z-index: 2000;
+  }
+  ol.simple_connected_list{
+      display: inline;
+  }
+
+  ol.simple_connected_list li {
+      list-style: none;
+  }
+
+  .question-item {
+    .box {
+      border: 1px solid;
+      background-color:#4f798c;
+      color:white;
+    }
+    .box-body {
+      display:none;
+      background-color:#375665;
+    }
+    .ion {
+      font-size:30px;
+      color:white;
+      cursor:pointer;
+      float:left;
+      margin-right: 10px;
+    }
+  }
+}

--- a/resources/views/adm/layout/sidebar.blade.php
+++ b/resources/views/adm/layout/sidebar.blade.php
@@ -80,7 +80,7 @@
             </ul>
         </li>--> --}}
             @if($_account->hasChildPermission("adm/mship"))
-                <li class="treeview {{ (\Request::is('adm/mship*') ? 'active' : '') }}">
+                <li class="treeview {{ ((\Request::is('adm/mship*') && !\Request::is('adm/mship/feedback*')) ? 'active' : '') }}">
                     <a href="#">
                         <i class="ion ion-person-stalker"></i> <span>Membership</span>
                         <i class="fa fa-angle-left pull-right"></i>
@@ -145,13 +145,39 @@
             @endif
 
             @if($_account->hasPermission("adm/mship/feedback"))
-                <li class="{{ ((\Request::is('adm/mship/feedback*')) ? 'active' : '') }}">
-                    <a href="{{ URL::route("adm.mship.feedback.forms") }}">
+                <li class="treeview {{ ((\Request::is('adm/mship/feedback*')) ? 'active' : '') }}">
+                    <a href="#">
                         <i class="ion ion-help"></i> <span>Member Feedback</span>
                         @if (isset($_unactioned_feedback))
-                          <small class="badge pull-right bg-green">New</small>
+                          <small class="badge pull-right bg-green">{{$_unactioned_feedback}} new</small>
                         @endif
                     </a>
+                    <ul class="treeview-menu">
+                       @if($_account->hasPermission("adm/mship/feedback/list/*"))
+                         <li {!! (\Request::is('adm/mship/feedback/list') ? ' class="active"' : '') !!}>
+                             <a href="{{ URL::route("adm.mship.feedback.all") }}">
+                               <i class="fa fa-bars"></i>
+                               <span>All Feedback</span>
+                             </a>
+                         </li>
+                       @endif
+                       @foreach($_feedbackForms as $f)
+                           @if($_account->hasPermission("adm/mship/feedback/list/".$f->slug) || $_account->hasPermission("adm/mship/feedback/list/*"))
+                               <li {!! (\Request::is('adm/mship/feedback/list/'.$f->slug) ? ' class="active"' : '') !!}>
+                                   <a href="{{ URL::route("adm.mship.feedback.form", [$f->slug]) }}">
+                                       <i class="fa fa-bars"></i>
+                                       <span>{!! $f->name !!}</span>
+                                   </a>
+                               </li>
+                           @endif
+                       @endforeach
+                       <li {!! ((\Request::is('adm/mship/feedback/configure*') || \Request::is('adm/mship/feedback')) ? ' class="active"' : '') !!}>
+                           <a href="{{ URL::route("adm.mship.feedback.forms") }}">
+                               <i class="fa fa-cog"></i>
+                               <span>Configure Forms</span>
+                           </a>
+                       </li>
+                   </ul>
                 </li>
             @endif
 

--- a/resources/views/adm/layout/sidebar.blade.php
+++ b/resources/views/adm/layout/sidebar.blade.php
@@ -148,6 +148,9 @@
                 <li class="{{ ((\Request::is('adm/mship/feedback*')) ? 'active' : '') }}">
                     <a href="{{ URL::route("adm.mship.feedback.forms") }}">
                         <i class="ion ion-help"></i> <span>Member Feedback</span>
+                        @if (isset($_unactioned_feedback))
+                          <small class="badge pull-right bg-green">New</small>
+                        @endif
                     </a>
                 </li>
             @endif

--- a/resources/views/adm/layout/sidebar.blade.php
+++ b/resources/views/adm/layout/sidebar.blade.php
@@ -149,8 +149,9 @@
                     <a href="#">
                         <i class="ion ion-help"></i> <span>Member Feedback</span>
                         @if (isset($_unactioned_feedback))
-                          <small class="badge pull-right bg-green">{{$_unactioned_feedback}} new</small>
+                          <small class="badge bg-green">{{$_unactioned_feedback}} new</small>
                         @endif
+                        <i class="fa fa-angle-left"></i>
                     </a>
                     <ul class="treeview-menu">
                        @if($_account->hasPermission("adm/mship/feedback/list/*"))
@@ -161,16 +162,26 @@
                              </a>
                          </li>
                        @endif
-                       @foreach($_feedbackForms as $f)
-                           @if($_account->hasPermission("adm/mship/feedback/list/".$f->slug) || $_account->hasPermission("adm/mship/feedback/list/*"))
-                               <li {!! (\Request::is('adm/mship/feedback/list/'.$f->slug) ? ' class="active"' : '') !!}>
-                                   <a href="{{ URL::route("adm.mship.feedback.form", [$f->slug]) }}">
-                                       <i class="fa fa-bars"></i>
-                                       <span>{!! $f->name !!}</span>
-                                   </a>
-                               </li>
-                           @endif
-                       @endforeach
+                       <li class="treeview {{ Request::is('adm/mship/feedback/list*') ? 'active' : '' }}">
+                         <a href="#">
+                           <i class="fa fa-bars"></i>
+                           <span>Feedback Forms</span>
+                           <i class="fa fa-angle-left"></i>
+                         </a>
+                          <ul class="treeview-menu">
+                            @foreach($_feedbackForms as $f)
+                                @if($_account->hasPermission("adm/mship/feedback/list/".$f->slug) || $_account->hasPermission("adm/mship/feedback/list/*"))
+                                    <li {!! (\Request::is('adm/mship/feedback/list/'.$f->slug) ? ' class="active"' : '') !!}>
+                                        <a href="{{ URL::route("adm.mship.feedback.form", [$f->slug]) }}">
+                                            <i class="fa fa-bars"></i>
+                                            <span>{!! $f->name !!}</span>
+                                        </a>
+                                    </li>
+                                @endif
+                            @endforeach
+                          </ul>
+                       </li>
+
                        <li {!! ((\Request::is('adm/mship/feedback/configure*') || \Request::is('adm/mship/feedback')) ? ' class="active"' : '') !!}>
                            <a href="{{ URL::route("adm.mship.feedback.forms") }}">
                                <i class="fa fa-cog"></i>

--- a/resources/views/adm/layout/sidebar.blade.php
+++ b/resources/views/adm/layout/sidebar.blade.php
@@ -145,49 +145,10 @@
             @endif
 
             @if($_account->hasPermission("adm/mship/feedback"))
-                <li class="treeview {{ ((\Request::is('adm/mship/feedback*')) ? 'active' : '') }}">
-                    <a href="#">
+                <li class="{{ ((\Request::is('adm/mship/feedback*')) ? 'active' : '') }}">
+                    <a href="{{ URL::route("adm.mship.feedback.forms") }}">
                         <i class="ion ion-help"></i> <span>Member Feedback</span>
-                        <i class="fa fa-angle-left pull-right"></i>
                     </a>
-                    <ul class="treeview-menu">
-                        @if($_account->hasPermission("adm/mship/feedback/configure/*"))
-                            <li {!! (\Request::is('adm/mship/feedback/new') ? ' class="active"' : '') !!}>
-                                <a href="{{ URL::route("adm.mship.feedback.new") }}">
-                                    <i class="fa fa-plus"></i>
-                                    <span>Add Feedback Form</span>
-                                </a>
-                            </li>
-                        @endif
-                        @if($_account->hasPermission("adm/mship/feedback/list/*"))
-                          <li {!! (\Request::is('adm/mship/feedback/list') ? ' class="active"' : '') !!}>
-                              <a href="{{ URL::route("adm.mship.feedback.all") }}">
-                                <i class="fa fa-bars"></i>
-                                <span>All Feedback</span>
-                              </a>
-                          </li>
-                        @endif
-                        @foreach($_feedbackForms as $f)
-                            @if($_account->hasPermission("adm/mship/feedback/list/".$f->slug) || $_account->hasPermission("adm/mship/feedback/list/*"))
-                                <li {!! (\Request::is('adm/mship/feedback/list/'.$f->slug) ? ' class="active"' : '') !!}>
-                                    <a href="{{ URL::route("adm.mship.feedback.form", [$f->slug]) }}">
-                                        <i class="fa fa-bars"></i>
-                                        <span>{!! $f->name !!}</span>
-                                    </a>
-                                </li>
-                            @endif
-                        @endforeach
-                        @foreach($_feedbackForms as $f)
-                          @if($_account->hasPermission("adm/mship/feedback/configure/".$f->slug) || $_account->hasPermission("adm/mship/feedback/configure/*"))
-                            <li {!! (\Request::is('adm/mship/feedback/configure/'.$f->slug) ? ' class="active"' : '') !!}>
-                                <a href="{{ URL::route("adm.mship.feedback.config", [$f->slug]) }}">
-                                    <i class="fa fa-cog"></i>
-                                    <span>{!! $f->name !!} Settings</span>
-                                </a>
-                            </li>
-                            @endif
-                        @endforeach
-                    </ul>
                 </li>
             @endif
 

--- a/resources/views/adm/mship/feedback/_question.blade.php
+++ b/resources/views/adm/mship/feedback/_question.blade.php
@@ -17,7 +17,7 @@
             @endif
           </div>
           <div class="col-md-4 text-center">
-            <div class="btn-group role="group">
+            <div class="btn-group" role="group">
               <button type=button class="btn btn-xs btn-danger question-delete-button">Delete</button>
               <button type="button" class="btn btn-xs questionButtonUp">Move Up</button>
               <button type="button" class="btn btn-xs questionButtonDown">Move Down</button>
@@ -25,7 +25,7 @@
           </div>
         </div>
       </div>
-      <div class="box-body" style="display:none" id="question_control_box_{{$num}}">
+      <div class="box-body" style="display:none; background-color:#375665;" id="question_control_box_{{$num}}">
         {{ Form::hidden('question['.$num.'][type]', (isset($question->type->name) ? $question->type->name : ""), ['class' => 'question_type_field']) }}
         <table style="width:100%">
           <tr>
@@ -40,7 +40,7 @@
               @if ((isset($question->required) && !$question->required))
                 {{ Form::select('question['.$num.'][required]', array(1 => 'Yes', 0 => 'No'), 0) }}
               @else
-                {{ Form::select('question['.$num.'][required]', array(1 => 'Yes', 0 => 'No', 1)) }}
+                {{ Form::select('question['.$num.'][required]', array(1 => 'Yes', 0 => 'No'), 1) }}
               @endif
             </td>
           </tr>

--- a/resources/views/adm/mship/feedback/_question.blade.php
+++ b/resources/views/adm/mship/feedback/_question.blade.php
@@ -4,16 +4,14 @@
       <div class="box-header">
         <div class="row">
           <div class="col-md-8">
-            <i onclick="$('#question_control_box_{{$num}}').slideToggle()" class="ion ion-gear-b" data-toggle="dropdown" aria-expanded="false"></i>
+            <i class="ion ion-gear-b question-settings-control"></i>
             <div class="input-group">
               <span class="input-group-addon" id="question-name-addon"><b>Question</b></span>
-              {{ Form::text('question['.$num.'][name]', $question->question, ['aria-describedby' => 'question-name-addon', 'size' => 50]) }}
+              {{ Form::text('question[template][name]', $question->question, ['aria-describedby' => 'question-name-addon', 'size' => 50]) }}
               <span class="input-group-addon">(<span class="question_type">{{ isset($question->type->name) ? $question->type->name : "" }}</span>)</span>
             </div>
-
-
             @if (!isset($hideme) && isset($question->id))
-              {{ Form::hidden('question['.$num.'][exists]', $question->id) }}
+              {{ Form::hidden('question[template][exists]', $question->id) }}
             @endif
           </div>
           <div class="col-md-4 text-center">
@@ -25,30 +23,30 @@
           </div>
         </div>
       </div>
-      <div class="box-body" id="question_control_box_{{$num}}">
-        {{ Form::hidden('question['.$num.'][type]', (isset($question->type->name) ? $question->type->name : ""), ['class' => 'question_type_field']) }}
+      <div class="box-body" style="{{ isset($hideme) ? 'display:block' : '' }}">
+        {{ Form::hidden('question[template][type]', (isset($question->type->name) ? $question->type->name : ""), ['class' => 'question_type_field']) }}
         <table style="width:100%">
           <tr>
-            <th>{{ Form::label('question['.$num.'][slug]', "Slug") }}</th>
+            <th>{{ Form::label('question[template][slug]', "Slug") }}</th>
             <td>
-              {{ Form::text('question['.$num.'][slug]', $question->slug, ['placeholder' => 'A unique one-word identifier']) }}
+              {{ Form::text('question[template][slug]', $question->slug, ['placeholder' => 'A unique one-word identifier']) }}
             </td>
           </tr>
           <tr>
-            <th>{{ Form::label('question['.$num.'][required]', "Required") }}</th>
+            <th>{{ Form::label('question[template][required]', "Required") }}</th>
             <td>
               @if ((isset($question->required) && !$question->required))
-                {{ Form::select('question['.$num.'][required]', array(1 => 'Yes', 0 => 'No'), 0) }}
+                {{ Form::select('question[template][required]', array(1 => 'Yes', 0 => 'No'), 0) }}
               @else
-                {{ Form::select('question['.$num.'][required]', array(1 => 'Yes', 0 => 'No'), 1) }}
+                {{ Form::select('question[template][required]', array(1 => 'Yes', 0 => 'No'), 1) }}
               @endif
             </td>
           </tr>
           @if ((isset($question->type->requires_value) && $question->type->requires_value) || isset($hideme))
             <tr class="question_valueinput">
-              <th>{{ Form::label('question['.$num.'][options][values]', "Values") }}</th>
+              <th>{{ Form::label('question[template][options][values]', "Values") }}</th>
               <td>
-                {{ Form::text('question['.$num.'][options][values]', (($question->optionValues()) ? join(",", $question->optionValues()) : ""), ['placeholder' => 'e.g Good,Average,Bad']) }}
+                {{ Form::text('question[template][options][values]', (($question->optionValues()) ? join(",", $question->optionValues()) : ""), ['placeholder' => 'e.g Good,Average,Bad']) }}
                 <small>Please enter in values, seperated by a comma</small>
               </td>
             </tr>

--- a/resources/views/adm/mship/feedback/_question.blade.php
+++ b/resources/views/adm/mship/feedback/_question.blade.php
@@ -3,7 +3,7 @@
     <div class="box" style="border: 1px solid;background-color:#4f798c;color:white">
       <div class="box-header">
         <div class="row">
-          <div class="col-md-10">
+          <div class="col-md-8">
             <i onclick="$('#question_control_box_{{$num}}').slideToggle()" class="ion ion-levels" style="font-size:30px; color:white; cursor:pointer; float:left; margin-right: 10px;" data-toggle="dropdown" aria-expanded="false"></i>
             <div class="input-group">
               <span class="input-group-addon" id="question-name-addon"><b>Question</b></span>
@@ -16,12 +16,12 @@
               {{ Form::hidden('question['.$num.'][exists]', $question->id) }}
             @endif
           </div>
-          <div class="col-md-2 text-center">
-            <div class="btn-group" role="group" style="margin-bottom: 10px">
+          <div class="col-md-4 text-center">
+            <div class="btn-group role="group">
+              <button type=button class="btn btn-xs btn-danger question-delete-button">Delete</button>
               <button type="button" class="btn btn-xs questionButtonUp">Move Up</button>
               <button type="button" class="btn btn-xs questionButtonDown">Move Down</button>
             </div>
-            <button type=button class="question-delete-button btn btn-xs btn-danger">Delete</button>
           </div>
         </div>
       </div>

--- a/resources/views/adm/mship/feedback/_question.blade.php
+++ b/resources/views/adm/mship/feedback/_question.blade.php
@@ -1,10 +1,10 @@
 <li class="question-item" {{ isset($hideme) ? "style=display:none id=question_template" : "" }}>
   <div class="col-md-12 permanent">
-    <div class="box" style="border: 1px solid;background-color:#4f798c;color:white">
+    <div class="box">
       <div class="box-header">
         <div class="row">
           <div class="col-md-8">
-            <i onclick="$('#question_control_box_{{$num}}').slideToggle()" class="ion ion-levels" style="font-size:30px; color:white; cursor:pointer; float:left; margin-right: 10px;" data-toggle="dropdown" aria-expanded="false"></i>
+            <i onclick="$('#question_control_box_{{$num}}').slideToggle()" class="ion ion-levels" data-toggle="dropdown" aria-expanded="false"></i>
             <div class="input-group">
               <span class="input-group-addon" id="question-name-addon"><b>Question</b></span>
               {{ Form::text('question['.$num.'][name]', $question->question, ['aria-describedby' => 'question-name-addon', 'size' => 50]) }}
@@ -25,7 +25,7 @@
           </div>
         </div>
       </div>
-      <div class="box-body" style="display:none; background-color:#375665;" id="question_control_box_{{$num}}">
+      <div class="box-body" id="question_control_box_{{$num}}">
         {{ Form::hidden('question['.$num.'][type]', (isset($question->type->name) ? $question->type->name : ""), ['class' => 'question_type_field']) }}
         <table style="width:100%">
           <tr>

--- a/resources/views/adm/mship/feedback/_question.blade.php
+++ b/resources/views/adm/mship/feedback/_question.blade.php
@@ -1,69 +1,60 @@
 <li class="question-item" {{ isset($hideme) ? "style=display:none id=question_template" : "" }}>
   <div class="col-md-12 permanent">
-      <div class="box box-warning" style="border: 1px solid">
-          <div class="box-header">
-              <div class="row">
-                  <div class="col-md-10">
-                      <h4 class="box-title" style="font-size:1.2em;width:100%">
-                        Question:
-                        {{ Form::text('question['.$num.'][name]', $question->question) }}
-                        Short Name: <small> A one-word identifier for this question. (Please ensure it is unique!) </small>
-                        {{ Form::text('question['.$num.'][slug]', $question->slug) }}
-                        @if (!isset($hideme) && isset($question->id))
-                          {{ Form::hidden('question['.$num.'][exists]', $question->id) }}
-                        @endif
-                      </h4>
-                  </div>
-                  <div class="col-md-2">
-                    <button type="button" class="btn btn-xs questionButtonUp">Up</button>
-                    <button type="button" class="btn btn-xs questionButtonDown">Down</button>
-                  </div>
-              </div>
-          </div>
-          <div class="box-body">
-              Question Type: <span class="question_type">{{ isset($question->type->name) ? $question->type->name : "" }}</span>
-              {{ Form::hidden('question['.$num.'][type]', (isset($question->type->name) ? $question->type->name : ""), ['class' => 'question_type_field']) }}
-              <hr>
-              <p>
-                Options:
-              </p>
-              <div class="form-group">
-                {{ Form::label('question['.$num.'][required]', "Required") }}
-                @if ((isset($question->required) && $question->required == false))
-                  {{ Form::select('question['.$num.'][required]', array(1 => 'Yes', 0 => 'No'), 0) }}
-                @else
-                  {{ Form::select('question['.$num.'][required]', array(1 => 'Yes', 0 => 'No')) }}
-                @endif
-              </div>
-              @if ((isset($question->type->requires_value) && $question->type->requires_value == true) || isset($hideme))
-                <div class="form-group question_valueinput">
-                  {{ Form::label('question['.$num.'][options][values]', "Values") }}
-                  <small>Please enter in values, seperated by a comma, for the options</small>
-                  {{ Form::text('question['.$num.'][options][values]', (($question->optionValues()) ? join(",", $question->optionValues()) : "")) }}
-                </div>
-              @endif
-              <hr>
-              <p>
-                Preview:
-              </p>
-              <p>
-                @if (!isset($hideme))
-                  {{ Form::label($question->question) }}</br>
-                  @if (isset($question->options['values']) && $question->options['values'] != "")
-                      @foreach ($question->options['values'] as $value)
-                          {!! sprintf($question->type->code, "", "", $value, $value, "") !!}
-                      @endforeach
-                  @else
-                      {!! sprintf($question->type->code, "", "", "example", "example") !!}
-                  @endif
+    <div class="box" style="border: 1px solid;background-color:#4f798c;color:white">
+      <div class="box-header">
+        <div class="row">
+          <div class="col-md-10">
+            <i onclick="$('#question_control_box_{{$num}}').slideToggle()" class="ion ion-levels" style="font-size:30px; color:white; cursor:pointer; float:left; margin-right: 10px;" data-toggle="dropdown" aria-expanded="false"></i>
+            <div class="input-group">
+              <span class="input-group-addon" id="question-name-addon"><b>Question</b></span>
+              {{ Form::text('question['.$num.'][name]', $question->question, ['aria-describedby' => 'question-name-addon', 'size' => 50]) }}
+              <span class="input-group-addon">({{ isset($question->type->name) ? $question->type->name : "" }})</span>
+            </div>
 
-                @else
-                  Preview for this question will be unavalible until you save and reload this page
-                @endif
-              </p>
-              <hr>
-              <button type=button class="question-delete-button btn btn-danger">Delete</button>
+
+            @if (!isset($hideme) && isset($question->id))
+              {{ Form::hidden('question['.$num.'][exists]', $question->id) }}
+            @endif
           </div>
+          <div class="col-md-2 text-center">
+            <div class="btn-group" role="group" style="margin-bottom: 10px">
+              <button type="button" class="btn btn-xs questionButtonUp">Move Up</button>
+              <button type="button" class="btn btn-xs questionButtonDown">Move Down</button>
+            </div>
+            <button type=button class="question-delete-button btn btn-xs btn-danger">Delete</button>
+          </div>
+        </div>
       </div>
+      <div class="box-body" style="display:none" id="question_control_box_{{$num}}">
+        {{ Form::hidden('question['.$num.'][type]', (isset($question->type->name) ? $question->type->name : ""), ['class' => 'question_type_field']) }}
+        <table style="width:100%">
+          <tr>
+            <th>{{ Form::label('question['.$num.'][slug]', "Slug") }}</th>
+            <td>
+              {{ Form::text('question['.$num.'][slug]', $question->slug, ['placeholder' => 'A unique one-word identifier']) }}
+            </td>
+          </tr>
+          <tr>
+            <th>{{ Form::label('question['.$num.'][required]', "Required") }}</th>
+            <td>
+              @if ((isset($question->required) && !$question->required))
+                {{ Form::select('question['.$num.'][required]', array(1 => 'Yes', 0 => 'No'), 0) }}
+              @else
+                {{ Form::select('question['.$num.'][required]', array(1 => 'Yes', 0 => 'No', 1)) }}
+              @endif
+            </td>
+          </tr>
+          @if ((isset($question->type->requires_value) && $question->type->requires_value) || isset($hideme))
+            <tr>
+              <th>{{ Form::label('question['.$num.'][options][values]', "Values") }}</th>
+              <td>
+                {{ Form::text('question['.$num.'][options][values]', (($question->optionValues()) ? join(",", $question->optionValues()) : ""), ['placeholder' => 'e.g Good,Average,Bad']) }}
+                <small>Please enter in values, seperated by a comma</small>
+              </td>
+            </tr>
+          @endif
+        </table>
+      </div>
+    </div>
   </div>
 </li>

--- a/resources/views/adm/mship/feedback/_question.blade.php
+++ b/resources/views/adm/mship/feedback/_question.blade.php
@@ -8,7 +8,7 @@
             <div class="input-group">
               <span class="input-group-addon" id="question-name-addon"><b>Question</b></span>
               {{ Form::text('question['.$num.'][name]', $question->question, ['aria-describedby' => 'question-name-addon', 'size' => 50]) }}
-              <span class="input-group-addon">({{ isset($question->type->name) ? $question->type->name : "" }})</span>
+              <span class="input-group-addon">(<span class="question_type">{{ isset($question->type->name) ? $question->type->name : "" }}</span>)</span>
             </div>
 
 
@@ -45,7 +45,7 @@
             </td>
           </tr>
           @if ((isset($question->type->requires_value) && $question->type->requires_value) || isset($hideme))
-            <tr>
+            <tr class="question_valueinput">
               <th>{{ Form::label('question['.$num.'][options][values]', "Values") }}</th>
               <td>
                 {{ Form::text('question['.$num.'][options][values]', (($question->optionValues()) ? join(",", $question->optionValues()) : ""), ['placeholder' => 'e.g Good,Average,Bad']) }}

--- a/resources/views/adm/mship/feedback/_question.blade.php
+++ b/resources/views/adm/mship/feedback/_question.blade.php
@@ -4,7 +4,7 @@
       <div class="box-header">
         <div class="row">
           <div class="col-md-8">
-            <i onclick="$('#question_control_box_{{$num}}').slideToggle()" class="ion ion-levels" data-toggle="dropdown" aria-expanded="false"></i>
+            <i onclick="$('#question_control_box_{{$num}}').slideToggle()" class="ion ion-gear-b" data-toggle="dropdown" aria-expanded="false"></i>
             <div class="input-group">
               <span class="input-group-addon" id="question-name-addon"><b>Question</b></span>
               {{ Form::text('question['.$num.'][name]', $question->question, ['aria-describedby' => 'question-name-addon', 'size' => 50]) }}

--- a/resources/views/adm/mship/feedback/forms.blade.php
+++ b/resources/views/adm/mship/feedback/forms.blade.php
@@ -8,6 +8,9 @@
         <div class="box">
             <div class="box-header">
                 <h3 class="box-title"><i class="fa fa-inbox"></i> Forms</b></h3>
+                @if ($_account->hasPermission("adm/mship/feedback/new"))
+                  <a href="{{ URL::route("adm.mship.feedback.new") }}" class="btn btn-success pull-right"><i class="fa fa-plus"></i> Create form</a>
+                @endif
             </div>
             <div class="box-body">
               <div class="row">

--- a/resources/views/adm/mship/feedback/forms.blade.php
+++ b/resources/views/adm/mship/feedback/forms.blade.php
@@ -17,6 +17,7 @@
                       <th>Form Name</th>
                       <th>Submissions</th>
                       <th>Number un-actioned</th>
+                      <th></th>
                     </tr>
                     @foreach ($forms as $form)
                       <tr>

--- a/resources/views/adm/mship/feedback/forms.blade.php
+++ b/resources/views/adm/mship/feedback/forms.blade.php
@@ -1,0 +1,44 @@
+@extends('adm.layout')
+
+@section('content')
+<!-- Main row -->
+<div class="row">
+    <!-- Left col -->
+    <section class="col-lg-12">
+        <div class="box">
+            <div class="box-header">
+                <h3 class="box-title"><i class="fa fa-inbox"></i> Forms</b></h3>
+            </div>
+            <div class="box-body">
+              <div class="row">
+                <div class="col-md-12">
+                  <table class="table text-center">
+                    <tr>
+                      <th>Form Name</th>
+                      <th>Submissions</th>
+                      <th>Number un-actioned</th>
+                    </tr>
+                    @foreach ($forms as $form)
+                      <tr>
+                        <td>{{$form->name}}</td>
+                        <td>{{$form->feedback()->count()}}</td>
+                        <td>{{$form->feedback()->unActioned()->count()}}</td>
+                        <td>
+                          <div class="btn-group" role="group">
+                            @if ($_account->hasPermission("adm/mship/feedback/configure/*") || $_account->hasPermission("adm/mship/feedback/configure/".$form->slug))
+                              <a type="button" href="{{ URL::route("adm.mship.feedback.config", [$form->slug]) }}" class="btn btn-warning"><i class="ion ion-gear-a"></i> Edit form</a>
+                            @endif
+                            @if ($_account->hasPermission("adm/mship/feedback/list/*") || $_account->hasPermission("adm/mship/feedback/list/".$form->slug))
+                              <a type="button" href="{{ URL::route("adm.mship.feedback.form", [$form->slug]) }}" class="btn btn-success"><i class="ion ion-search"></i> View Submissions</a>
+                            @endif
+                          </div>
+                        </td>
+                      </tr>
+                    @endforeach
+                  </table>
+                </div>
+            </div>
+        </div><!-- /.nav-tabs-custom -->
+    </section><!-- /.Left col -->
+</div><!-- /.row (main row) -->
+@stop

--- a/resources/views/adm/mship/feedback/forms.blade.php
+++ b/resources/views/adm/mship/feedback/forms.blade.php
@@ -32,9 +32,9 @@
                             @if ($_account->hasPermission("adm/mship/feedback/configure/*") || $_account->hasPermission("adm/mship/feedback/configure/".$form->slug))
                               <a type="button" href="{{ URL::route("adm.mship.feedback.config", [$form->slug]) }}" class="btn btn-warning"><i class="ion ion-gear-a"></i> Edit form</a>
                             @endif
-                            @if ($_account->hasPermission("adm/mship/feedback/list/*") || $_account->hasPermission("adm/mship/feedback/list/".$form->slug))
+                            {{-- @if ($_account->hasPermission("adm/mship/feedback/list/*") || $_account->hasPermission("adm/mship/feedback/list/".$form->slug))
                               <a type="button" href="{{ URL::route("adm.mship.feedback.form", [$form->slug]) }}" class="btn btn-success"><i class="ion ion-search"></i> View Submissions</a>
-                            @endif
+                            @endif --}}
                           </div>
                         </td>
                       </tr>

--- a/resources/views/adm/mship/feedback/new.blade.php
+++ b/resources/views/adm/mship/feedback/new.blade.php
@@ -51,8 +51,6 @@
                 // Quickly number the arrays
                 var count = 1;
                 $("#feedback-form-questions").children(".question-item").each(function () {
-                    console.log(count)
-                    console.log(this)
                     $(this).html($(this).html().replace(/template/g, count))
                     count = count + 1;
                 })
@@ -83,6 +81,12 @@
             $("#feedback-form-questions").on("click", ".question-delete-button", function () {
                 $(this).closest('.question-item').remove();
             });
+
+
+            // Question accordion control
+            $("#feedback-form-questions").on( 'click', '.question-settings-control', function () {
+                $(this).closest('.box').children('.box-body').slideToggle()
+            });
         });
         $(document).ready(function () {
             $('.datetimepickercustom').datetimepicker();
@@ -109,9 +113,10 @@
                                 <div class="box-header">
                                     <h4 class="box-title" style="font-size:1.5em">
                                         Form Questions
-                                    </h4>
+                                      </h4></br>
+                                      <small><b>Note:</b> You do NOT need to add a 'userlookup' question if the form is targeted. It is added automatically</small>
                                 </div>
-                                <div class="box-body">
+                                <div class="box-body feedback-form-config">
                                     <div class="row">
                                         <ol class='simple_connected_list' id="feedback-form-questions">
                                             @if (old('old_data') != null)

--- a/resources/views/adm/mship/feedback/settings.blade.php
+++ b/resources/views/adm/mship/feedback/settings.blade.php
@@ -109,10 +109,29 @@
                                 <div class="box-header">
                                     <h4 class="box-title" style="font-size:1.5em">
                                         Form Questions
-                                    </h4>
+                                    </h4></br>
+                                    <small><b>Note:</b> You do NOT need to add a 'userlookup' question if the form is targeted. It is added automatically</small>
                                 </div>
                                 <div class="box-body feedback-form-config">
                                     <div class="row">
+                                        @if ($form->targeted)
+                                          <div class="col-md-12 permanent question-item">
+                                            <div class="box">
+                                              <div class="box-header">
+                                                <div class="row">
+                                                  <div class="col-md-8">
+                                                    <div class="input-group">
+                                                      <span class="input-group-addon" id="question-name-addon"><b>Question</b></span>
+                                                      {{ Form::text('', 'CID of the member you are leaving feedback for.', ['aria-describedby' => 'question-name-addon', 'size' => 50, 'disabled']) }}
+                                                      <span class="input-group-addon">(Permanent)</span>
+                                                    </div>
+
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        @endif
                                         <ol class='simple_connected_list' id="feedback-form-questions">
                                             @if (old('old_data') != null)
                                                 {!! old('old_data') !!}

--- a/resources/views/adm/mship/feedback/settings.blade.php
+++ b/resources/views/adm/mship/feedback/settings.blade.php
@@ -1,27 +1,5 @@
 @extends('adm.layout')
 
-@section('styles')
-<style>
-    /* JQuery Sortable Styling */
-    body.dragging, body.dragging * {
-        cursor: move !important;
-    }
-
-    .dragged {
-        position: absolute;
-        opacity: 0.5;
-        z-index: 2000;
-    }
-    ol.simple_connected_list{
-        display: inline;
-    }
-
-    ol.simple_connected_list li {
-        list-style: none;
-    }
-</style>
-@endsection
-
 @section('scripts')
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-sortable/0.9.13/jquery-sortable-min.js"
             integrity="sha384-mwD0+87SDVjJjyfTMQHNVV+IyWDM38MhzdCFZ+SRefmD75v+M5K0R3naFNLnZf1L"
@@ -133,7 +111,7 @@
                                         Form Questions
                                     </h4>
                                 </div>
-                                <div class="box-body">
+                                <div class="box-body feedback-form-config">
                                     <div class="row">
                                         <ol class='simple_connected_list' id="feedback-form-questions">
                                             @if (old('old_data') != null)

--- a/resources/views/adm/mship/feedback/settings.blade.php
+++ b/resources/views/adm/mship/feedback/settings.blade.php
@@ -51,13 +51,11 @@
                 // Quickly number the arrays
                 var count = 1;
                 $("#feedback-form-questions").children(".question-item").each(function () {
-                    console.log(count)
-                    console.log(this)
                     $(this).html($(this).html().replace(/template/g, count))
                     count = count + 1;
                 })
                 $('#old_data_input').val($('#feedback-form-questions').html())
-                //event.preventDefault()
+
             });
 
             // Detect change in input values so that they are preserved if form submission fails
@@ -83,6 +81,13 @@
             $("#feedback-form-questions").on("click", ".question-delete-button", function () {
                 $(this).closest('.question-item').remove();
             });
+
+            // Question accordion control
+            $("#feedback-form-questions").on( 'click', '.question-settings-control', function () {
+                $(this).closest('.box').children('.box-body').slideToggle()
+            });
+
+
         });
         $(document).ready(function () {
             $('.datetimepickercustom').datetimepicker();

--- a/resources/views/adm/mship/feedback/settings.blade.php
+++ b/resources/views/adm/mship/feedback/settings.blade.php
@@ -143,7 +143,7 @@
                                                     $i = 1;
                                                 @endphp
                                                 @foreach ($current_questions as $question)
-                                                    @include('adm.mship.feedback._question', ['question' => $question, 'num' => 'template'])
+                                                    @include('adm.mship.feedback._question', ['question' => $question, 'num' => $i])
                                                     @php
                                                         $i++;
                                                     @endphp

--- a/resources/views/adm/mship/feedback/view.blade.php
+++ b/resources/views/adm/mship/feedback/view.blade.php
@@ -56,7 +56,7 @@
               </h3>
           </div><!-- /.box-header -->
           <div class="box-body">
-              <div class="col-md-3">
+              <div class="col-lg-2 col-md-6">
                 <b> Status:</b></br>
                 @if ($feedback->actioned_at)
                   {!! HTML::img("tick_mark_circle", "png", 24, 32) !!}
@@ -65,20 +65,20 @@
                 @endif
               </div>
               @if ($feedback->actioned_at)
-              <div class="col-md-3">
+              <div class="col-lg-3 col-md-6">
                 <b>Marked actioned at:</b></br>
                 {{ $feedback->actioned_at->format("d-m-Y H:i A") }}
               </div>
-              <div class="col-md-3">
+              <div class="col-lg-3 col-md-6">
                 <b>Marked actioned by:</b></br>
                 {{ $feedback->actioner->real_name }}
               </div>
                 @if (\Auth::user()->hasChildPermission('adm/mship/feedback/view/*/unaction'))
-                <div class="col-md-3">
-                  <a href="{{route('adm.mship.feedback.unaction', [$feedback->id])}}">{{ Form::button('Unmark as Actioned', ['class' => 'btn btn-danger']) }}</a>
+                <div class="col-lg-4 col-md-6">
+                  <a href="{{route('adm.mship.feedback.unaction', [$feedback->id])}}">{{ Form::button('Unmark as Actioned', ['class' => 'btn btn-block btn-danger', 'style' => 'font-size: 9pt;']) }}</a>
                 </div>
                 @endif
-              <div class="col-md-12">
+              <div class="col-lg-12 col-md-12">
                 <b>Actioned Comment:</b></br>
                 {{ $feedback->actioned_comment }}
               </div>

--- a/routes/web-admin.php
+++ b/routes/web-admin.php
@@ -70,6 +70,8 @@ Route::group(['prefix' => 'adm', 'namespace' => 'Adm', 'middleware' => ['auth_fu
         });
 
         Route::group(['prefix' => 'feedback', 'as' => 'adm.mship.feedback.'], function () {
+            Route::get('', ['as' => 'forms', 'uses' => 'Feedback@getListForms']);
+
             Route::get('new', ['as' => 'new', 'uses' => 'Feedback@getNewForm']);
             Route::post('new', ['as' => 'new.create', 'uses' => 'Feedback@postNewForm']);
 


### PR DESCRIPTION
1) Removal of sequence number from form slug (No use now that sequence is itself a column)
2) Introduce validation for question types that require values to be set. Fixes #1122 
3) Increase form slug to 255 chars. Fixes #1126 
4) Restyling of feedback configuration page, making it understandable and less cluttered.
![image](https://user-images.githubusercontent.com/17804618/36913160-f737a83a-1e40-11e8-9be0-e2add5cdf9f1.png)
5) Move the various feedback links from the sidebar into a standalone page. De-clutters the sidebar. Also, adds a little New icon when un-actioned feedback exists for forms that the user can view.
![image](https://user-images.githubusercontent.com/17804618/36913171-00243c42-1e41-11e8-92f1-4bc2f1535099.png)
6) Check that contact exists for feedback summary job. If it doesn't exist, no email is sent. Fixes #1145 

