### PR TITLE
HOTFIX: Fix user appearing logged out in navigation when authenticated

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -184,7 +184,7 @@ function is_local_environment()
 
 function currentUserHasAuth()
 {
-    return Auth::guard('vatsim-sso')->check() && Auth::guard('web')->check();
+    return Auth::guard('web')->check();
 }
 
 function appUrl()


### PR DESCRIPTION
Sometimes, the user is only auth'ed through the web guard, and not the vatsim-sso guard. This results in the user still being able to see the site as a logged in user (because they are), but the navigation bar reflects a non-authenticated user.