### PR TITLE
CORE-55 - Referee notification

### DIFF
--- a/app/Http/Controllers/VisitTransfer/Site/Reference.php
+++ b/app/Http/Controllers/VisitTransfer/Site/Reference.php
@@ -4,9 +4,8 @@ namespace App\Http\Controllers\VisitTransfer\Site;
 
 use App\Http\Controllers\BaseController;
 use App\Http\Requests\VisitTransfer\ReferenceSubmitRequest;
-use App\Notifications\ApplicationReferenceCancelledByReferee;
-use App\Models\Mship\Note\Type;
 use App\Models\Sys\Token;
+use App\Notifications\ApplicationReferenceCancelledByReferee;
 use Exception;
 use Input;
 use Redirect;

--- a/app/Http/Controllers/VisitTransfer/Site/Reference.php
+++ b/app/Http/Controllers/VisitTransfer/Site/Reference.php
@@ -52,6 +52,7 @@ class Reference extends BaseController
             $this
         );
         $reference->notes()->save($note);
+        $reference->cancel();
 
         $reference->application->account->notify(new ApplicationReferenceCancelledByReferee($reference));
         $reference->application->markAsUnderReview();

--- a/app/Http/Controllers/VisitTransfer/Site/Reference.php
+++ b/app/Http/Controllers/VisitTransfer/Site/Reference.php
@@ -44,14 +44,7 @@ class Reference extends BaseController
     public function postCancel(Token $token)
     {
         $reference = $token->related;
-        $noteContent = 'VT Reference from '.$reference->account->name." was cancelled.\n".'Applicant not known to referee';
-        $note = $reference->application->account->addNote(
-            Type::isShortCode('visittransfer')->first(),
-            $noteContent,
-            null,
-            $this
-        );
-        $reference->notes()->save($note);
+        $reference->status_note = 'Referee reported that applicant is not known to them';
         $reference->cancel();
 
         $reference->application->account->notify(new ApplicationReferenceCancelledByReferee($reference));

--- a/app/Listeners/VisitTransfer/NotifyCommunityOfUnderReviewApplication.php
+++ b/app/Listeners/VisitTransfer/NotifyCommunityOfUnderReviewApplication.php
@@ -16,8 +16,8 @@ class NotifyCommunityOfUnderReviewApplication implements ShouldQueue
 
     public function handle(ApplicationUnderReview $event)
     {
-        // TODO: Use the staff services feature to choose recipient
-        $account = Account::find(1002707);
-        $account->notify(new ApplicationReview($event->application));
+        // Disabled pending better implementation
+        // $account = Account::find(1002707);
+        // $account->notify(new ApplicationReview($event->application));
     }
 }

--- a/app/Listeners/VisitTransfer/NotifyRefereeOfReferenceCancellation.php
+++ b/app/Listeners/VisitTransfer/NotifyRefereeOfReferenceCancellation.php
@@ -3,10 +3,10 @@
 namespace App\Listeners\VisitTransfer;
 
 use App\Events\VisitTransfer\ReferenceCancelled;
-use App\Notifications\ApplicationReferenceCancelled;
+use App\Notifications\ApplicationReferenceNoLongerNeeded;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class NotifyApplicantOfReferenceCancellation implements ShouldQueue
+class NotifyRefereeOfReferenceCancellation implements ShouldQueue
 {
     public function __construct()
     {
@@ -15,7 +15,6 @@ class NotifyApplicantOfReferenceCancellation implements ShouldQueue
 
     public function handle(ReferenceCancelled $event)
     {
-        $reference = $event->reference;
-        $reference->application->account->notify(new ApplicationReferenceCancelled($reference));
+        $event->reference->notify(new ApplicationReferenceNoLongerNeeded($event->reference));
     }
 }

--- a/app/Models/VisitTransfer/Application.php
+++ b/app/Models/VisitTransfer/Application.php
@@ -529,6 +529,11 @@ class Application extends Model
         $this->attributes['status'] = self::STATUS_WITHDRAWN;
         $this->save();
 
+        // Delete references
+        foreach ($this->referees as $reference) {
+            $reference->delete();
+        }
+
         event(new ApplicationWithdrawn($this));
 
         if ($this->facility) {
@@ -543,6 +548,11 @@ class Application extends Model
         $this->attributes['status'] = self::STATUS_EXPIRED;
         $this->save();
 
+        // Delete references
+        foreach ($this->referees as $reference) {
+            $reference->delete();
+        }
+
         event(new ApplicationExpired($this));
 
         if ($this->facility) {
@@ -551,10 +561,6 @@ class Application extends Model
 
         if ($this->is_transfer) {
             $this->account->removeState(State::findByCode('TRANSFERRING'));
-        }
-
-        foreach ($this->referees as $reference) {
-            $reference->delete();
         }
     }
 

--- a/app/Models/VisitTransfer/Reference.php
+++ b/app/Models/VisitTransfer/Reference.php
@@ -149,15 +149,6 @@ class Reference extends Model
         return $query->status(self::STATUS_REJECTED);
     }
 
-    public function delete()
-    {
-        $deleted = parent::delete();
-
-        if ($deleted === true) {
-            event(new ReferenceDeleted($this));
-        }
-    }
-
     public function account()
     {
         return $this->belongsTo(\App\Models\Mship\Account::class);
@@ -314,5 +305,15 @@ class Reference extends Model
         if ($this->status != self::STATUS_UNDER_REVIEW) {
             throw new ReferenceNotUnderReviewException($this);
         }
+    }
+
+    public static function boot ()
+    {
+        parent::boot();
+
+        static::deleting(function (Reference $reference) {
+            $reference->tokens()->delete();
+            event(new ReferenceDeleted($reference));
+        });
     }
 }

--- a/app/Models/VisitTransfer/Reference.php
+++ b/app/Models/VisitTransfer/Reference.php
@@ -307,7 +307,7 @@ class Reference extends Model
         }
     }
 
-    public static function boot ()
+    public static function boot()
     {
         parent::boot();
 

--- a/app/Models/VisitTransfer/Reference.php
+++ b/app/Models/VisitTransfer/Reference.php
@@ -276,7 +276,7 @@ class Reference extends Model
 
     public function cancel()
     {
-        if($this->isStatusIn(self::$REFERENCE_IS_PENDING) === false) {
+        if ($this->isStatusIn(self::$REFERENCE_IS_PENDING) === false) {
             return;
         }
         $this->status = self::STATUS_CANCELLED;

--- a/app/Notifications/ApplicationReferenceCancelledByReferee.php
+++ b/app/Notifications/ApplicationReferenceCancelledByReferee.php
@@ -7,7 +7,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 
-class ApplicationReferenceCancelled extends Notification implements ShouldQueue
+class ApplicationReferenceCancelledByReferee extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -59,6 +59,10 @@ class EventServiceProvider extends ServiceProvider
             \App\Listeners\VisitTransfer\NotifyApplicantOfStatusChange::class,
         ],
 
+        \App\Events\VisitTransfer\ApplicationWithdrawn::class => [
+            \App\Listeners\VisitTransfer\NotifyApplicantOfStatusChange::class,
+        ],
+
         \App\Events\VisitTransfer\ApplicationStatusChanged::class => [
             \App\Listeners\VisitTransfer\NotifyApplicantOfStatusChange::class,
         ],

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -68,7 +68,7 @@ class EventServiceProvider extends ServiceProvider
         ],
 
         \App\Events\VisitTransfer\ReferenceCancelled::class => [
-            \App\Listeners\VisitTransfer\NotifyApplicantOfReferenceCancellation::class,
+            \App\Listeners\VisitTransfer\NotifyRefereeOfReferenceCancellation::class,
         ],
 
         \App\Events\VisitTransfer\ReferenceUnderReview::class => [

--- a/resources/assets/less/admin.less
+++ b/resources/assets/less/admin.less
@@ -41,3 +41,7 @@
     }
   }
 }
+
+.panel-title {
+  overflow: hidden;
+}

--- a/resources/views/visit-transfer/admin/application/view.blade.php
+++ b/resources/views/visit-transfer/admin/application/view.blade.php
@@ -119,7 +119,7 @@
                                 </tr>
                             </table>
 
-                            @forelse($application->referees as $count=>$reference)
+                            @forelse($application->referees()->withTrashed()->get() as $count=>$reference)
                                 <br/>
                                 <h4>
                                     Reference {{ $count+1 }} - {{ $reference->account->name }}

--- a/resources/views/visit-transfer/admin/application/view.blade.php
+++ b/resources/views/visit-transfer/admin/application/view.blade.php
@@ -125,9 +125,11 @@
                                     Reference {{ $count+1 }} - {{ $reference->account->name }}
 
                                     @if($reference->is_rejected)
-                                        REJECTED
+                                        - REJECTED
                                     @elseif($reference->is_accepted)
-                                        ACCEPTED
+                                        - ACCEPTED
+                                    @elseif($reference->is_cancelled)
+                                        - CANCELLED
                                     @endif
 
                                     <small>DBID: {{ $reference->id }}</small>

--- a/resources/views/visit-transfer/emails/applicant/_layout.blade.php
+++ b/resources/views/visit-transfer/emails/applicant/_layout.blade.php
@@ -3,14 +3,14 @@
 @section('body')
 
 @yield("email-content")
+    @if(!$application->is_withdrawn)
+    <p>
+        You will be notified of any future updates or changes to your application as it progresses.
+        You can view your application at any point {!! link_to(route("visiting.application.view", [$application->public_id]), "from the VT website") !!}.
+        Alternatively, copy the link below into your browser:</p>
 
-<p>
-    You will be notified of any future updates or changes to your application as it progresses.
-    You can view your application at any point {!! link_to(route("visiting.application.view", [$application->public_id]), "from the VT website") !!}.
-    Alternatively, copy the link below into your browser:</p>
-
-<p>
-    {!! route("visiting.application.view", [$application->public_id]) !!}
-</p>
-
+    <p>
+        {!! route("visiting.application.view", [$application->public_id]) !!}
+    </p>
+    @endif
 @stop

--- a/resources/views/visit-transfer/emails/applicant/status_changed.blade.php
+++ b/resources/views/visit-transfer/emails/applicant/status_changed.blade.php
@@ -70,5 +70,9 @@
                 visiting status will be revoked.
             </p>
         @endif
+    @elseif($application->is_withdrawn)
+        <p>
+            Your application will not be processed any further and no further action will be taken. Your referee(s) have been notified that their reference is no longer required.
+        </p>
     @endif
 @stop

--- a/resources/views/visit-transfer/emails/reference/reference_not_required.blade.php
+++ b/resources/views/visit-transfer/emails/reference/reference_not_required.blade.php
@@ -2,7 +2,7 @@
 
 @section('body')
 <p>
-    There has been a change in circumstances with {{ $application->account->name }}'s {{ $application->type_string }} application to VATSIM United Kingdom.
+    There has been a change in circumstances with {{ $application->account->name }}'s {{ $application->type_string }} application to VATSIM United Kingdom, or you have decided to cancel your reference for them.
 </p>
 
 <p>


### PR DESCRIPTION
Fixed logic that deletes references & notifies referees. Once the application is withdrawn or expired, the reference and its access tokens are deleted, and the referee is emailed.

Closed CORE-55