### PR TITLE
1756 - Handle GDPR Removed Reg Date

### DIFF
--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -74,7 +74,7 @@ class UpdateMember extends Job implements ShouldQueue
             $member->cert_checked_at = Carbon::now();
             $member->is_inactive = (bool) ($this->data->rating < 0);
 
-            if ($this->data->regdate !== '0000-00-00 00:00:00') {
+            if ($this->data->regdate !== '0000-00-00 00:00:00' && $this->data->regdate !== 'None') {
                 $member->joined_at = $this->data->regdate;
             }
 


### PR DESCRIPTION
Resolves #1756 

Example: https://cert.vatsim.net/vatsimnet/idstatus.php?cid=1430931

"None" was throwing an exception when trying to convert it to a DateTime... because... it isn't a date or time!