### PR TITLE
CORE-388 - Fix Hour Checking Bug

### DIFF
--- a/app/Models/Training/WaitingListAccount.php
+++ b/app/Models/Training/WaitingListAccount.php
@@ -117,15 +117,13 @@ class WaitingListAccount extends Pivot
     public function atcHourCheck()
     {
         // gather the sessions from the last 3 months in the UK (isUK scope)
-        $controllingSessions = Atc::where('account_id', $this->account_id)
-            ->whereDate('disconnected_at', '>=', \Carbon\Carbon::parse('3 months ago'))->isUk()->get();
-
-        $time = (int)$controllingSessions->sum('minutes_online');
+        $hours = Atc::where('account_id', $this->account_id)
+            ->whereDate('disconnected_at', '>=', Carbon::parse('3 months ago'))->isUk()->sum('minutes_online');
 
         // 12 hours is represented as 720 minutes
         $minutesRequired = 720;
         // for a user in a waiting list, they should have > 12 hours controlled within the UK.
-        if ($time >= $minutesRequired) {
+        if ($hours >= $minutesRequired) {
             return true;
         }
 


### PR DESCRIPTION
Fixes a bug which didn't properly compute the status of an hour check for a member based upon their ATC NetworkData.