### PR TITLE
Remove change to permissions on $SHARED_DIRECTORY

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -190,7 +190,6 @@ jobs:
             ln -s $SHARED_DIRECTORY/storage $RELEASE_DIRECTORY/storage
 
             # Update Permissions on Application Directories
-            chmod -R u+rwX,g+rwX,o-rwx $SHARED_DIRECTORY
             chmod -R u+rwX,g+rwX,o-rwx $RELEASE_DIRECTORY
 
             # Update the current link to point to this release


### PR DESCRIPTION
The change to the permissions on $SHARED_DIRECTORY was failing due to the `github` service user not owning the files within said directory. However, this is handled in other ways for a task which just removes anonymous access.