### PR TITLE
1879 - Remove Slack References

### DIFF
--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -40,7 +40,6 @@ use Watson\Rememberable\Rememberable;
  * App\Models\Mship\Account.
  *
  * @property int $id
- * @property string|null $slack_id
  * @property int|null $discord_id
  * @property int|null $discord_access_token
  * @property int|null $discord_refresh_token
@@ -154,7 +153,6 @@ use Watson\Rememberable\Rememberable;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\Mship\Account wherePasswordExpiresAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\Mship\Account wherePasswordSetAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\Mship\Account whereRememberToken($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\Mship\Account whereSlackId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\Mship\Account whereUpdatedAt($value)
  * @method static \Illuminate\Database\Query\Builder|\App\Models\Mship\Account withTrashed()
  * @method static \Illuminate\Database\Query\Builder|\App\Models\Mship\Account withoutTrashed()

--- a/database/migrations/2020_08_10_164240_remove_slack_id_column.php
+++ b/database/migrations/2020_08_10_164240_remove_slack_id_column.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemoveSlackIdColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mship_account', function (Blueprint $table) {
+            $table->dropColumn('slack_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2020_08_10_164240_remove_slack_id_column.php
+++ b/database/migrations/2020_08_10_164240_remove_slack_id_column.php
@@ -17,14 +17,4 @@ class RemoveSlackIdColumn extends Migration
             $table->dropColumn('slack_id');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        //
-    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,10 +32,6 @@
     <env name="SESSION_DRIVER" value="array"/>
     <env name="QUEUE_DRIVER" value="sync"/>
     <env name="MAIL_DRIVER" value="log"/>
-    <env name="SLACK_SECRET" value="testing"/>
-    <env name="SLACK_BOT_TOKEN" value="testing"/>
-    <env name="SLACK_TOKEN_REGISTER" value="testing"/>
-    <env name="SLACK_ENDPOINT" value="testing"/>
     <ini name="memory_limit" value="-1"/>
 </php>
 </phpunit>

--- a/resources/views/components/top-notification.blade.php
+++ b/resources/views/components/top-notification.blade.php
@@ -8,7 +8,7 @@
                 </div>
                 <div class="col-md-8 message">
                     <p><strong>Discord has arrived. Join us {{ auth()->user()->name_first }}!</strong></p>
-                    <p>Discord is now available to all VATSIM UK members. Registration takes less than 60 seconds. Simply hit the button to get started. <strong>Slack will be closed from Sunday 16th August</strong>.</p>
+                    <p>Discord is now available to all VATSIM UK members. Registration takes less than 60 seconds. Simply hit the button to get started.</p>
                 </div>
                 <div class="col-md-3 cta text-center">
                     <a href="{{ route('discord.show') }}" class="button secondary">

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -298,20 +298,6 @@
                     </div>
                 </div>
             </div>
-            <div class="panel panel-ukblue">
-                <div class="panel-heading"><i class="fab fa-slack"></i>
-                    Slack Registration
-                </div>
-                <div class="panel-body">
-                    <div class="row">
-                        <div class="col-xs-12">
-                            We are no longer using Slack in VATSIM UK.<br>
-                            You can sign up for Discord, Slack's replacement, by <a href="{{ route('discord.show') }}">clicking here</a>.<br>
-                            <a href="https://community.vatsim.uk/news/web-services/slacks-retirement-our-transition-to-discord-r336/">Find out why we are moving from Slack to Discord</a>.
-                        </div>
-                    </div>
-                </div>
-            </div>
         </div>
         <div class="col-md-6">
             <div class="panel panel-ukblue">

--- a/tests/Unit/Account/AccountModelTest.php
+++ b/tests/Unit/Account/AccountModelTest.php
@@ -278,19 +278,6 @@ class AccountModelTest extends TestCase
     }
 
     /** @test */
-    public function itReturnsTheCorrectAccountBasedOnSlackId()
-    {
-        $slackID = substr(strrev(uniqid()), 0, 10);
-
-        $this->user->slack_id = $slackID;
-        $this->user->save();
-
-        $slackAccount = Account::where('slack_id', $slackID)->first();
-
-        $this->assertEquals($slackAccount->id, $this->user->fresh()->id);
-    }
-
-    /** @test */
     public function itDeterminesThatPasswordIsNotSet()
     {
         $this->assertFalse($this->user->hasPassword());

--- a/tests/Unit/Account/AccountModelTest.php
+++ b/tests/Unit/Account/AccountModelTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit\Account;
 
-use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
 use App\Notifications\Mship\EmailVerification;
 use Carbon\Carbon;


### PR DESCRIPTION
- Removes remaining Slack references in code and from the user's point of view
- Drops the `slack_id` column

Resolves #1879 