### PR TITLE
CORE-41 - FTE Network Check

### DIFF
--- a/app/Listeners/Smartcars/EvaluateFlightCriteria.php
+++ b/app/Listeners/Smartcars/EvaluateFlightCriteria.php
@@ -75,7 +75,7 @@ class EvaluateFlightCriteria implements ShouldQueue
         $pirep->save();
     }
 
-    public function minutes($time)
+    protected function minutes($time)
     {
         $time = explode(':', $time);
         return ($time[0]*60) + ($time[1]) + ($time[2]/60);

--- a/app/Listeners/Smartcars/EvaluateFlightCriteria.php
+++ b/app/Listeners/Smartcars/EvaluateFlightCriteria.php
@@ -65,7 +65,7 @@ class EvaluateFlightCriteria implements ShouldQueue
             ->sum('minutes_online');
 
         if ((($networkTime / $pirepTime) * 100 ) < 90) {
-            $pirep->markFailed('You were not connected to the VATSIM network.', null);
+            $pirep->markFailed('Failed: You were not connected to the VATSIM network.', null);
             $pirep->save();
 
             return;

--- a/app/Listeners/Smartcars/EvaluateFlightCriteria.php
+++ b/app/Listeners/Smartcars/EvaluateFlightCriteria.php
@@ -4,6 +4,7 @@ namespace App\Listeners\Smartcars;
 
 use App\Events\Smartcars\BidCompleted;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\DB;
 
 class EvaluateFlightCriteria implements ShouldQueue
 {
@@ -57,7 +58,27 @@ class EvaluateFlightCriteria implements ShouldQueue
             return;
         }
 
+        $pirepTime = $this->minutes($pirep->flight_time);
+
+        $networkTime = DB::table('networkdata_pilots')
+            ->whereBetween('connected_at', [$posreps->first()->created_at, $posreps->last()->created_at])
+            ->where('account_id', '=', $bid->account_id)
+            ->sum('minutes_online');
+
+        if ((($networkTime / $pirepTime) * 100 ) < 90) {
+            $pirep->markFailed('You were not connected to the VATSIM network.', null);
+            $pirep->save();
+
+            return;
+        }
+
         $pirep->markPassed('Success: Flight passed all required checks');
         $pirep->save();
+    }
+
+    public function minutes($time)
+    {
+        $time = explode(':', $time);
+        return ($time[0]*60) + ($time[1]) + ($time[2]/60);
     }
 }

--- a/app/Listeners/Smartcars/EvaluateFlightCriteria.php
+++ b/app/Listeners/Smartcars/EvaluateFlightCriteria.php
@@ -4,7 +4,7 @@ namespace App\Listeners\Smartcars;
 
 use App\Events\Smartcars\BidCompleted;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Support\Facades\DB;
+use App\Models\NetworkData\Pilot as NetworkData;
 
 class EvaluateFlightCriteria implements ShouldQueue
 {
@@ -60,9 +60,7 @@ class EvaluateFlightCriteria implements ShouldQueue
 
         $pirepTime = $this->minutes($pirep->flight_time);
 
-        $networkTime = DB::table('networkdata_pilots')
-            ->where('account_id', '=', $bid->account_id)
-            ->where('disconnected_at', '>', $posreps->first()->created_at)
+        $networkTime = NetworkData::where('disconnected_at', '>', $posreps->first()->created_at)
             ->where('connected_at', '<', $posreps->last()->created_at)
             ->sum('minutes_online');
 

--- a/app/Listeners/Smartcars/EvaluateFlightCriteria.php
+++ b/app/Listeners/Smartcars/EvaluateFlightCriteria.php
@@ -61,8 +61,9 @@ class EvaluateFlightCriteria implements ShouldQueue
         $pirepTime = $this->minutes($pirep->flight_time);
 
         $networkTime = DB::table('networkdata_pilots')
-            ->whereBetween('connected_at', [$posreps->first()->created_at, $posreps->last()->created_at])
             ->where('account_id', '=', $bid->account_id)
+            ->where('disconnected_at', '>', $posreps->first()->created_at)
+            ->where('connected_at', '<', $posreps->last()->created_at)
             ->sum('minutes_online');
 
         if ((($networkTime / $pirepTime) * 100 ) < 90) {


### PR DESCRIPTION
**Strongly suggest a review of #1159 first.**

- `$pirepTime` the time logged on the PIREP (smartCARS only logs airborne time) in HH:MM:SS format.
- `$networkTime` pulls any records of that user being connected to VATSIM as a Pilot between the first and last posrep received from smartCars for this flight.
- Checks whether `$networkTime` is at least 90% of `$pirepTime` and marks as failed if it is not.

Not really hugely happy with...

- DB query just thrown in the middle
- Looks a bit messy all within the listener

Happy to take any suggestions about whether this logic would be better in its own function.