### PR TITLE
Extend Horizon Notification Time

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -87,7 +87,7 @@ return [
     */
 
     'waits' => [
-        'redis:queue' => 60,
+        'redis:queue' => 600,
     ],
 
     /*


### PR DESCRIPTION
We only really need to know if things are running super slowly - 10 minutes is fine.