### PR TITLE
Stop duplicate suspended role operation

### DIFF
--- a/app/Console/Commands/ExternalServices/ManageDiscord.php
+++ b/app/Console/Commands/ExternalServices/ManageDiscord.php
@@ -133,6 +133,10 @@ class ManageDiscord extends Command
         Log::info("Account {$account->id} detected as suspended. Removing Discord roles.");
         $currentRoles = $this->discord->getUserRoles($account);
 
+        if ($currentRoles->contains($this->suspendedRoleId)) {
+            return;
+        }
+
         // remove the roles which are currently applied to the user.
         $currentRoles->each(function (int $role) use ($account) {
             $this->discord->removeRoleById($account, $role);

--- a/tests/Unit/Command/DiscordManagerTest.php
+++ b/tests/Unit/Command/DiscordManagerTest.php
@@ -61,4 +61,17 @@ class DiscordManagerTest extends TestCase
         $command = new ManageDiscord($mockDiscordLibrary);
         $command->removeRoles($this->account);
     }
+
+    /** @test */
+    public function itShouldDoNothingIfAlreadyContainsSuspendedRole()
+    {
+        $mockDiscordLibrary = $this->mock(Discord::class, function ($mock) {
+            // collection represents random set of roles which need to be removed from a suspended user.
+            $mock->shouldReceive('getUserRoles')->with($this->account)->once()->andReturn(collect([$this->mockRoleId]));
+            $mock->shouldNotReceive('removeRoleById');
+        });
+
+        $command = new ManageDiscord($mockDiscordLibrary);
+        $command->processSuspendedMember($this->account);
+    }
 }


### PR DESCRIPTION
Stops the execution of the `processSuspendedRole` function if they already contain the role. 