### PR TITLE
1799 - Handle CERT Down

### DIFF
--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -4,7 +4,6 @@ namespace App\Jobs;
 
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification as QualificationData;
-use Bugsnag;
 use Carbon\Carbon;
 use DB;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -37,7 +37,7 @@ class UpdateMember extends Job implements ShouldQueue
         try {
             $this->data = VatsimXML::getData($this->accountID, 'idstatusint');
         } catch (\Exception $e) {
-            return
+            return;
         }
 
         DB::beginTransaction();

--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -37,13 +37,7 @@ class UpdateMember extends Job implements ShouldQueue
         try {
             $this->data = VatsimXML::getData($this->accountID, 'idstatusint');
         } catch (\Exception $e) {
-            if (strpos($e->getMessage(), 'Name or service not known') !== false) {
-                // CERT unavailable. Not our fault, so will ignore.
-                return;
-            }
-            Bugsnag::notifyException($e);
-
-            return;
+            return
         }
         DB::beginTransaction();
         if (! is_string($this->data->region)) {

--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -39,10 +39,13 @@ class UpdateMember extends Job implements ShouldQueue
         } catch (\Exception $e) {
             return
         }
+
         DB::beginTransaction();
+
         if (! is_string($this->data->region)) {
             $this->data->region = '';
         }
+
         if (! is_string($this->data->division)) {
             $this->data->division = '';
         }


### PR DESCRIPTION
Resolves #1799 

Amended this to just catch all exceptions.

The facade this is using from the XML package is fairly simple and is only going to blow up if the request fails on CERT's side. Given that this will be replaced by the VATSIM API and Connect soon, I'm happy for this to just catch all exceptions and ignore them.

The other option is we check for multiple exception types;

`failed to open stream: HTTP request failed!` and `Name or service not known` are the two biggest offenders.
