### PR TITLE
Ignore nova on upstream branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ yarn-error.log
 _ide_helper.php
 .phpstorm.meta.php
 /build
+
+/_nova/*
+/nova/*
+!/nova/composer.json
+!/nova/src/NovaCoreServiceProvider.php


### PR DESCRIPTION
As CORE-171 is a long way off, I'm fed up of checking out branches being slow due to nova files.