### PR TITLE
fix: deferral not being selected when previous been in list

### DIFF
--- a/app/Models/Mship/Concerns/HasNovaPermissions.php
+++ b/app/Models/Mship/Concerns/HasNovaPermissions.php
@@ -10,7 +10,7 @@ trait HasNovaPermissions
     public function waitingLists()
     {
         return $this->belongsToMany(WaitingList::class, 'training_waiting_list_account',
-            'account_id', 'list_id')->using(WaitingListAccount::class)->withPivot(['id']);
+            'account_id', 'list_id')->using(WaitingListAccount::class)->withPivot(['id', 'deleted_at']);
     }
 
     public function waitingListDepartments()


### PR DESCRIPTION
When a user had been previously added to a list, and then deleted, that user couldn't be deferred again because the `deleted_at` on the pivot was always going to be null as it wasn't defined in the relationship.

This PR fixes this by adding it into the pivot so it would only defer on the non-softDeleted WaitingListAccount.﻿
