### PR TITLE
fix: permission name cannot be null, error

### DIFF
--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Permission extends \Spatie\Permission\Models\Permission
+{
+    protected $guarded = [];
+    protected $fillable = ['name', 'guard_name'];
+}

--- a/config/permission.php
+++ b/config/permission.php
@@ -13,7 +13,7 @@ return [
          * `Spatie\Permission\Contracts\Permission` contract.
          */
 
-        'permission' => Spatie\Permission\Models\Permission::class,
+        'permission' => App\Models\Permission::class,
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which

--- a/database/migrations/2019_07_20_085104_add_waiting_list_table.php
+++ b/database/migrations/2019_07_20_085104_add_waiting_list_table.php
@@ -124,7 +124,7 @@ class AddWaitingListTable extends Migration
 
     private function createPermission(string $name, $guard = 'web')
     {
-        return \Spatie\Permission\Models\Permission::create([
+        return \DB::table(config('permission.table_names.permissions'))->insert([
             'name' => $name,
             'guard_name' => $guard,
         ]);

--- a/database/migrations/2020_01_31_180100_add_waiting_list_action_permissions.php
+++ b/database/migrations/2020_01_31_180100_add_waiting_list_action_permissions.php
@@ -27,7 +27,7 @@ class AddWaitingListActionPermissions extends Migration
 
     private function createPermission(string $name, $guard = 'web')
     {
-        return \Spatie\Permission\Models\Permission::create([
+        return \DB::table(config('permission.table_names.permissions'))->insert([
             'name' => $name,
             'guard_name' => $guard,
         ]);

--- a/database/migrations/2020_02_01_095731_create_nova_feedback_permissions.php
+++ b/database/migrations/2020_02_01_095731_create_nova_feedback_permissions.php
@@ -53,7 +53,7 @@ class CreateNovaFeedbackPermissions extends Migration
 
     private function createPermission(string $name, $guard = 'web')
     {
-        return \Spatie\Permission\Models\Permission::create([
+        return \DB::table(config('permission.table_names.permissions'))->insert([
             'name' => $name,
             'guard_name' => $guard,
         ]);

--- a/database/migrations/2020_02_13_190400_create_add_student_admin_permission.php
+++ b/database/migrations/2020_02_13_190400_create_add_student_admin_permission.php
@@ -16,7 +16,7 @@ class CreateAddStudentAdminPermission extends Migration
 
     private function createPermission(string $name, $guard = 'web')
     {
-        return \Spatie\Permission\Models\Permission::create([
+        return \DB::table(config('permission.table_names.permissions'))->insert([
             'name' => $name,
             'guard_name' => $guard,
         ]);

--- a/database/migrations/2020_05_10_195144_create_telescope_permission.php
+++ b/database/migrations/2020_05_10_195144_create_telescope_permission.php
@@ -16,7 +16,7 @@ class CreateTelescopePermission extends Migration
 
     private function createPermission(string $name, $guard = 'web')
     {
-        return \Spatie\Permission\Models\Permission::create([
+        return \DB::table(config('permission.table_names.permissions'))->insert([
             'name' => $name,
             'guard_name' => $guard,
         ]);

--- a/database/migrations/2020_05_11_184510_add_horizon_permission.php
+++ b/database/migrations/2020_05_11_184510_add_horizon_permission.php
@@ -16,7 +16,7 @@ class AddHorizonPermission extends Migration
 
     private function createPermission(string $name, $guard = 'web')
     {
-        return \Spatie\Permission\Models\Permission::create([
+        return \DB::table(config('permission.table_names.permissions'))->insert([
             'name' => $name,
             'guard_name' => $guard,
         ]);

--- a/database/migrations/2020_08_03_170100_add_discord_permissions.php
+++ b/database/migrations/2020_08_03_170100_add_discord_permissions.php
@@ -54,7 +54,7 @@ class AddDiscordPermissions extends Migration
 
     private function createPermission(string $name, $guard = 'web')
     {
-        return Permission::create([
+        return \DB::table(config('permission.table_names.permissions'))->insert([
             'name' => $name,
             'guard_name' => $guard,
         ]);


### PR DESCRIPTION
In the latest version of Laravel 7.25, there are issues with the Spatie permission package, because of changes made to how $guarded works (in light of a security issue).  This should resolve those issues until the package is updated.

cc: @CalumTowers <- he asked me to open this PR.