### PR TITLE
Auto Scale Queue Workers

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -172,8 +172,9 @@ return [
             'supervisor-1' => [
                 'connection' => 'redis',
                 'queue' => ['notifications', 'default'],
-                'balance' => 'simple',
-                'processes' => 1,
+                'balance' => 'auto',
+                'min-processes' => 1,
+                'max-processes' => 5,
                 'tries' => 3,
             ],
         ],


### PR DESCRIPTION
Balance them between queues and then allow them to scale up - we have the overhead in production to account for this.