### PR TITLE
CORE-321 - Slack Regression Issues

### DIFF
--- a/app/Notifications/Mship/SlackInvitation.php
+++ b/app/Notifications/Mship/SlackInvitation.php
@@ -3,7 +3,6 @@
 namespace App\Notifications\Mship;
 
 use App\Notifications\Notification;
-use Gate;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -30,7 +29,7 @@ class SlackInvitation extends Notification implements ShouldQueue
      */
     public function via($notifiable)
     {
-        if (Gate::forUser($notifiable)->allows('register-slack')) {
+        if (!$notifiable->slack_id) {
             return ['mail', 'database'];
         } else {
             return [];

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -470,11 +470,8 @@
                             &thinsp;
                             Slack Registration
                             <div class="pull-right">
-                                @if(Gate::allows('register-slack'))
-                                    <a href="{{ route("slack.new") }}">
-                                        <i class="fa fa-plus-circle"></i>
-                                    </a>
-                                @endif
+                                <a href="{{ route("slack.new") }}">
+                                    <i class="fa fa-plus-circle"></i>
                             </div>
                         </div>
                         <div class="panel-body">
@@ -482,10 +479,9 @@
                                 <div class="col-xs-12">
                                     @if($_account->slack_id)
                                         Currently registered with Slack ID {{ $_account->slack_id }}.
-                                    @elseif(Gate::allows('register-slack'))
-                                        You are not yet registered.  {!! link_to_route("slack.new", "Click here to register.") !!}
                                     @else
-                                        You are not eligible for Slack registration.
+                                        You are not yet
+                                        registered.  {!! link_to_route("slack.new", "Click here to register.") !!}
                                     @endif
                                 </div>
                             </div>


### PR DESCRIPTION
Gate removal has been causing a few issues...

- Conditional on membership dashboard always showing as not eligible.
- Email invite never being sent.

If someone doesn't have a `slack_id`, they should be eligible. Simple!