### PR TITLE
Adding more AFISO/AG Airfields

### DIFF
--- a/resources/views/site/atc/endorsements.blade.php
+++ b/resources/views/site/atc/endorsements.blade.php
@@ -227,9 +227,11 @@
                         <li>Andrewsfield (EGSL)</li>
                         <li>Barra (EGPR)</li>
                         <li>Bedford (EGBF)</li>
+                        <li>Bembridge (EGHJ)</li>
                         <li>Blackbushe (EGLK)</li>
                         <li>Bodmin (EGLA)</li>
                         <li>Chichester Goodwood (EGHR)</li>
+                        <li>Clacton (EGSQ)</li>
                         <li>Coventry (EGBE)</li>
                         <li>Cumbernauld (EGPG)</li>
                         <li>Dunkeswell (EGTU)</li>
@@ -240,8 +242,10 @@
                         <li>Haverfordwest (EGFE)</li>
                         <li>Kemble (EGBP)</li>
                         <li>Manchester Barton (EGCB)</li>
+                        <li>Newtownards (EGAD)</li>
                         <li>Old Sarum (EGLS)</li>
                         <li>Rochester (EGTO)</li>
+                        <li>Sherburn-in-Elmet (EGCJ)</li>
                         <li>Stapleford (EGSG)</li>
                         <li>Swansea (EGFH)</li>
                         <li>Thruxton (EGHO)</li>


### PR DESCRIPTION
As per: https://community.vatsim.uk/news/atc-training/more-aerodromes-for-s1-afisosag-operators-r240/