### PR TITLE
Hotfix: Stop syncing forum groups from scheduler

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,7 +27,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command('telescope:prune')->daily();
-        $schedule->command('sync:tg-forum-groups')->dailyAt('04:00');
+        // $schedule->command('sync:tg-forum-groups')->dailyAt('04:00');
     }
 
     /**


### PR DESCRIPTION
This is causing the queue to crash at the scheduled time each day