### PR TITLE
1981 - Include ATC Qualification In "Fully Defined"

### DIFF
--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -406,7 +406,7 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
 
     public function getFullyDefinedAttribute()
     {
-        return $this->name_first && $this->name_last && $this->email;
+        return $this->name_first && $this->name_last && $this->email && $this->qualification_atc;
     }
 
     private function allowedNames($includeATC = false, $withNumberWildcard = false)

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -407,7 +407,6 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
     public function getFullyDefinedAttribute()
     {
         return $this->name_first && $this->name_last && $this->email && $this->qualifications_atc;
-
     }
 
     private function allowedNames($includeATC = false, $withNumberWildcard = false)

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -406,7 +406,8 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
 
     public function getFullyDefinedAttribute()
     {
-        return $this->name_first && $this->name_last && $this->email && $this->qualification_atc;
+        return $this->name_first && $this->name_last && $this->email && $this->qualifications_atc;
+
     }
 
     private function allowedNames($includeATC = false, $withNumberWildcard = false)


### PR DESCRIPTION
The `SyncSubscriber` (which triggers syncs of users to CTS, Helpdesk, Moodle & Discord) only runs when `$event->account->fully_defined` is true.

Sometimes, users appear in the feed without a rating, and this causes issue when we try to sync them to external services. All users should have at least an "OBS" rating, thus `$this->qualification_atc` would not be null and return true for this method.

Resolves #1981 