### PR TITLE
Hotfix 3.6.5

### DIFF
--- a/app/Http/Controllers/Smartcars/Api/Flight.php
+++ b/app/Http/Controllers/Smartcars/Api/Flight.php
@@ -109,8 +109,8 @@ class Flight extends AdmController
         $posrep->altitude = Input::get('altitude');
         $posrep->heading_mag = Input::get('magneticheading');
         $posrep->heading_true = Input::get('trueheading');
-        $posrep->latitude = Input::get('latitude');
-        $posrep->longitude = Input::get('longitude');
+        $posrep->latitude = str_replace(',', '.', Input::get('latitude'));
+        $posrep->longitude = str_replace(',', '.', Input::get('longitude'));
         $posrep->groundspeed = Input::get('groundspeed');
         $posrep->distance_remaining = Input::get('distanceremaining');
         $posrep->phase = Input::get('phase');

--- a/app/Http/Controllers/Smartcars/Api/Pirep.php
+++ b/app/Http/Controllers/Smartcars/Api/Pirep.php
@@ -25,7 +25,9 @@ class Pirep extends AdmController
                 return 'NONE';
             }
 
-            $pireps->where('departure_id', '=', $departure->id);
+            $pireps->whereHas('bid.flight', function ($query) use ($departure) {
+                $query->where('departure_id', $departure->id);
+            });
         }
 
         $arrival = Airport::findByIcao(Input::get('arrivalicao'));
@@ -34,10 +36,16 @@ class Pirep extends AdmController
                 return 'NONE';
             }
 
-            $pireps->where('arrival_id', '=', $arrival->id);
+            $pireps->whereHas('bid.flight', function ($query) use ($arrival) {
+                $query->where('arrival_id', $arrival->id);
+            });
         }
 
         $pireps = $pireps->get();
+
+        if ($pireps->isEmpty()) {
+            return 'NONE';
+        }
 
         $return = '';
         foreach ($pireps as $p) {

--- a/app/Models/VisitTransfer/Application.php
+++ b/app/Models/VisitTransfer/Application.php
@@ -547,6 +547,24 @@ class Application extends Model
         }
     }
 
+    public function lapse()
+    {
+        $this->status = self::STATUS_LAPSED;
+        $this->save();
+
+        if ($this->facility) {
+            $this->facility->addTrainingSpace();
+        }
+
+        if ($this->is_transfer) {
+            $this->account->removeState(State::findByCode('TRANSFERRING'));
+        }
+
+        foreach ($this->referees as $reference) {
+            $reference->delete();
+        }
+    }
+
     public function submit()
     {
         $this->guardAgainstInvalidSubmission();

--- a/database/migrations/2018_03_07_194806_fix_teamspeak_foreign_keys.php
+++ b/database/migrations/2018_03_07_194806_fix_teamspeak_foreign_keys.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class FixTeamspeakForeignKeys extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('teamspeak_channel_group_permission', function (Blueprint $table) {
+            $table->dropForeign('teamspeak_channel_group_permission_channelgroup_id_foreign');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('teamspeak_channel_group_permission', function (Blueprint $table) {
+            $table->foreign('channelgroup_id')->references('id')->on('teamspeak_group')->onDelete('cascade');
+        });
+    }
+}

--- a/resources/views/visit-transfer/admin/application/view.blade.php
+++ b/resources/views/visit-transfer/admin/application/view.blade.php
@@ -60,7 +60,11 @@
                                 <tr>
                                     <th class="col-md-2">Current Rating</th>
                                     <td>
-                                        @include("mship.partials._qualification", ["qualification" => $application->account->qualification_atc])
+                                        @empty($application->account->qualification_atc)
+                                            Unknown ATC
+                                        @else
+                                            @include("mship.partials._qualification", ["qualification" => $application->account->qualification_atc])
+                                        @endempty
                                         /
                                         {{ $application->account->qualifications_pilot_string }}
                                     </td>
@@ -140,7 +144,11 @@
                                     <tr>
                                         <th>Referee Rating</th>
                                         <td>
-                                            @include("mship.partials._qualification", ["qualification" => $reference->account->qualification_atc])
+                                            @empty($reference->account->qualification_atc)
+                                                Unknown
+                                            @else
+                                                @include("mship.partials._qualification", ["qualification" => $reference->account->qualification_atc])
+                                            @endempty
                                         </td>
                                     </tr>
                                     <tr>
@@ -588,7 +596,8 @@
 
                         <p>
                             You must write a staff note detailing why you have completed the application.
-                            <strong class="text-danger">The member will not be provided a copy of this information</strong>.
+                            <strong class="text-danger">The member will not be provided a copy of this
+                                information</strong>.
                         </p>
 
                         <div class="form-group">


### PR DESCRIPTION
Resolves:

CORE-38 - Remove incorrect TeamSpeak foreign key
CORE-51 - Fix issue searching PIREPs for those with a specific departure/arrival ID
CORE-52 - Fix smartCARS POSREPs using commas instead of periods in their lat/lons.
CORE-53 - Fix displaying of VT applications where a user's previous rating is unknown.
CORE-56 - Lapse VT applications with expired referees.