### PR TITLE
1944 - CERT Sync Schedule Change

### DIFF
--- a/app/Console/Commands/Members/UpdateMembers.php
+++ b/app/Console/Commands/Members/UpdateMembers.php
@@ -18,8 +18,7 @@ class UpdateMembers extends Command
      * @var string
      */
     protected $signature = 'Members:CertUpdate
-                        {max_members=1000}
-                        {--t|type=all : Which update are we running? Hourly, Daily, Weekly or Monthly?}
+                        {max_members=5000}
                         {--f|force= : If specified, only this CID will be checked.}';
 
     /**
@@ -48,33 +47,12 @@ class UpdateMembers extends Command
     {
         $members = Account::where('id', '>=', 800000);
 
-        // add parameters based on the cron type
         if ($this->option('force')) {
             $members->where('id', $this->option('force'));
-        } elseif (starts_with($this->option('type'), 'h')) {
-            // members who have logged in in the last 30 days or who have never been checked
+        } else {
             $members->where(function ($query) {
-                $query->where('last_login', '>=', Carbon::now()->subMonth())
+                $query->where('cert_checked_at', '<=', Carbon::now()->subDay())
                     ->orWhereNull('cert_checked_at');
-            });
-        } elseif (starts_with($this->option('type'), 'd')) {
-            // members who have logged in in the last 90 days and haven't been checked today
-            $members->where(function ($query) {
-                $query->where('cert_checked_at', '<=', Carbon::now()->subHours(23))
-                    ->where('last_login', '>=', Carbon::now()->subMonths(3));
-            });
-        } elseif ((starts_with($this->option('type'), 'w'))) {
-            // members who have logged in in the last 180 days and haven't been checked this week
-            $members->where(function ($query) {
-                $query->where('cert_checked_at', '<=', Carbon::now()->subDays(6))
-                    ->where('last_login', '>=', Carbon::now()->subMonths(6));
-            });
-        } elseif ((starts_with($this->option('type'), 'm'))) {
-            // members who have never logged in and haven't been checked this month, but are still active VATSIM members
-            $members->where(function ($query) {
-                $query->where('cert_checked_at', '<=', Carbon::now()->subDays(25))
-                    ->whereNull('last_login')
-                    ->where('inactive', 0);
             });
         }
 

--- a/app/Console/Commands/Members/UpdateMembers.php
+++ b/app/Console/Commands/Members/UpdateMembers.php
@@ -18,7 +18,7 @@ class UpdateMembers extends Command
      * @var string
      */
     protected $signature = 'Members:CertUpdate
-                        {max_members=5000}
+                        {max_members=1000}
                         {--f|force= : If specified, only this CID will be checked.}';
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -53,7 +53,7 @@ class Kernel extends ConsoleKernel
 
         // === By Hour === //
 
-        $schedule->command('members:certupdate', ['--type=hourly'])
+        $schedule->command('members:certupdate')
             ->hourly()
             ->runInBackground();
 
@@ -68,10 +68,6 @@ class Kernel extends ConsoleKernel
         $schedule->command('sync:community')
             ->dailyAt('00:01');
 
-        $schedule->command('members:certupdate', ['--type=daily', 5000])
-            ->dailyAt('00:45')
-            ->runInBackground();
-
         $schedule->command('sync:tg-forum-groups')
             ->dailyAt('04:00');
 
@@ -81,21 +77,6 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('members:certimport', ['--full'])
             ->twiceDaily(2, 14)
-            ->runInBackground();
-
-        // === By Week === //
-
-        $schedule->command('members:certupdate', ['--type=weekly', 5000])
-            ->weeklyOn(1, '01:15')
-            ->runInBackground();
-
-        // === By Month === //
-        $schedule->command('members:certupdate', ['--type=monthly', 5000])
-            ->cron('0 0 1,10,20 * *') // At 00:00 on the 1st, 10th and 20th of every month
-            ->runInBackground();
-
-        $schedule->command('members:certupdate', ['--type=all', 5000])
-            ->monthlyOn(2, '01:45')
             ->runInBackground();
     }
 


### PR DESCRIPTION
The automated updates from CERT (using `Members:CertUpdate`) are currently flawed in a number of ways.

- It primarily focuses on users that have logged in, despite users being updated when they login automatically, thus not needing to be synced by this command
- It limits the number of members being captured that have never logged in by capping it at 1000 people every 30 days. This results in us holding outdated data on members as we never get a chance to clear the backlog
- It has very little chance to update inactive members - again, resulting in outdated data (e.g. for right to be forgotten requests)

My proposal, and contained within this PR, is that we process updates once per hour, the same way each time. Each run is capped at 1000 members and queued on a dedicated queue as it is now.
The 1000 members are selected only using their `cert_checked_at`. By sorting it `ASC`, we prioritise those that have never been checked (`null`) and then in reverse date order to get the oldest first.

Given the number of members we currently have in production, and assuming no one logs in to prompt an update on the fly, this would ensure that every user in our database "phones home" to .net at least once every 7 days.

Once merged, this resolves #1944 