### PR TITLE
Ignore Tags on GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,9 @@
 name: Build & Test
 
-on: push
+on:
+  push:
+    tags-ignore:
+      - '**'
 
 jobs:
   laravel-tests:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,9 +3,10 @@ name: Build & Test
 on:
   push:
     branches:
-      - 'master'
-    tags-ignore:
+      - '*'
       - '**'
+    tags-ignore:
+      - v*
 
 jobs:
   laravel-tests:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,6 +2,8 @@ name: Build & Test
 
 on:
   push:
+    branches:
+      - 'master'
     tags-ignore:
       - '**'
 

--- a/routes/web-public.php
+++ b/routes/web-public.php
@@ -14,13 +14,13 @@ Route::group([
         'as' => 'atc.',
         'prefix' => 'atc',
     ], function () {
-            Route::get('/')->uses('ATCPagesController@viewLanding')->name('landing');
-            Route::get('/new-controller')->uses('ATCPagesController@viewNewController')->name('newController');
-            Route::get('/progression-guide')->uses('ATCPagesController@viewProgressionGuide')->name('progression');
-            Route::get('/endorsements')->uses('ATCPagesController@viewEndorsements')->name('endorsements');
-            Route::get('/becoming-a-mentor')->uses('ATCPagesController@viewBecomingAMentor')->name('mentor');
-            Route::get('/bookings')->uses('ATCPagesController@viewBookings')->name('bookings');
-        });
+        Route::get('/')->uses('ATCPagesController@viewLanding')->name('landing');
+        Route::get('/new-controller')->uses('ATCPagesController@viewNewController')->name('newController');
+        Route::get('/progression-guide')->uses('ATCPagesController@viewProgressionGuide')->name('progression');
+        Route::get('/endorsements')->uses('ATCPagesController@viewEndorsements')->name('endorsements');
+        Route::get('/becoming-a-mentor')->uses('ATCPagesController@viewBecomingAMentor')->name('mentor');
+        Route::get('/bookings')->uses('ATCPagesController@viewBookings')->name('bookings');
+    });
 
     Route::group([
         'as' => 'pilots.',


### PR DESCRIPTION
Ref: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags and https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags

We should ignore all pushes to tags as there is no point running the workflows twice on `master`

<img width="584" alt="Image 2020-05-14 at 4 38 07 pm png" src="https://user-images.githubusercontent.com/7726792/81954873-4da4c880-9601-11ea-9688-1ec75aaa6196.png">
