### PR TITLE
Semantic Release Plugin Config

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,14 @@
   },
   "release": {
     "repositoryUrl": "https://github.com/VATSIM-UK/core",
-    "branch": "master"
+    "branch": "master",
+    "plugins": [
+        "@semantic-release/npm",
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+          ["@semantic-release/github", {
+              "releasedLabels": false
+          }]
+      ]
   }
 }


### PR DESCRIPTION
- Defines explicitly the plugins we use (rather than just assuming the defaults are correct)
- Overrides the releasedLabel config value to `false` to prevent that label being added to PRs and issues after release.