### PR TITLE
Stamp Cert Checked For Failure

### DIFF
--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -51,9 +51,13 @@ class UpdateMember extends Job implements ShouldQueue
      */
     public function handle()
     {
+        $member = Account::firstOrNew([(new Account)->getKeyName() => $this->accountID]);
+
         try {
             $this->data = VatsimXML::getData($this->accountID, 'idstatusint');
         } catch (\Exception $e) {
+            $member->cert_checked_at = Carbon::now();
+
             return;
         }
 
@@ -66,8 +70,6 @@ class UpdateMember extends Job implements ShouldQueue
         if (! is_string($this->data->division)) {
             $this->data->division = '';
         }
-
-        $member = Account::firstOrNew([(new Account)->getKeyName() => $this->accountID]);
 
         // if member no longer exists, delete
         // else process update


### PR DESCRIPTION
Example: https://cert.vatsim.net/cert/vatsimnet/idstatus.php?cid=1476109

When this is eventually refactored to call the new API (#1736), we will handle returns of a 404 a little better. Its quite difficult to do here as it is buried in the `VatsimXML` package.

I believe the easiest approach for now, as I've implemented here, is to stamp the member's `cert_checked_at` regardless of whether the check itself was successful or not. An attempt was made, so they need to go to the back of the queue for the next batch of checks.