### PR TITLE
Correct UTC Timestamp

### DIFF
--- a/resources/views/site/home.blade.php
+++ b/resources/views/site/home.blade.php
@@ -32,14 +32,14 @@
             var h = today.getUTCHours();
             var m = today.getUTCMinutes();
             var s = today.getSeconds();
-            if(h<12){
-                h = "0"+m
+            if(h < 12){
+                h = "0" + h
             }
-            if(m<10){
-                m = "0"+m;
+            if(m < 10){
+                m = "0" + m;
             }
-            if(s<10){
-                s = "0"+s;
+            if(s < 10){
+                s = "0" +s;
             }
 
             $("#clock").text(h+":"+m+":"+s+'Z');


### PR DESCRIPTION
Return hours appended to 0 instead of minutes. Was returning crazy figures - 029:29:43