### PR TITLE
Updated The Process Of Event Approval

### DIFF
--- a/resources/views/site/atc/bookings.blade.php
+++ b/resources/views/site/atc/bookings.blade.php
@@ -77,7 +77,7 @@
 
                     <ul>
                         <li>
-                            When approved by the Community Director, controllers may be allocated positions to control.
+                            When approved by the Marketing Director, controllers may be allocated positions to control.
                             Allocated controlling shall take priority over controller bookings.
                         </li>
                     </ul>


### PR DESCRIPTION
Replaced 'Community Director' with 'Marketing Director' to keep the process up-to-date with the recent changes of delegated power among the staff team.