### PR TITLE
fix: CERT Update update frequency

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -53,6 +53,10 @@ class Kernel extends ConsoleKernel
 
         // === By Hour === //
 
+        $schedule->command('members:certupdate', ['--type=hourly'])
+            ->hourly()
+            ->runInBackground();
+
         $schedule->command('members:certimport')
             ->cron('30 */2 * * *') // every second hour
             ->runInBackground();
@@ -91,11 +95,11 @@ class Kernel extends ConsoleKernel
 
         // === By Month === //
         $schedule->command('members:certupdate', ['--type=monthly', 5000])
-            ->monthlyOn(1, '01:45')
+            ->cron('0 0 1,14,30 * *') // At 00:00 on the 1st, 14th and 30th of every month
             ->runInBackground();
 
-        $schedule->command('members:certupdate', ['--type=all', 1000])
-            ->monthlyOn(1, '01:45')
+        $schedule->command('members:certupdate', ['--type=all', 5000])
+            ->monthlyOn(2, '01:45')
             ->runInBackground();
     }
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -95,7 +95,7 @@ class Kernel extends ConsoleKernel
 
         // === By Month === //
         $schedule->command('members:certupdate', ['--type=monthly', 5000])
-            ->cron('0 0 1,14,28 * *') // At 00:00 on the 1st, 14th and 30th of every month
+            ->cron('0 0 1,14,28 * *') // At 00:00 on the 1st, 14th and 28th of every month
             ->runInBackground();
 
         $schedule->command('members:certupdate', ['--type=all', 5000])

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -95,7 +95,7 @@ class Kernel extends ConsoleKernel
 
         // === By Month === //
         $schedule->command('members:certupdate', ['--type=monthly', 5000])
-            ->cron('0 0 1,14,28 * *') // At 00:00 on the 1st, 14th and 28th of every month
+            ->cron('0 0 1,10,20 * *') // At 00:00 on the 1st, 10th and 20th of every month
             ->runInBackground();
 
         $schedule->command('members:certupdate', ['--type=all', 5000])

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -95,7 +95,7 @@ class Kernel extends ConsoleKernel
 
         // === By Month === //
         $schedule->command('members:certupdate', ['--type=monthly', 5000])
-            ->cron('0 0 1,14,30 * *') // At 00:00 on the 1st, 14th and 30th of every month
+            ->cron('0 0 1,14,28 * *') // At 00:00 on the 1st, 14th and 30th of every month
             ->runInBackground();
 
         $schedule->command('members:certupdate', ['--type=all', 5000])

--- a/app/Jobs/Middleware/RateLimited.php
+++ b/app/Jobs/Middleware/RateLimited.php
@@ -42,10 +42,9 @@ class RateLimited
 
                     $job->release($this->retryAfter);
                 });
-        }catch (ConnectionException $exception){
+        } catch (ConnectionException $exception) {
             // Redis probably not installed. We will send the job anyway
             $next($job);
         }
-
     }
 }

--- a/app/Jobs/Middleware/RateLimited.php
+++ b/app/Jobs/Middleware/RateLimited.php
@@ -3,6 +3,7 @@
 namespace App\Jobs\Middleware;
 
 use Illuminate\Support\Facades\Redis;
+use Predis\Connection\ConnectionException;
 
 class RateLimited
 {
@@ -28,17 +29,23 @@ class RateLimited
 
     public function handle($job, $next)
     {
-        Redis::throttle($this->key)
-             ->allow($this->allow)
-             ->every($this->every)
-             ->then(function () use ($job, $next) {
-                 // Lock obtained...
+        try {
+            Redis::throttle($this->key)
+                ->allow($this->allow)
+                ->every($this->every)
+                ->then(function () use ($job, $next) {
+                    // Lock obtained...
 
-                 $next($job);
-             }, function () use ($job) {
-                 // Could not obtain lock...
+                    $next($job);
+                }, function () use ($job) {
+                    // Could not obtain lock...
 
-                 $job->release($this->retryAfter);
-             });
+                    $job->release($this->retryAfter);
+                });
+        }catch (ConnectionException $exception){
+            // Redis probably not installed. We will send the job anyway
+            $next($job);
+        }
+
     }
 }

--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Jobs\Middleware\RateLimited;
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification as QualificationData;
 use Carbon\Carbon;
@@ -154,5 +155,10 @@ class UpdateMember extends Job implements ShouldQueue
         }
 
         return $member;
+    }
+
+    public function middleware()
+    {
+        return [new RateLimited('update_member_job', 60, 60)];
     }
 }

--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -159,6 +159,6 @@ class UpdateMember extends Job implements ShouldQueue
 
     public function middleware()
     {
-        return [new RateLimited('update_member_job', 60, 60)];
+        return [new RateLimited('update_member_job', 100, 60)];
     }
 }

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -2,8 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
-
 class Permission extends \Spatie\Permission\Models\Permission
 {
     protected $guarded = [];


### PR DESCRIPTION
Does the following:
- Add rate middleware to the UpdateMember job to limit to 100 updates per 60 seconds
- Reinstates the hourly Cert Update Job
- Increases Monthly update frequency to tri-monthly
- Increase the capacity of the all-members job


Closes #1896 