### PR TITLE
CORE-229 - Intended Redirect Fix

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -111,6 +111,7 @@ class LoginController extends BaseController
             Auth::login(Auth::guard('vatsim-sso')->user(), true);
 
             $intended = Session::get('url.intended') ?? route('site.home');
+
             return redirect($intended);
         }
     }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -110,7 +110,8 @@ class LoginController extends BaseController
         } else {
             Auth::login(Auth::guard('vatsim-sso')->user(), true);
 
-            return redirect('/');
+            $intended = Session::get('url.intended') ?? route('site.home');
+            return redirect($intended);
         }
     }
 


### PR DESCRIPTION
Users that do not have a secondary password (and therefore only ever need to pass through the vatsim-sso guard) are being redirected to the homepage with every login, rather than to their intended route.