### PR TITLE
Address query issues with waiting lists

### DIFF
--- a/nova-components/WaitingListsManager/src/Http/WaitingListsManagerController.php
+++ b/nova-components/WaitingListsManager/src/Http/WaitingListsManagerController.php
@@ -77,7 +77,7 @@ class WaitingListsManagerController extends Controller
     private function getWaitingListAccounts(WaitingList &$waitingList, bool $eligibility): AnonymousResourceCollection
     {
         return WaitingListAccountResource::collection(
-            $waitingList->accounts
+            $waitingList->load(['accounts', 'flags'])->accounts
                 ->where('pivot.deleted_at', '==', null)
                 ->sortBy('pivot.created_at')
                 ->filter(function ($model) use ($eligibility) {


### PR DESCRIPTION
I can't fully test this on the right dataset but this is the best way I can think of to reduce the N + 1 issues with the waiting lists.

It eager-loads the attributes used in queries; no breaking changes as all unit and feature tests pass. Will be interested to see how it performs in production.
