### PR TITLE
Fix: CTS Next Event 502 Exceptions

### DIFF
--- a/app/Http/Controllers/Site/HomePageController.php
+++ b/app/Http/Controllers/Site/HomePageController.php
@@ -23,6 +23,7 @@ class HomePageController extends \App\Http\Controllers\BaseController
     private function nextEvent()
     {
         $response = Http::get('https://cts.vatsim.uk/extras/next_event.php');
+
         return $response->failed() ? '' : $this->getHTMLByID('next', $response);
     }
 

--- a/app/Http/Controllers/Site/HomePageController.php
+++ b/app/Http/Controllers/Site/HomePageController.php
@@ -22,7 +22,8 @@ class HomePageController extends \App\Http\Controllers\BaseController
 
     private function nextEvent()
     {
-        return $this->getHTMLByID('next', Http::get('https://cts.vatsim.uk/extras/next_event.php'));
+        $response = Http::get('https://cts.vatsim.uk/extras/next_event.php');
+        return $response->failed() ? '' : $this->getHTMLByID('next', $response);
     }
 
     public function getHTMLByID($id, $html)

--- a/app/Http/Controllers/Site/HomePageController.php
+++ b/app/Http/Controllers/Site/HomePageController.php
@@ -7,6 +7,7 @@ use App\Repositories\Cts\BookingRepository;
 use App\Repositories\Cts\EventRepository;
 use Illuminate\Support\Facades\Cache as Cache;
 use Illuminate\Support\Facades\DB as DB;
+use Illuminate\Support\Facades\Http;
 
 class HomePageController extends \App\Http\Controllers\BaseController
 {
@@ -21,14 +22,7 @@ class HomePageController extends \App\Http\Controllers\BaseController
 
     private function nextEvent()
     {
-        try {
-            $html = file_get_contents('https://cts.vatsim.uk/extras/next_event.php');
-
-            return $this->getHTMLByID('next', $html);
-        } catch (\HttpRequestException $e) {
-            // CTS likely unavailable.
-            return;
-        }
+        return $this->getHTMLByID('next', Http::get('https://cts.vatsim.uk/extras/next_event.php'));
     }
 
     public function getHTMLByID($id, $html)


### PR DESCRIPTION
Migrates CTS next event request to HTTP facade, which won't throw an exception for 400 or 500 HTTP errors.

Fixes #1839 