### PR TITLE
Only Use One Pilot Rating For Latest Qualification

### DIFF
--- a/app/Models/Mship/Concerns/HasQualifications.php
+++ b/app/Models/Mship/Concerns/HasQualifications.php
@@ -129,15 +129,6 @@ trait HasQualifications
         });
     }
 
-    public function getQualificationPilotAttribute()
-    {
-        return $this->qualifications->filter(function ($qual) {
-            return $qual->type == 'pilot';
-        })->sortByDesc(function ($qualification, $key) {
-            return $qualification->pivot->created_at;
-        })->first();
-    }
-
     public function getQualificationsPilotAttribute()
     {
         return $this->qualifications->filter(function ($qual) {


### PR DESCRIPTION
Pilot ratings are now sequencial and you can only hold one at a time.
For that reason, when grabbing a member's active qualifications, we can just use getQualificationPilot attribute to get the first result based on the latest pilot rating to be added in the pivot.

This active_qualifications method is only used on the TeamSpeak bot so the only impact of this change should be that TeamSpeak only gives one group per pilot rating.