### PR TITLE
API Exceptions For ATC Rating

### DIFF
--- a/app/Http/Controllers/Api/OAuthUserController.php
+++ b/app/Http/Controllers/Api/OAuthUserController.php
@@ -30,10 +30,16 @@ class OAuthUserController
             $return['email'] = $ssoEmailAssigned[0]->email->email;
         }
 
-        $return['atc_rating'] = $account->qualification_atc->vatsim;
-        $return['atc_rating_human_short'] = $account->qualification_atc->name_small;
-        $return['atc_rating_human_long'] = $account->qualification_atc->name_long;
-        $return['atc_rating_date'] = $account->qualification_atc->pivot->created_at->toDateTimeString();
+        if (count($account->qualification_atc) < 1) {
+            $return['atc_rating'][] = 0;
+            $return['atc_rating_human_short'][] = 'NA';
+            $return['atc_rating_human_long'][] = 'None Awarded';
+        } else {
+            $return['atc_rating'] = $account->qualification_atc->vatsim;
+            $return['atc_rating_human_short'] = $account->qualification_atc->name_small;
+            $return['atc_rating_human_long'] = $account->qualification_atc->name_long;
+            $return['atc_rating_date'] = $account->qualification_atc->pivot->created_at->toDateTimeString();
+        }
 
         $return['pilot_ratings_bin'] = 0;
         $return['pilot_ratings'] = [];


### PR DESCRIPTION
Fixed #1865

Seems to be an issue for inactive users - they do not have an ATC rating in `mship_account_qualification` so we should not presume it'll be present, similar to how we handle pilot ratings a few lines below.