### PR TITLE
Fixes #1822 Removed "Scottish Control (SCO_CTR)"

### DIFF
--- a/resources/views/site/community/vt-guide.blade.php
+++ b/resources/views/site/community/vt-guide.blade.php
@@ -265,9 +265,6 @@
 
                 <ul>
                     <li>
-                        Scottish Control (SCO_CTR)
-                    </li>
-                    <li>
                         London Control (LON_W_CTR)
                     </li>
                     <li>


### PR DESCRIPTION
Removed reference to Scottish Control (SCO_CTR) on the VT-Guide.