### PR TITLE
Use PCOV For Coverage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.3']
+        php: ['7.3', '7.4']
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,6 +13,21 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
+      - name: Set PHP Version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.3'
+      - name: Install PCOV
+        if: ${{ matrix.phpunit == 'with-coverage' }}
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: pcov
+      - name: Remove xDebug
+        if: ${{ matrix.phpunit == 'without-coverage' }}
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+
       - name: Write Nova Secrets
         env:
           NOVA_USERNAME: ${{ secrets.NOVA_USERNAME }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: '7.3'
+        php: ['7.3']
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,25 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        phpunit: ['without-coverage', 'with-coverage']
+        php: '7.3'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Set PHP Version
+      - name: Configure PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
-      - name: Install PCOV
-        if: ${{ matrix.phpunit == 'with-coverage' }}
-        uses: shivammathur/setup-php@v2
-        with:
+          php-version: ${{ matrix.php }}
           coverage: pcov
-      - name: Remove xDebug
-        if: ${{ matrix.phpunit == 'without-coverage' }}
-        uses: shivammathur/setup-php@v2
-        with:
-          coverage: none
 
       - name: Write Nova Secrets
         env:
@@ -130,17 +121,11 @@ jobs:
       - name: Serve Application
         run: php artisan serve -q &
 
-      - name: Execute PHPUnit Tests
-        if: ${{ matrix.phpunit == 'without-coverage' }}
-        run: vendor/bin/phpunit
-
       - name: Execute PHPUnit Tests With Coverage
-        if: ${{ matrix.phpunit == 'with-coverage' }}
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
 
       - name: Upload Code Coverage Report
         uses: codecov/codecov-action@v1.0.5
-        if: ${{ matrix.phpunit == 'with-coverage' }}
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml

--- a/routes/web-public.php
+++ b/routes/web-public.php
@@ -14,13 +14,13 @@ Route::group([
         'as' => 'atc.',
         'prefix' => 'atc',
     ], function () {
-            Route::get('/')->uses('ATCPagesController@viewLanding')->name('landing');
-            Route::get('/new-controller')->uses('ATCPagesController@viewNewController')->name('newController');
-            Route::get('/progression-guide')->uses('ATCPagesController@viewProgressionGuide')->name('progression');
-            Route::get('/endorsements')->uses('ATCPagesController@viewEndorsements')->name('endorsements');
-            Route::get('/becoming-a-mentor')->uses('ATCPagesController@viewBecomingAMentor')->name('mentor');
-            Route::get('/bookings')->uses('ATCPagesController@viewBookings')->name('bookings');
-        });
+        Route::get('/')->uses('ATCPagesController@viewLanding')->name('landing');
+        Route::get('/new-controller')->uses('ATCPagesController@viewNewController')->name('newController');
+        Route::get('/progression-guide')->uses('ATCPagesController@viewProgressionGuide')->name('progression');
+        Route::get('/endorsements')->uses('ATCPagesController@viewEndorsements')->name('endorsements');
+        Route::get('/becoming-a-mentor')->uses('ATCPagesController@viewBecomingAMentor')->name('mentor');
+        Route::get('/bookings')->uses('ATCPagesController@viewBookings')->name('bookings');
+    });
 
     Route::group([
         'as' => 'pilots.',


### PR DESCRIPTION
- Merges with and without coverage tests so that we always run with coverage to simplify the process
- Swaps XDebug (installed by default) for PCOV to run coverage reports significantly quicker
- Runs tests on PHP 7.3 and PHP 7.4