### PR TITLE
Sys Config & Notice

### DIFF
--- a/app/Models/Sys/Config.php
+++ b/app/Models/Sys/Config.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models\Sys;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Config extends Model
+{
+    protected $table = 'sys_config';
+    protected $primaryKey = 'key';
+    public $timestamps = false;
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('active', function (Builder $builder) {
+            $builder->where('active', '=', '1');
+        });
+    }
+}

--- a/app/Models/Sys/Config.php
+++ b/app/Models/Sys/Config.php
@@ -9,6 +9,7 @@ class Config extends Model
 {
     protected $table = 'sys_config';
     protected $primaryKey = 'key';
+    protected $fillable = ['value'];
     public $timestamps = false;
 
     protected static function boot()

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -220,5 +220,11 @@ function maskEmail($email)
 
 function sys_config($key)
 {
-    return optional(\App\Models\Sys\Config::find($key))->value('value');
+    $cacheKey = 'sys_config_' . $key;
+
+    if (!cache($cacheKey)) {
+        cache([$cacheKey => \App\Models\Sys\Config::find($key)->value('value')], now()->addMinutes(10));
+    }
+
+    return cache($cacheKey);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -217,3 +217,8 @@ function maskEmail($email)
 
     return "{$delimited[0]}@{$delimited[1]}";
 }
+
+function sys_config($key)
+{
+    return optional(\App\Models\Sys\Config::find($key))->value('value');
+}

--- a/database/migrations/2019_10_13_164450_create_sys_config_table.php
+++ b/database/migrations/2019_10_13_164450_create_sys_config_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSysConfigTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sys_config', function (Blueprint $table) {
+            $table->string('key')->unique()->primary();
+            $table->string('value')->nullable();
+            $table->boolean('active')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sys_config');
+    }
+}

--- a/database/migrations/2019_10_13_171328_add_notice_key.php
+++ b/database/migrations/2019_10_13_171328_add_notice_key.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class AddNoticeKey extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('sys_config')->insert(
+            ['key' => 'notice']
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::delete("DELETE FROM sys_config WHERE `key` = 'notice'");
+    }
+}

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -41,9 +41,25 @@ body, html {
 }
 
 .dev_environment_notification {
-  height:20px;
-  background-color:red;
-  text-align: center;
+    height: 20px;
+    background-color: red;
+    text-align: center;
+}
+
+.top_notification {
+    height: 40px;
+    background-color: grey;
+    position: relative;
+
+    .text {
+        margin: 0;
+        position: absolute;
+        top: 50%;
+        -ms-transform: translateY(-50%);
+        transform: translateY(-50%);
+        text-align: center;
+        width: 100%;
+    }
 }
 
 .banner {

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -4,6 +4,13 @@
             You are in a <b>NON-PRODUCTION</b> environment
         </div>
     @endif
+    @if (sys_config('notice'))
+        <div class="top_notification">
+            <div class="text">
+                {!! sys_config('notice') !!}
+            </div>
+        </div>
+    @endif
     <div class="nav_upper_container">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle nav nav-collapsed" data-toggle="collapse"

--- a/tests/Unit/Sys/ConfigTest.php
+++ b/tests/Unit/Sys/ConfigTest.php
@@ -53,4 +53,16 @@ class ConfigTest extends TestCase
         $this->assertNotNull(Config::find('active'));
         $this->assertNull(Config::find('inactive'));
     }
+
+    /** @test */
+    public function theHelperFunctionReturnsTheValue()
+    {
+        Config::forceCreate([
+            'key'    => 'key',
+            'value'  => 'value',
+            'active' => 1
+        ]);
+
+        $this->assertEquals(sys_config('key'), 'value');
+    }
 }

--- a/tests/Unit/Sys/ConfigTest.php
+++ b/tests/Unit/Sys/ConfigTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\Sys;
+
+use App\Models\Sys\Config;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ConfigTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function itDoesNotAllowConfigKeysToBeCreated()
+    {
+        $this->expectException(QueryException::class);
+
+        Config::create([
+            'key'    => 'key',
+            'value'  => 'value',
+            'active' => 1
+        ]);
+    }
+
+    /** @test */
+    public function itFindsConfigKeysByKey()
+    {
+        $key = Config::forceCreate([
+            'key'    => 'key',
+            'value'  => 'value',
+            'active' => 1
+        ]);
+
+        $this->assertNotNull(Config::find('key'));
+    }
+
+    /** @test */
+    public function itOnlyReturnsActiveConfigKeys()
+    {
+        Config::forceCreate([
+            'key'    => 'active',
+            'value'  => 'active-value',
+            'active' => 1
+        ]);
+
+        Config::forceCreate([
+            'key'    => 'inactive',
+            'value'  => 'inactive-value',
+            'active' => 0
+        ]);
+
+        $this->assertNotNull(Config::find('active'));
+        $this->assertNull(Config::find('inactive'));
+    }
+}

--- a/tests/Unit/Sys/ConfigTest.php
+++ b/tests/Unit/Sys/ConfigTest.php
@@ -32,7 +32,7 @@ class ConfigTest extends TestCase
             'active' => 1
         ]);
 
-        $this->assertNotNull(Config::find('key'));
+        $this->assertEquals(Config::find('key')->value('value'), 'value');
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds;

- Adds concept of "sys_config" where you can have a key, a value and decide whether it is active or not. This allows us to configure things on the fly without pushing new builds.
- Adds first implementation of this config by adding the ability to add a banner at the top of Core based on the value against the config key "notice".