### PR TITLE
CORE-207 - Existing Slack Registration Error Message

### DIFF
--- a/app/Http/Controllers/Slack/Registration.php
+++ b/app/Http/Controllers/Slack/Registration.php
@@ -20,9 +20,7 @@ class Registration extends \App\Http\Controllers\BaseController
      */
     public function getNew()
     {
-        try {
-            $this->authorize('register-slack');
-        } catch (AuthorizationException $e) {
+        if (!$this->account->can('register-slack')) {
             return Redirect::route('mship.manage.dashboard')
                 ->withError('You already have a Slack registration with this account. Please contact the Web Services Department if you believe this to be an error.');
         }

--- a/app/Http/Controllers/Slack/Registration.php
+++ b/app/Http/Controllers/Slack/Registration.php
@@ -19,14 +19,9 @@ class Registration extends \App\Http\Controllers\BaseController
      */
     public function getNew()
     {
-        if (!is_null($this->account->slack_id)) {
-            return Redirect::route('mship.manage.dashboard')
-                ->withError('You already have a Slack registration with this account. Please contact the Web Services Department if you believe this to be an error.');
-        }
-
         if (!$this->account->can('register-slack')) {
             return Redirect::route('mship.manage.dashboard')
-                ->withError('Your account is listed as an International Member, whom are not permitted to register for slack. Please contact the Web Services Department if you believe this to be an error.');
+                ->withError('You already have a Slack registration with this account. Please contact the Web Services Department if you believe this to be an error.');
         }
 
         if (!($_slackToken = $this->account->tokens()->notExpired()->ofType('slack_registration')->first())) {

--- a/app/Http/Controllers/Slack/Registration.php
+++ b/app/Http/Controllers/Slack/Registration.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Slack;
 
 use App\Models\Sys\Token;
 use DB;
-use Illuminate\Auth\Access\AuthorizationException;
 use Redirect;
 use Response;
 use SlackUserAdmin;

--- a/app/Http/Controllers/Slack/Registration.php
+++ b/app/Http/Controllers/Slack/Registration.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Slack;
 
 use App\Models\Sys\Token;
 use DB;
+use Illuminate\Auth\Access\AuthorizationException;
 use Redirect;
 use Response;
 use SlackUserAdmin;
@@ -19,7 +20,12 @@ class Registration extends \App\Http\Controllers\BaseController
      */
     public function getNew()
     {
-        $this->authorize('register-slack');
+        try {
+            $this->authorize('register-slack');
+        } catch (AuthorizationException $e) {
+            return Redirect::route('mship.manage.dashboard')
+                ->withError('You already have a Slack registration with this account. Please contact the Web Services Department if you believe this to be an error.');
+        }
 
         if (!($_slackToken = $this->account->tokens()->notExpired()->ofType('slack_registration')->first())) {
             DB::beginTransaction();

--- a/app/Http/Controllers/Slack/Registration.php
+++ b/app/Http/Controllers/Slack/Registration.php
@@ -19,10 +19,16 @@ class Registration extends \App\Http\Controllers\BaseController
      */
     public function getNew()
     {
-        if (!$this->account->can('register-slack')) {
+        if (!is_null($this->account->slack_id)) {
             return Redirect::route('mship.manage.dashboard')
                 ->withError('You already have a Slack registration with this account. Please contact the Web Services Department if you believe this to be an error.');
         }
+
+        if (!$this->account->can('register-slack')) {
+            return Redirect::route('mship.manage.dashboard')
+                ->withError('Your account is listed as an International Member, whom are not permitted to register for slack. Please contact the Web Services Department if you believe this to be an error.');
+        }
+
 
         if (!($_slackToken = $this->account->tokens()->notExpired()->ofType('slack_registration')->first())) {
             DB::beginTransaction();

--- a/app/Http/Controllers/Slack/Registration.php
+++ b/app/Http/Controllers/Slack/Registration.php
@@ -29,7 +29,6 @@ class Registration extends \App\Http\Controllers\BaseController
                 ->withError('Your account is listed as an International Member, whom are not permitted to register for slack. Please contact the Web Services Department if you believe this to be an error.');
         }
 
-
         if (!($_slackToken = $this->account->tokens()->notExpired()->ofType('slack_registration')->first())) {
             DB::beginTransaction();
             $_slackToken = Token::generate('slack_registration', false, $this->account);

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -63,9 +63,8 @@ class AuthServiceProvider extends ServiceProvider
     {
         Gate::define('register-slack', function (Account $user) {
             $correctState = $user->hasState('division') || $user->hasState('visiting') || $user->hasState('transferring');
-            $isRegistered = !is_null($user->slack_id);
 
-            return $correctState && !$isRegistered;
+            return $correctState;
         });
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -61,10 +61,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function serviceAccessGates()
     {
-        Gate::define('register-slack', function (Account $user) {
-            $correctState = $user->hasState('division') || $user->hasState('visiting') || $user->hasState('transferring');
-
-            return $correctState;
+        Gate::define('register-slack', function (Account $account) {
+            return is_null($account->slack_id);
         });
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -197,3 +197,23 @@ function appUrl()
 
     return $appUrl;
 }
+
+function maskEmail($email)
+{
+    $delimited = explode('@', $email);
+
+    if(strlen($delimited[0]) <= 2) {
+        $delimited[0] = str_repeat("*", strlen($delimited[0]));
+
+        return "{$delimited[0]}@{$delimited[1]}";
+    }
+
+    for($pos = 1; $pos < strlen($delimited[0]) - 1; $pos++) {
+        if ($pos % 3 == 0) {
+            continue;
+        }
+        $delimited[0][$pos] = '*';
+    }
+
+    return "{$delimited[0]}@{$delimited[1]}";
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -202,13 +202,13 @@ function maskEmail($email)
 {
     $delimited = explode('@', $email);
 
-    if(strlen($delimited[0]) <= 2) {
-        $delimited[0] = str_repeat("*", strlen($delimited[0]));
+    if (strlen($delimited[0]) <= 2) {
+        $delimited[0] = str_repeat('*', strlen($delimited[0]));
 
         return "{$delimited[0]}@{$delimited[1]}";
     }
 
-    for($pos = 1; $pos < strlen($delimited[0]) - 1; $pos++) {
+    for ($pos = 1; $pos < strlen($delimited[0]) - 1; $pos++) {
         if ($pos % 3 == 0) {
             continue;
         }

--- a/tests/Feature/Mship/SlackFeatureTest.php
+++ b/tests/Feature/Mship/SlackFeatureTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Mship;
 
 use App\Models\Mship\Account;
+use App\Models\Mship\State;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -22,8 +23,21 @@ class SlackFeatureTest extends TestCase
     /** @test **/
     public function testRedirectIfRegistrationAlreadyExists()
     {
+        $this->account->addState(State::find(3));
+
         $this->actingAs($this->account)->get(route('slack.new'))->assertRedirect(route('mship.manage.dashboard'))
             ->assertSessionHas('error',
                 'You already have a Slack registration with this account. Please contact the Web Services Department if you believe this to be an error.');
+    }
+
+    /** @test **/
+    public function testRedirectIfInternationalMember()
+    {
+        $account = factory(Account::class)->create();
+        $account->addState(State::find(5), "USA", "ZLA"); // TODO: Add International member state
+
+        $this->actingAs($account)->get(route('slack.new'))->assertRedirect(route('mship.manage.dashboard'))
+            ->assertSessionHas('error',
+                'Your account is listed as an International Member, whom are not permitted to register for slack. Please contact the Web Services Department if you believe this to be an error.');
     }
 }

--- a/tests/Feature/Mship/SlackFeatureTest.php
+++ b/tests/Feature/Mship/SlackFeatureTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Mship;
 use App\Models\Mship\Account;
 use App\Models\Mship\State;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class SlackFeatureTest extends TestCase
@@ -23,21 +24,8 @@ class SlackFeatureTest extends TestCase
     /** @test **/
     public function testRedirectIfRegistrationAlreadyExists()
     {
-        $this->account->addState(State::find(3));
-
         $this->actingAs($this->account)->get(route('slack.new'))->assertRedirect(route('mship.manage.dashboard'))
             ->assertSessionHas('error',
                 'You already have a Slack registration with this account. Please contact the Web Services Department if you believe this to be an error.');
-    }
-
-    /** @test **/
-    public function testRedirectIfInternationalMember()
-    {
-        $account = factory(Account::class)->create();
-        $account->addState(State::find(5), 'USA', 'ZLA'); // TODO: Add International member state
-
-        $this->actingAs($account)->get(route('slack.new'))->assertRedirect(route('mship.manage.dashboard'))
-            ->assertSessionHas('error',
-                'Your account is listed as an International Member, whom are not permitted to register for slack. Please contact the Web Services Department if you believe this to be an error.');
     }
 }

--- a/tests/Feature/Mship/SlackFeatureTest.php
+++ b/tests/Feature/Mship/SlackFeatureTest.php
@@ -34,7 +34,7 @@ class SlackFeatureTest extends TestCase
     public function testRedirectIfInternationalMember()
     {
         $account = factory(Account::class)->create();
-        $account->addState(State::find(5), "USA", "ZLA"); // TODO: Add International member state
+        $account->addState(State::find(5), 'USA', 'ZLA'); // TODO: Add International member state
 
         $this->actingAs($account)->get(route('slack.new'))->assertRedirect(route('mship.manage.dashboard'))
             ->assertSessionHas('error',

--- a/tests/Feature/Mship/SlackFeatureTest.php
+++ b/tests/Feature/Mship/SlackFeatureTest.php
@@ -3,9 +3,8 @@
 namespace Tests\Feature\Mship;
 
 use App\Models\Mship\Account;
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class SlackFeatureTest extends TestCase
 {

--- a/tests/Feature/Mship/SlackFeatureTest.php
+++ b/tests/Feature/Mship/SlackFeatureTest.php
@@ -3,9 +3,7 @@
 namespace Tests\Feature\Mship;
 
 use App\Models\Mship\Account;
-use App\Models\Mship\State;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class SlackFeatureTest extends TestCase

--- a/tests/Feature/Mship/SlackFeatureTest.php
+++ b/tests/Feature/Mship/SlackFeatureTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature\Mship;
+
+use App\Models\Mship\Account;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class SlackFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $account;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->account = factory(Account::class)->create(['slack_id' => '123456789']);
+    }
+
+    /** @test **/
+    public function testRedirectIfRegistrationAlreadyExists()
+    {
+        $this->actingAs($this->account)->get(route('slack.new'))->assertRedirect(route('mship.manage.dashboard'))
+            ->assertSessionHas('error',
+                'You already have a Slack registration with this account. Please contact the Web Services Department if you believe this to be an error.');
+    }
+}


### PR DESCRIPTION
Improves error message displayed when an existing slack registration is found. Resolves CORE-207. 