### PR TITLE
ApiTracking - firstOrFail

### DIFF
--- a/app/Http/Middleware/ApiTracking.php
+++ b/app/Http/Middleware/ApiTracking.php
@@ -32,7 +32,7 @@ class ApiTracking
             $apiRequest = \App\Models\Api\Request::where('api_account_id', '=', \Auth::guard('api')->user()->id)
                 ->where('method', '=', $request->method())
                 ->whereNull('response_code')
-                ->orderBy('created_at', 'DESC')->first();
+                ->orderBy('created_at', 'DESC')->firstOrFail();
 
             $apiRequest->response_code = $response->status();
             $apiRequest->response_full = $response->content();


### PR DESCRIPTION
Resolves #1554 

Exception being thrown because there is no apiRequest object. Amend Eloquent call to `firstOrFail()` to gracefully throw a 404 if it does not find the appropriate request in the database.