### PR TITLE
Console / Network Data Improvements

### DIFF
--- a/app/Console/Commands/NetworkData/ProcessNetworkData.php
+++ b/app/Console/Commands/NetworkData/ProcessNetworkData.php
@@ -149,10 +149,12 @@ class ProcessNetworkData extends Command
             $progressBar->advance();
         }
 
-        $this->endExpiredAtcSessions($awaitingUpdate);
         $progressBar->finish();
         $this->newLine();
 
+        if($awaitingUpdate->isNotEmpty()) {
+            $this->endExpiredAtcSessions($awaitingUpdate);
+        }
     }
 
     /**
@@ -288,10 +290,12 @@ class ProcessNetworkData extends Command
             $progressBar->advance();
         }
 
-        $this->endExpiredPilotSessions($awaitingUpdate);
         $progressBar->finish();
         $this->newLine();
 
+        if($awaitingUpdate->isNotEmpty()) {
+            $this->endExpiredPilotSessions($awaitingUpdate);
+        }
     }
 
     /**

--- a/app/Console/Commands/NetworkData/ProcessNetworkData.php
+++ b/app/Console/Commands/NetworkData/ProcessNetworkData.php
@@ -56,7 +56,7 @@ class ProcessNetworkData extends Command
     {
         $this->info('Getting network data from VATSIM.');
 
-        if ($this->networkData->failed() || !$this->networkData->json()) {
+        if ($this->networkData->failed() || ! $this->networkData->json()) {
             $this->error('VATSIM feed unavailable.');
             exit();
         }
@@ -152,7 +152,7 @@ class ProcessNetworkData extends Command
         $progressBar->finish();
         $this->newLine();
 
-        if($awaitingUpdate->isNotEmpty()) {
+        if ($awaitingUpdate->isNotEmpty()) {
             $this->endExpiredAtcSessions($awaitingUpdate);
         }
     }
@@ -293,7 +293,7 @@ class ProcessNetworkData extends Command
         $progressBar->finish();
         $this->newLine();
 
-        if($awaitingUpdate->isNotEmpty()) {
+        if ($awaitingUpdate->isNotEmpty()) {
             $this->endExpiredPilotSessions($awaitingUpdate);
         }
     }

--- a/app/Console/Commands/NetworkData/ProcessNetworkData.php
+++ b/app/Console/Commands/NetworkData/ProcessNetworkData.php
@@ -54,6 +54,11 @@ class ProcessNetworkData extends Command
      */
     public function handle()
     {
+        if ($this->networkData->failed() || !$this->networkData->json()) {
+            $this->error('VATSIM feed unavailable.');
+            exit();
+        }
+
         $this->setLastUpdatedTimestamp();
         event(new NetworkDataDownloaded());
         $this->processATC();

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -66,9 +66,9 @@ class Kernel extends ConsoleKernel
             ->dailyAt('00:01')
             ->graceTimeInMinutes(30);
 
-        $schedule->command('discord:manager')
-            ->dailyAt('06:00')
-            ->graceTimeInMinutes(30);
+        // $schedule->command('discord:manager')
+        //     ->dailyAt('06:00')
+        //     ->graceTimeInMinutes(30);
 
         $schedule->command('schedule-monitor:sync')
             ->dailyAt('07:00');

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -41,6 +41,7 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('networkdata:download')
             ->cron('*/2 * * * *') // every second minute
+            ->graceTimeInMinutes(10)
             ->withoutOverlapping();
 
         $schedule->command('horizon:snapshot')


### PR DESCRIPTION
- Disables Discord Manager whilst we try and improve performance
- Extends grace period for network data
- Adds error handling for when the network data feed is unavailable
- Improves output of the `networkdata:download` command to show progress
- Small refactors within the network data command