### PR TITLE
Move Discord Id Columns

### DIFF
--- a/database/migrations/2020_08_10_164413_change_order_of_discord_columns.php
+++ b/database/migrations/2020_08_10_164413_change_order_of_discord_columns.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeOrderOfDiscordColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement('ALTER TABLE `mship_account` MODIFY COLUMN `discord_id` varchar(30) AFTER `remember_token`');
+        DB::statement('ALTER TABLE `mship_account` MODIFY COLUMN `discord_access_token` text AFTER `discord_id`');
+        DB::statement('ALTER TABLE `mship_account` MODIFY COLUMN `discord_refresh_token` text AFTER `discord_access_token`');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2020_08_10_164413_change_order_of_discord_columns.php
+++ b/database/migrations/2020_08_10_164413_change_order_of_discord_columns.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 class ChangeOrderOfDiscordColumns extends Migration
 {


### PR DESCRIPTION
Names should be first, rather than three columns with id numbers / tokens relating to Discord.