### PR TITLE
CORE-322 - Duplicate Account States

### DIFF
--- a/app/Models/Mship/Concerns/HasStates.php
+++ b/app/Models/Mship/Concerns/HasStates.php
@@ -118,12 +118,12 @@ trait HasStates
     public function addState(State $state, $region = null, $division = null)
     {
         // Cleanup Old States
-        $permanent_states = $this->states->sortByDesc('pivot.start_at')->filter(function ($state) {
+        $permanentStates = $this->states->sortByDesc('pivot.start_at')->filter(function ($state) {
             return $state->isPermanent;
         });
-        if ($permanent_states->count() > 1) {
+        if ($permanentStates->count() > 1) {
             // They have more than 1 permanent state? Let's set all but the latest to ended...
-            $this->states()->permanent()->wherePivot('id', '!=', $permanent_states->first()->pivot->id)->update(['end_at' => Carbon::now()]);
+            $this->states()->permanent()->wherePivot('id', '!=', $permanentStates->first()->pivot->id)->update(['end_at' => Carbon::now()]);
         }
 
         if ($this->hasState($state)) {
@@ -136,7 +136,6 @@ trait HasStates
         }
 
         // New state
-
         if ($this->primary_permanent_state && $state->is_permanent) {
             // New state is a permanent one, so lets remove the old permanent state
             $this->removeState($this->primary_permanent_state);

--- a/app/Models/Mship/Concerns/HasStates.php
+++ b/app/Models/Mship/Concerns/HasStates.php
@@ -17,7 +17,7 @@ trait HasStates
     public function states()
     {
         return $this->belongsToMany(State::class, 'mship_account_state', 'account_id', 'state_id')
-            ->withPivot(['region', 'division', 'start_at', 'end_at'])
+            ->withPivot(['id', 'region', 'division', 'start_at', 'end_at'])
             ->wherePivot('end_at', null);
     }
 
@@ -117,16 +117,30 @@ trait HasStates
      */
     public function addState(State $state, $region = null, $division = null)
     {
+        // Cleanup Old States
+        $permanent_states = $this->states->sortByDesc('pivot.start_at')->filter(function ($state) {
+            return $state->isPermanent;
+        });
+
+        if($permanent_states->count() > 0){
+            // They have more than 1 permanent state? Let's set all but the latest to ended...
+            $this->states()->permanent()->where('start_at', '!=', $permanent_states->first()->pivot->start_at)->update(['end_at' => Carbon::now()]);
+        }
+
         if ($this->hasState($state)) {
+            // Already has same class of state (e.g Intl)
             // Verify the same region/division information, else we want to update the state
-            $exisitingState = $this->states->where('id', $state->id)->first();
+            $exisitingState = $this->states->sortByDesc('pivot.start_at')->where('id', $state->id)->first();
             if ($exisitingState->pivot->region == $region && $exisitingState->pivot->division == $division) {
                 return;
             }
         }
 
-        if ($this->primary_state && $this->primary_state->is_permanent && $state->is_permanent) {
-            $this->removeState($this->primary_state);
+        // New state
+
+        if ($this->primary_permanent_state && $state->is_permanent) {
+            // New state is a permanent one, so lets remove the old permanent state
+            $this->removeState($this->primary_permanent_state);
         }
 
         if ($state->delete_all_temps) {

--- a/app/Models/Mship/Concerns/HasStates.php
+++ b/app/Models/Mship/Concerns/HasStates.php
@@ -122,7 +122,7 @@ trait HasStates
             return $state->isPermanent;
         });
 
-        if($permanent_states->count() > 0){
+        if ($permanent_states->count() > 0) {
             // They have more than 1 permanent state? Let's set all but the latest to ended...
             $this->states()->permanent()->where('start_at', '!=', $permanent_states->first()->pivot->start_at)->update(['end_at' => Carbon::now()]);
         }

--- a/app/Models/Mship/Concerns/HasStates.php
+++ b/app/Models/Mship/Concerns/HasStates.php
@@ -121,16 +121,15 @@ trait HasStates
         $permanent_states = $this->states->sortByDesc('pivot.start_at')->filter(function ($state) {
             return $state->isPermanent;
         });
-
-        if ($permanent_states->count() > 0) {
+        if ($permanent_states->count() > 1) {
             // They have more than 1 permanent state? Let's set all but the latest to ended...
-            $this->states()->permanent()->where('start_at', '!=', $permanent_states->first()->pivot->start_at)->update(['end_at' => Carbon::now()]);
+            $this->states()->permanent()->wherePivot('id', '!=', $permanent_states->first()->pivot->id)->update(['end_at' => Carbon::now()]);
         }
 
         if ($this->hasState($state)) {
             // Already has same class of state (e.g Intl)
             // Verify the same region/division information, else we want to update the state
-            $exisitingState = $this->states->sortByDesc('pivot.start_at')->where('id', $state->id)->first();
+            $exisitingState = $this->fresh()->states->sortByDesc('pivot.start_at')->where('id', $state->id)->first();
             if ($exisitingState->pivot->region == $region && $exisitingState->pivot->division == $division) {
                 return;
             }

--- a/tests/Unit/Mship/MshipAccountTest.php
+++ b/tests/Unit/Mship/MshipAccountTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Mship;
 
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;

--- a/tests/Unit/Mship/MshipAuthenticationTest.php
+++ b/tests/Unit/Mship/MshipAuthenticationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Mship;
 
 use App\Models\Mship\Account;
 use Illuminate\Foundation\Testing\DatabaseTransactions;

--- a/tests/Unit/Mship/MshipRoleTest.php
+++ b/tests/Unit/Mship/MshipRoleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Mship;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Spatie\Permission\Models\Permission;

--- a/tests/Unit/Mship/MshipStateTest.php
+++ b/tests/Unit/Mship/MshipStateTest.php
@@ -84,8 +84,11 @@ class MshipStateTest extends TestCase
     public function itDeletesOldPermanentStates()
     {
         // Setup
-
         $regionState = \App\Models\Mship\State::findByCode('REGION');
+        $visitingState = \App\Models\Mship\State::findByCode('VISITING');
+        $this->account->states()->attach($visitingState, [
+            'start_at' => Carbon::now(),
+        ]);
         for ($i=0;$i<5;$i++) {
             $this->account->states()->attach($regionState, [
                 'start_at' => Carbon::now(),
@@ -93,11 +96,11 @@ class MshipStateTest extends TestCase
                 'division' => 'EUD',
             ]);
         }
-        $this->assertEquals(5, $this->account->fresh()->states()->count());
+        $this->assertEquals(6, $this->account->fresh()->states()->count());
 
         // Now add the same state again.
         $this->account->fresh()->addState($regionState, 'EUR', 'EUD');
-        $this->assertEquals(1, $this->account->fresh()->states()->count());
+        $this->assertEquals(1, $this->account->fresh()->states()->permanent()->count());
         $this->assertDatabaseHas('mship_account_state', [
             'account_id' => $this->account->id,
             'state_id' => $regionState->id,

--- a/tests/Unit/Mship/MshipStateTest.php
+++ b/tests/Unit/Mship/MshipStateTest.php
@@ -86,7 +86,7 @@ class MshipStateTest extends TestCase
         // Setup
 
         $regionState = \App\Models\Mship\State::findByCode('REGION');
-        for ($i=0;$i<5;$i++){
+        for ($i=0;$i<5;$i++) {
             $this->account->states()->attach($regionState, [
                 'start_at' => Carbon::now(),
                 'region' => 'EUR',


### PR DESCRIPTION
What was happening with these accounts was:
- The user (for some reason or another) had an old state that had not been ended, say USA USA-N
- They then transferred to say CAN USA-N. The existing logic kept on looking at this first original state each time, and so decided it needed to add the new state.
- `$this->primary_states` was returning their visiting state. As this isn't a permanent state, it didn't use the logic to remove it, thus creating a never ending loop of adding new states but not deleting the old ones.

Closes CORE-322