### PR TITLE
Increase Queue Alerts For user_sync

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -88,6 +88,7 @@ return [
 
     'waits' => [
         'redis:default' => 900,
+        'redis:user_sync' => 21600,
     ],
 
     /*


### PR DESCRIPTION
Increases to 6 hours, to prevent notifications firing off when there are long running processes overnight.