### PR TITLE
1980 - Fix Login Validation

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -65,9 +65,9 @@ class LoginController extends BaseController
             ! $resourceOwner->data ||
             ! $resourceOwner->data->cid ||
             ! $resourceOwner->data->personal ||
-            ! $resourceOwner->data->personal->name_first ||
-            ! $resourceOwner->data->personal->name_last ||
-            ! $resourceOwner->data->personal->email ||
+            ! optional($resourceOwner->data->personal)->name_first ||
+            ! optional($resourceOwner->data->personal)->name_last ||
+            ! optional($resourceOwner->data->personal)->email ||
             ! $resourceOwner->data->vatsim ||
             ! $resourceOwner->data->oauth->token_valid === 'true'
         ) {


### PR DESCRIPTION
If a user logs in and does not provide us with any of the personal permissions we risk running `->name_first`, `->name_last` or `->email` on `[ ]`, resulting in an error.

Fixed #1980 