### PR TITLE
Remove flushcache method call

### DIFF
--- a/app/Console/Commands/NetworkData/ProcessNetworkData.php
+++ b/app/Console/Commands/NetworkData/ProcessNetworkData.php
@@ -61,7 +61,7 @@ class ProcessNetworkData extends Command
         $this->processATC();
         $this->processPilots();
         event(new NetworkDataParsed());
-        Atc::flushCache();
+        //Atc::flushCache();
     }
 
     /**


### PR DESCRIPTION
Not supported with current production drivers (database)

Ref: https://github.com/Zizaco/entrust/issues/468