### PR TITLE
Feature - Endorsement cache bust on ATC session end

### DIFF
--- a/app/Events/NetworkData/AtcSessionEnded.php
+++ b/app/Events/NetworkData/AtcSessionEnded.php
@@ -16,6 +16,7 @@ class AtcSessionEnded extends Event
      * Construct the event, storing the ATC session that's just ended.
      *
      * There's little to construct at the minute as it's simply a notification!
+     * @param Atc $atc
      */
     public function __construct(Atc $atc)
     {

--- a/app/Listeners/NetworkData/FlushEndorsementCache.php
+++ b/app/Listeners/NetworkData/FlushEndorsementCache.php
@@ -13,8 +13,8 @@ class FlushEndorsementCache implements ShouldQueue
     public function handle(AtcSessionEnded $event)
     {
         $user = $event->atcSession->account;
-        Endorsement::pluck('id')->each(function ($id) use ($user) {
-            Cache::forget(Endorsement::generateCacheKey($id, $user->id));
+        Endorsement::get(['id'])->each(function (Endorsement $endorsement) use ($user) {
+            Cache::forget($endorsement->generateCacheKey($user));
         });
     }
 }

--- a/app/Listeners/NetworkData/FlushEndorsementCache.php
+++ b/app/Listeners/NetworkData/FlushEndorsementCache.php
@@ -13,7 +13,7 @@ class FlushEndorsementCache implements ShouldQueue
     public function handle(AtcSessionEnded $event)
     {
         $user = $event->atcSession->account;
-        Endorsement::pluck('id')->each(function ($id) use ($user){
+        Endorsement::pluck('id')->each(function ($id) use ($user) {
             Cache::forget(Endorsement::generateCacheKey($id, $user->id));
         });
     }

--- a/app/Listeners/NetworkData/FlushEndorsementCache.php
+++ b/app/Listeners/NetworkData/FlushEndorsementCache.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Listeners\NetworkData;
+
+use App\Events\NetworkData\AtcSessionEnded;
+use App\Models\Atc\Endorsement;
+use App\Notifications\AtcSessionRecordedConfirmation;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Cache;
+
+class FlushEndorsementCache implements ShouldQueue
+{
+    public function handle(AtcSessionEnded $event)
+    {
+        $user = $event->atcSession->account;
+        $endorsementIds = Endorsement::pluck('id');
+
+        foreach ($endorsementIds as $endorsementId){
+            Cache::forget(Endorsement::generateCacheKey($endorsementId, $user->id));
+        }
+    }
+}

--- a/app/Listeners/NetworkData/FlushEndorsementCache.php
+++ b/app/Listeners/NetworkData/FlushEndorsementCache.php
@@ -13,10 +13,8 @@ class FlushEndorsementCache implements ShouldQueue
     public function handle(AtcSessionEnded $event)
     {
         $user = $event->atcSession->account;
-        $endorsementIds = Endorsement::pluck('id');
-
-        foreach ($endorsementIds as $endorsementId) {
-            Cache::forget(Endorsement::generateCacheKey($endorsementId, $user->id));
-        }
+        Endorsement::pluck('id')->each(function ($id) use ($user){
+            Cache::forget(Endorsement::generateCacheKey($id, $user->id));
+        });
     }
 }

--- a/app/Models/Atc/Endorsement.php
+++ b/app/Models/Atc/Endorsement.php
@@ -21,7 +21,7 @@ class Endorsement extends Model
 
     public function conditionsMetForUser(Account $account): bool
     {
-        $cacheKey = self::generateCacheKey($this->id, $account->id);
+        $cacheKey = $this->generateCacheKey($account);
         $cacheTtl = 86400; // 24 hours
 
         if (Cache::has($cacheKey)) {
@@ -39,8 +39,8 @@ class Endorsement extends Model
         return $allMet;
     }
 
-    public static function generateCacheKey(int $endorsementId, int $accountId)
+    public function generateCacheKey(Account $account)
     {
-        return "endorsement:{$endorsementId}:account:{$accountId}:met";
+        return "endorsement:{$this->id}:account:{$account->id}:met";
     }
 }

--- a/app/Models/Atc/Endorsement.php
+++ b/app/Models/Atc/Endorsement.php
@@ -21,7 +21,7 @@ class Endorsement extends Model
 
     public function conditionsMetForUser(Account $account): bool
     {
-        $cacheKey = "endorsement:{$this->id}:account:{$account->id}:met";
+        $cacheKey = self::generateCacheKey($this->id, $account->id);
         $cacheTtl = 86400; // 24 hours
 
         if (Cache::has($cacheKey)) {
@@ -37,5 +37,9 @@ class Endorsement extends Model
         Cache::put($cacheKey, $allMet, $cacheTtl);
 
         return $allMet;
+    }
+
+    public static function generateCacheKey($endorsementId, $accountId){
+        return "endorsement:{$endorsementId}:account:{$accountId}:met";
     }
 }

--- a/app/Models/Atc/Endorsement.php
+++ b/app/Models/Atc/Endorsement.php
@@ -39,7 +39,7 @@ class Endorsement extends Model
         return $allMet;
     }
 
-    public static function generateCacheKey($endorsementId, $accountId)
+    public static function generateCacheKey(int $endorsementId, int $accountId)
     {
         return "endorsement:{$endorsementId}:account:{$accountId}:met";
     }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Events\NetworkData\AtcSessionEnded;
 use App\Events\Smartcars\BidCompleted;
+use App\Listeners\NetworkData\FlushEndorsementCache;
 use App\Listeners\Smartcars\EvaluateFlightCriteria;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -34,6 +35,7 @@ class EventServiceProvider extends ServiceProvider
 
         AtcSessionEnded::class => [
             //AtcSessionRecordedSuccessNotification::class, // temporarily disabled
+            FlushEndorsementCache::class
         ],
 
         \App\Events\VisitTransfer\ApplicationSubmitted::class => [

--- a/tests/Unit/Endorsements/EndorsementModelTest.php
+++ b/tests/Unit/Endorsements/EndorsementModelTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Endorsements;
 
 use App\Models\Atc\Endorsement;
 use App\Models\NetworkData\Atc;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
@@ -129,6 +130,32 @@ class EndorsementModelTest extends TestCase
         // true assertion based upon the return value of the mocked cache facade above.
         $this->assertTrue($this->endorsement->fresh()->conditionsMetForUser($this->user));
     }
+
+    /** @test */
+    public function itFlushesUserEndorsementCacheAfterATCSession()
+    {
+        $this->createMockCondition();
+
+        $spy = Cache::spy();
+
+        $this->assertFalse($this->endorsement->fresh()->conditionsMetForUser($this->user));
+
+        $atc = factory(Atc::class)->create([
+            'account_id' => $this->user->id,
+            'callsign' => 'EGKK_TWR',
+            'connected_at' => Carbon::now()->subHours(2)
+        ]);
+
+        $atc->disconnectAt(Carbon::now());
+
+        $spy->shouldHaveReceived('put')
+            ->once();
+        $spy->shouldHaveReceived('forget')
+            ->times(Endorsement::count());
+
+        $this->assertTrue($this->endorsement->fresh()->conditionsMetForUser($this->user));
+    }
+
 
     private function createMockCondition($positions = ['EGKK_%'], $type = Endorsement\Condition::TYPE_ON_SINGLE_AIRFIELD)
     {

--- a/tests/Unit/Endorsements/EndorsementModelTest.php
+++ b/tests/Unit/Endorsements/EndorsementModelTest.php
@@ -140,16 +140,16 @@ class EndorsementModelTest extends TestCase
 
         $this->assertFalse($this->endorsement->fresh()->conditionsMetForUser($this->user));
 
+        $spy->shouldHaveReceived('put')
+            ->once();
+
         $atc = factory(Atc::class)->create([
             'account_id' => $this->user->id,
             'callsign' => 'EGKK_TWR',
             'connected_at' => Carbon::now()->subHours(2)
         ]);
-
         $atc->disconnectAt(Carbon::now());
 
-        $spy->shouldHaveReceived('put')
-            ->once();
         $spy->shouldHaveReceived('forget')
             ->times(Endorsement::count());
 


### PR DESCRIPTION
Busts a user's endorsement cache when a ATC session ends.

Currently, the overall status for an endorsement does not tally with the status for the individual conditions. This fix will cache-bust the user's endorsement-met status when their ATC session ends.