### PR TITLE
CORE-185 Update Teamspeak Bot Local Ban Handling

### DIFF
--- a/app/Libraries/TeamSpeak.php
+++ b/app/Libraries/TeamSpeak.php
@@ -207,6 +207,8 @@ class TeamSpeak
             $duration = 60 * 60 * 12; // 12 hours
             self::banClient($client, trans('teamspeak.ban.network.ban'), $duration);
         } elseif ($member->is_system_banned) {
+            self::kickClient($client, trans('teamspeak.ban.system.ban'));
+            sleep(2);
             $duration = $member->system_ban->period_left;
             self::banClient($client, trans('teamspeak.ban.system.ban'), $duration);
         } elseif ($member->is_inactive) {


### PR DESCRIPTION
Teamspeak bot now kicks the locally banned client then waits 2 seconds before then going ahead with banning them.