### PR TITLE
Discord Invite Email

### DIFF
--- a/app/Notifications/Mship/DiscordInvite.php
+++ b/app/Notifications/Mship/DiscordInvite.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Notifications\Mship;
+
+use App\Models\Mship\Account;
+use App\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Cache;
+
+class DiscordInvite extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $discordCount = Cache::remember('discord.count', 1440 * 60, function () {
+            return Account::whereNotNull('discord_id')->count();
+        });
+
+        return (new MailMessage)
+                ->from('community@vatsim.uk', 'VATSIM UK - Community Department')
+                ->subject("$notifiable->name_first! Join us on Discord?")
+                ->view('emails.mship.discord_invite', [
+                        'recipient' => $notifiable,
+                        'discordCount' => $discordCount
+                ]);
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [];
+    }
+}

--- a/app/Notifications/Mship/DiscordInvite.php
+++ b/app/Notifications/Mship/DiscordInvite.php
@@ -40,8 +40,8 @@ class DiscordInvite extends Notification implements ShouldQueue
                 ->from('community@vatsim.uk', 'VATSIM UK - Community Department')
                 ->subject("$notifiable->name_first! Join us on Discord?")
                 ->view('emails.mship.discord_invite', [
-                        'recipient' => $notifiable,
-                        'discordCount' => $discordCount
+                    'recipient' => $notifiable,
+                    'discordCount' => $discordCount,
                 ]);
     }
 

--- a/resources/views/emails/mship/discord_invite.blade.php
+++ b/resources/views/emails/mship/discord_invite.blade.php
@@ -1,0 +1,13 @@
+@extends('emails.messages.post')
+
+@section('body')
+
+<p>Why not come and <a href="{{ route('discord.show') }}">join us on Discord</a>?</p>
+
+<p>If you've never heard of <a href="https://www.discord.com/">Discord</a>, that's fine! Discord is a new, 21st century chat platform which allows groups of people with a mutual interest to communicate in real-time. If there's a burning question you want to ask about real world aviation, or a suggestion you've got for the division, or even a request for a flying buddy, there's bound to be someone around to support you.</p>
+
+<p><strong>As of right now there are {{ $discordCount }} other VATSIM members sharing their love of aviation in our Discord server; and you could be too!</strong></p>
+
+<p>Registration is really simple. Visit <a href="{{route('discord.show')}}">the Discord registraion page on our website</a> to get started, or visit {{ route('discord.show') }}</p>
+
+@stop


### PR DESCRIPTION
Discord invite email, will be used to manually send to people that have joined us on Slack but not Discord, but may be useful in future too.

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/7726792/90165991-6dc75d80-dd91-11ea-87d2-e3cb4d02822f.png">
