### PR TITLE
1984 - TeamSpeak Registration Deletion Fix

### DIFF
--- a/app/Models/TeamSpeak/Registration.php
+++ b/app/Models/TeamSpeak/Registration.php
@@ -62,12 +62,10 @@ class Registration extends Model
             }
 
             if ($this->confirmation) {
-
                 try {
                     $tscon->privilegeKeyDelete($this->confirmation->privilege_key);
                 } catch (TeamSpeak3_Adapter_ServerQuery_Exception $e) {
-                    if($e->getMessage() === 'ok')
-                    {
+                    if ($e->getMessage() === 'ok') {
                         $this->confirmation->delete();
                     }
                 }

--- a/app/Models/TeamSpeak/Registration.php
+++ b/app/Models/TeamSpeak/Registration.php
@@ -7,6 +7,7 @@ use App\Models\Model;
 use App\Models\Mship\Account;
 use Illuminate\Database\Eloquent\SoftDeletes as SoftDeletingTrait;
 use TeamSpeak3;
+use TeamSpeak3_Adapter_ServerQuery_Exception;
 
 /**
  * App\Models\TeamSpeak\Registration.
@@ -59,8 +60,18 @@ class Registration extends Model
             if ($tscon == null) {
                 $tscon = TeamSpeak::run('VATSIM UK Registrations');
             }
+
             if ($this->confirmation) {
-                $tscon->privilegeKeyDelete($this->confirmation->privilege_key);
+
+                try {
+                    $tscon->privilegeKeyDelete($this->confirmation->privilege_key);
+                } catch (TeamSpeak3_Adapter_ServerQuery_Exception $e) {
+                    if($e->getMessage() === 'ok')
+                    {
+                        $this->confirmation->delete();
+                    }
+                }
+
                 $this->confirmation->delete();
             }
 


### PR DESCRIPTION
This PR will be easier to review with the stack trace in #1984 
The TeamSpeak library is throwing an exception incorrectly.

When removing a registration, we first check that there is a privilege key in our system (stored in `teamspeak_confirmation`) associated with the registration being deleted.

We then delete it from TeamSpeak (`$tscon->privilegeKeyDelete($this->confirmation->privilege_key);`) and then remove it from our database (`$this->confirmation->delete();`).

The first line is throwing a `TeamSpeak3_Adapter_ServerQuery_Exception` exception even though the exception message is `ok` and the privilege key is removed on TeamSpeak. The result it that the privilege key isn't removed from our system and the registration also is not removed - throwing an error to the user.

This is not the proudest code I have ever written, but it should fix the problem for now. We need to decide on the future of TeamSpeak and if we are retaining it, it is highly likely a lot of this needs a full re-write to tidy it up...

Resolves #1984 