### PR TITLE
Enable Debugbar Backtrace

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -119,7 +119,7 @@ return [
         'db' => [
             'with_params' => true,   // Render SQL with the parameters substituted
             'timeline' => false,  // Add the queries to the timeline
-            'backtrace' => false,  // EXPERIMENTAL: Use a backtrace to find the origin of the query in your files.
+            'backtrace' => true,  // EXPERIMENTAL: Use a backtrace to find the origin of the query in your files.
             'explain' => [            // EXPERIMENTAL: Show EXPLAIN output on queries
                 'enabled' => false,
                 'types' => ['SELECT'], // array('SELECT', 'INSERT', 'UPDATE', 'DELETE'); for MySQL 5.6.3+


### PR DESCRIPTION
This is really helpful for identifying where duplicated queries are coming from.