### PR TITLE
Fix - Primary Qualification Selection

### DIFF
--- a/app/Models/Mship/Concerns/HasQualifications.php
+++ b/app/Models/Mship/Concerns/HasQualifications.php
@@ -111,7 +111,7 @@ trait HasQualifications
         return $this->qualifications->filter(function ($qual) {
             return $qual->type == 'atc';
         })->sortByDesc(function ($qualification, $key) {
-            return $qualification->pivot->created_at;
+            return $qualification->vatsim;
         })->first();
     }
 
@@ -141,7 +141,7 @@ trait HasQualifications
         return $this->qualifications->filter(function ($qual) {
             return $qual->type == 'pilot';
         })->sortByDesc(function ($qualification) {
-            return $qualification->pivot->created_at;
+            return $qualification->vatsim;
         })->first();
     }
 

--- a/tests/Unit/Account/AccountModelTest.php
+++ b/tests/Unit/Account/AccountModelTest.php
@@ -268,15 +268,19 @@ class AccountModelTest extends TestCase
         Carbon::setTestNow(Carbon::now()); // Check this works even when the timestamps are the same
 
         $mockS1Qual = factory(Qualification::class)->state('atc')->create([
+            'code' => 'S11',
             'vatsim' => 1,
         ]);
         $mockS2Qual = factory(Qualification::class)->state('atc')->create([
+            'code' => 'S22',
             'vatsim' => 2,
         ]);
         $mockP1Qual = factory(Qualification::class)->state('pilot')->create([
+            'code' => 'P11',
             'vatsim' => 3,
         ]);
         $mockP2Qual = factory(Qualification::class)->state('pilot')->create([
+            'code' => 'P22',
             'vatsim' => 4,
         ]);
 

--- a/tests/Unit/Account/AccountModelTest.php
+++ b/tests/Unit/Account/AccountModelTest.php
@@ -268,16 +268,16 @@ class AccountModelTest extends TestCase
         Carbon::setTestNow(Carbon::now()); // Check this works even when the timestamps are the same
 
         $mockS1Qual = factory(Qualification::class)->state('atc')->create([
-            'vatsim' => 1
+            'vatsim' => 1,
         ]);
         $mockS2Qual = factory(Qualification::class)->state('atc')->create([
-            'vatsim' => 2
+            'vatsim' => 2,
         ]);
         $mockP1Qual = factory(Qualification::class)->state('pilot')->create([
-            'vatsim' => 3
+            'vatsim' => 3,
         ]);
         $mockP2Qual = factory(Qualification::class)->state('pilot')->create([
-            'vatsim' => 4
+            'vatsim' => 4,
         ]);
 
         $this->user->qualifications()->sync([$mockS1Qual->id, $mockS2Qual->id, $mockP1Qual->id, $mockP2Qual->id]);
@@ -292,9 +292,7 @@ class AccountModelTest extends TestCase
             return $qual->id;
         })->all());
 
-
         Carbon::setTestNow();
-
     }
 
     /** @test */


### PR DESCRIPTION
Selects the primary qualification based on the "vatsim" code, rather than date added