### PR TITLE
Feat - Utilise .NET Auth required_scopes

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -36,7 +36,9 @@ class LoginController extends BaseController
     public function login(Request $request)
     {
         if (! $request->has('code') || ! $request->has('state')) {
-            $authorizationUrl = $this->provider->getAuthorizationUrl();
+            $authorizationUrl = $this->provider->getAuthorizationUrl([
+                "required_scopes" => join(' ', config('vatsim-connect.scopes'))
+            ]);
             $request->session()->put('vatsimauthstate', $this->provider->getState());
 
             return redirect()->away($authorizationUrl);

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -37,7 +37,7 @@ class LoginController extends BaseController
     {
         if (! $request->has('code') || ! $request->has('state')) {
             $authorizationUrl = $this->provider->getAuthorizationUrl([
-                "required_scopes" => join(' ', config('vatsim-connect.scopes'))
+                'required_scopes' => join(' ', config('vatsim-connect.scopes')),
             ]);
             $request->session()->put('vatsimauthstate', $this->provider->getState());
 


### PR DESCRIPTION
Utilise required_scopes on OAuth requests to reduce chance of user unselecting and then getting an error message.
Disables the ability to deselect the requested scopes.
![image](https://user-images.githubusercontent.com/17804618/105421428-fd731100-5c39-11eb-8de0-aee44c4fb21f.png)
