### PR TITLE
Properly Catch UKCP FileNotFound Exceptions

### DIFF
--- a/app/Http/Controllers/UKCP/Token.php
+++ b/app/Http/Controllers/UKCP/Token.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\BaseController;
 use App\Libraries\UKCP as UKCPLibrary;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
+use League\Flysystem\FileNotFoundException;
 
 class Token extends BaseController
 {


### PR DESCRIPTION
Fixed #1858 

The `Storage` facade uses League's Flysystem so we need to catch that exception.