### PR TITLE
Remove Deprecated PHPUnit Functions

### DIFF
--- a/app/Models/Cts/Booking.php
+++ b/app/Models/Cts/Booking.php
@@ -11,6 +11,9 @@ class Booking extends Model
     public const CREATED_AT = 'time_booked';
     public const UPDATED_AT = null;
     protected $attributes = ['local_id' => 0];
+    protected $hidden = [
+        'type_id', 'groupID', 'local_id', 'eurobook_id', 'eurobook_import', 'member_id', 'time_booked'
+    ];
 
     public function member()
     {

--- a/tests/Feature/Account/Feedback/FeedbackUserSearchTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackUserSearchTest.php
@@ -26,8 +26,8 @@ class FeedbackUserSearchTest extends TestCase
             ->get(route('mship.feedback.usersearch', $this->otherUser->real_name))
             ->getContent();
 
-        $this->assertContains(e($this->otherUser->real_name), $searchQuery);
-        $this->assertContains((string)($this->otherUser->id), $searchQuery);
+        $this->assertStringContainsString(e($this->otherUser->real_name), $searchQuery);
+        $this->assertStringContainsString((string)($this->otherUser->id), $searchQuery);
     }
 
     /** @test */
@@ -37,7 +37,7 @@ class FeedbackUserSearchTest extends TestCase
             ->get(route('mship.feedback.usersearch', $this->user->real_name))
             ->getContent();
 
-        $this->assertNotContains(e($this->user->real_name), $searchQuery);
-        $this->assertNotContains((string)($this->user->id), $searchQuery);
+        $this->assertStringNotContainsString(e($this->user->real_name), $searchQuery);
+        $this->assertStringNotContainsString((string)($this->user->id), $searchQuery);
     }
 }

--- a/tests/Unit/CTS/BookingsRepositoryTest.php
+++ b/tests/Unit/CTS/BookingsRepositoryTest.php
@@ -38,48 +38,49 @@ class BookingsRepositoryTest extends TestCase
         factory(Booking::class, 2)->create(['date' => $this->knownDate->copy()->addDays(5)->toDateString()]);
 
         $bookingTodayOne = factory(Booking::class)->create([
-            'id' => '96155',
-            'date' => $this->today,
-            'from' => '17:00',
+            'id'        => '96155',
+            'date'      => $this->today,
+            'from'      => '17:00',
             'member_id' => factory(Member::class)->create()->id,
-            'type' => 'BK',
+            'type'      => 'BK',
         ]);
 
         $bookingTodayTwo = factory(Booking::class)->create([
-            'id' => '96156',
-            'date' => $this->today,
-            'from' => '18:00',
+            'id'        => '96156',
+            'date'      => $this->today,
+            'from'      => '18:00',
             'member_id' => factory(Member::class)->create()->id,
-            'type' => 'ME',
+            'type'      => 'ME',
         ]);
 
         $bookings = $this->subjectUnderTest->getTodaysBookings();
 
         $this->assertInstanceOf(Collection::class, $bookings);
         $this->assertCount(2, $bookings);
-        $this->assertArraySubset([
-            'id' => $bookingTodayOne->id,
-            'date' => $this->today,
-            'from' => Carbon::parse($bookingTodayOne->from)->format('H:i'),
-            'to' => Carbon::parse($bookingTodayOne->to)->format('H:i'),
+
+        $this->assertEquals([
+            'id'       => $bookingTodayOne->id,
+            'date'     => $this->today,
+            'from'     => Carbon::parse($bookingTodayOne->from)->format('H:i'),
+            'to'       => Carbon::parse($bookingTodayOne->to)->format('H:i'),
             'position' => $bookingTodayOne->position,
-            'member' => [
-                'id' => $bookingTodayOne['member']['cid'],
+            'type'     => $bookingTodayOne->type,
+            'member'   => [
+                'id'   => $bookingTodayOne['member']['cid'],
                 'name' => $bookingTodayOne['member']['name'],
             ],
-            'type' => $bookingTodayOne->type,
         ], $bookings->get(0)->toArray());
-        $this->assertArraySubset([
-            'id' => $bookingTodayTwo->id,
-            'date' => $this->today,
-            'from' => Carbon::parse($bookingTodayTwo->from)->format('H:i'),
-            'to' => Carbon::parse($bookingTodayTwo->to)->format('H:i'),
+        $this->assertEquals([
+            'id'       => $bookingTodayTwo->id,
+            'date'     => $this->today,
+            'from'     => Carbon::parse($bookingTodayTwo->from)->format('H:i'),
+            'to'       => Carbon::parse($bookingTodayTwo->to)->format('H:i'),
             'position' => $bookingTodayTwo->position,
-            'member' => [
-                'id' => $bookingTodayTwo['member']['cid'],
+            'type'     => $bookingTodayTwo->type,
+            'member'   => [
+                'id'   => $bookingTodayTwo['member']['cid'],
                 'name' => $bookingTodayTwo['member']['name'],
             ],
-            'type' => $bookingTodayTwo->type,
         ], $bookings->get(1)->toArray());
     }
 
@@ -92,12 +93,12 @@ class BookingsRepositoryTest extends TestCase
         $bookings = $this->subjectUnderTest->getTodaysBookings();
 
         $this->assertEquals([
-            'id' => $normalBooking->member->cid,
+            'id'   => $normalBooking->member->cid,
             'name' => $normalBooking->member->name,
         ], $bookings->get(0)['member']);
 
         $this->assertEquals([
-            'id' => '',
+            'id'   => '',
             'name' => 'Hidden',
         ], $bookings->get(1)['member']);
     }

--- a/tests/Unit/Endorsements/ConditionModelTest.php
+++ b/tests/Unit/Endorsements/ConditionModelTest.php
@@ -55,7 +55,7 @@ class ConditionModelTest extends TestCase
         $this->condition->save();
 
         $this->assertTrue(is_array($this->condition->fresh()->human_positions));
-        $this->assertArraySubset(['EGKK_XXX', 'EGLL_XXX'], $this->condition->fresh()->human_positions);
+        $this->assertEquals(['EGKK_XXX', 'EGLL_XXX'], $this->condition->fresh()->human_positions);
     }
 
     /** @test */


### PR DESCRIPTION
1) Tests\Unit\Endorsements\ConditionModelTest::itReturnsAListOfHumanPositions  assertArraySubset() is deprecated and will be removed in PHPUnit 9.

2) Tests\Unit\CTS\BookingsRepositoryTest::itCanReturnAListOfTodaysBookingsWithOwnerAndType  assertArraySubset() is deprecated and will be removed in PHPUnit 9.

3) Tests\Feature\FeedbackUserSearchTest::testItDoesNotReturnCurrentUser  Using assertNotContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringNotContainsString() or assertStringNotContainsStringIgnoringCase() instead.

4) Tests\Feature\FeedbackUserSearchTest::testItReturnsAnotherUser  Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.