### PR TITLE
Add support for serialised deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,12 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
+      - name: Extract tag
+        run: |
+          echo "::set-env name=TAG::$(git describe --tags --abbrev=0)"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
       #
       # DEPLOYMENT PARAMETERS
       #

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   deploy:
+    # Wait for ~3 builds (3m each - see Turnstyle action below) + current build (3m) before timeout.
+    timeout-minutes: 12
     name: Deploy
     runs-on: ubuntu-latest
     steps:
@@ -15,15 +17,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.client_payload.ref }}
 
+      - name: Wait for current executions to complete (Turnstyle)
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract short commit hash
         run: |
           echo "::set-env name=COMMIT::$(echo ${GITHUB_SHA} | cut -c1-7)"
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-
-      - name: Extract tag
-        run: |
-          echo "::set-env name=TAG::$(git describe --tags --abbrev=0)"
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 


### PR DESCRIPTION
As Actions is event-driven, multiple successive PR merges currently resulting in multiple concurrent deployments. This change adds https://github.com/softprops/turnstyle to the workflow to enforce them to queue for any existing deployment jobs to complete. 

The timeout is also added which will support waiting for ~3 builds to complete + the time for the workflow itself.