### PR TITLE
Hotfix 3.6.6 - Fix Importing Member Emails

### DIFF
--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -66,7 +66,7 @@ class ImportMembers extends Command
     protected function processMember($member)
     {
         if (array_get($this->member_list, $member['cid'], 'unknown') != 'unknown') {
-            if (strcasecmp($this->member_list[$member['cid']], $member['email']) == 0) {
+            if (strcasecmp($this->member_list[$member['cid']], $member['email']) !== 0) {
                 $this->updateMember($member);
                 $this->log('updated member');
                 $this->count_emails++;


### PR DESCRIPTION
Fixes regression from 79b6b533, where members are currently being updated if their email matches the one in CERT, rather than if it does not.