### PR TITLE
Auto Sync Role Changes

### DIFF
--- a/app/Events/Mship/Roles/RoleAssigned.php
+++ b/app/Events/Mship/Roles/RoleAssigned.php
@@ -11,11 +11,9 @@ class RoleAssigned extends Event
 {
     use SerializesModels;
 
-    /* @var Account */
-    public $account;
+    public Account $account;
 
-    /* @var Role */
-    public $role;
+    public Role $role;
 
     public function __construct(Account $account, Role $role)
     {

--- a/app/Events/Mship/Roles/RoleAssigned.php
+++ b/app/Events/Mship/Roles/RoleAssigned.php
@@ -4,8 +4,8 @@ namespace App\Events\Mship\Roles;
 
 use App\Events\Event;
 use App\Models\Mship\Account;
-use Spatie\Permission\Models\Role;
 use Illuminate\Queue\SerializesModels;
+use Spatie\Permission\Models\Role;
 
 class RoleAssigned extends Event
 {

--- a/app/Events/Mship/Roles/RoleAssigned.php
+++ b/app/Events/Mship/Roles/RoleAssigned.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Events\Mship\Roles;
+
+use App\Events\Event;
+use App\Models\Mship\Account;
+use Spatie\Permission\Models\Role;
+use Illuminate\Queue\SerializesModels;
+
+class RoleAssigned extends Event
+{
+    use SerializesModels;
+
+    /* @var Account */
+    public $account;
+
+    /* @var Role */
+    public $role;
+
+    public function __construct(Account $account, Role $role)
+    {
+        $this->account = $account;
+        $this->role = $role;
+    }
+}

--- a/app/Events/Mship/Roles/RoleRemoved.php
+++ b/app/Events/Mship/Roles/RoleRemoved.php
@@ -4,8 +4,8 @@ namespace App\Events\Mship\Roles;
 
 use App\Events\Event;
 use App\Models\Mship\Account;
-use Spatie\Permission\Models\Role;
 use Illuminate\Queue\SerializesModels;
+use Spatie\Permission\Models\Role;
 
 class RoleRemoved extends Event
 {

--- a/app/Events/Mship/Roles/RoleRemoved.php
+++ b/app/Events/Mship/Roles/RoleRemoved.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Events\Mship\Roles;
+
+use App\Events\Event;
+use App\Models\Mship\Account;
+use Spatie\Permission\Models\Role;
+use Illuminate\Queue\SerializesModels;
+
+class RoleRemoved extends Event
+{
+    use SerializesModels;
+
+    /* @var Account */
+    public $account;
+
+    /* @var Role */
+    public $role;
+
+    public function __construct(Account $account, Role $role)
+    {
+        $this->account = $account;
+        $this->role = $role;
+    }
+}

--- a/app/Events/Mship/Roles/RoleRemoved.php
+++ b/app/Events/Mship/Roles/RoleRemoved.php
@@ -11,11 +11,9 @@ class RoleRemoved extends Event
 {
     use SerializesModels;
 
-    /* @var Account */
-    public $account;
+    public Account $account;
 
-    /* @var Role */
-    public $role;
+    public Role $role;
 
     public function __construct(Account $account, Role $role)
     {

--- a/app/Listeners/Mship/SyncSubscriber.php
+++ b/app/Listeners/Mship/SyncSubscriber.php
@@ -43,5 +43,15 @@ class SyncSubscriber
             \App\Events\Mship\AccountAltered::class,
             '\App\Listeners\Mship\SyncSubscriber@syncToAllServices'
         );
+
+        $events->listen(
+            \App\Events\Mship\Roles\RoleAssigned::class,
+            '\App\Listeners\Mship\SyncSubscriber@syncToAllServices'
+        );
+
+        $events->listen(
+            \App\Events\Mship\Roles\RoleRemoved::class,
+            '\App\Listeners\Mship\SyncSubscriber@syncToAllServices'
+        );
     }
 }

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -20,6 +20,7 @@ use App\Models\Mship\Concerns\HasNotifications;
 use App\Models\Mship\Concerns\HasNovaPermissions;
 use App\Models\Mship\Concerns\HasPassword;
 use App\Models\Mship\Concerns\HasQualifications;
+use App\Models\Mship\Concerns\HasRoles;
 use App\Models\Mship\Concerns\HasStates;
 use App\Models\Mship\Concerns\HasTeamSpeakRegistrations;
 use App\Models\Mship\Concerns\HasVisitTransferApplications;
@@ -34,7 +35,6 @@ use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Passport\HasApiTokens;
 use Spatie\Permission\Models\Role;
-use Spatie\Permission\Traits\HasRoles;
 use Watson\Rememberable\Rememberable;
 
 /**

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -17,7 +17,7 @@ trait HasDiscordAccount
      */
     public function syncToDiscord()
     {
-        if (! config('services.discord')) {
+        if (! config('services.discord.token')) {
             return;
         }
 

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -17,6 +17,10 @@ trait HasDiscordAccount
      */
     public function syncToDiscord()
     {
+        if (! config('services.discord')) {
+            return;
+        }
+
         $discord = (new Discord);
 
         $suspendedRoleId = config('services.discord.suspended_member_role_id');

--- a/app/Models/Mship/Concerns/HasRoles.php
+++ b/app/Models/Mship/Concerns/HasRoles.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models\Mship\Concerns;
+
+use App\Events\Mship\Roles\RoleRemoved;
+use App\Events\Mship\Roles\RoleAssigned;
+use Spatie\Permission\Traits\HasRoles as OriginalHasRoles;
+
+/**
+ * @mixin \App\Models\BaseModel
+ */
+trait HasRoles
+{
+    use OriginalHasRoles {
+        assignRole as protected originalAssignRole;
+        removeRole as protected originalRemoveRole;
+        syncRoles as protected originalSyncRoles;
+    }
+
+    /**
+     * @param mixed ...$roles
+     * @return $this
+     */
+    public function assignRole(...$roles)
+    {
+        $this->originalAssignRole(...$roles);
+
+        $this->fireRoleAssignedEvent($roles);
+
+        return $this;
+    }
+
+    /**
+     * @param $role
+     * @return bool
+     */
+    public function fireRoleAssignedEvent($role)
+    {
+        if (is_iterable($role)) {
+            return array_walk($role, [$this, 'fireRoleAssignedEvent']);
+        }
+
+        event(new RoleAssigned($this, $this->getStoredRole($role)));
+
+        return true;
+    }
+
+    /**
+     * @param $role
+     * @return $this
+     */
+    public function removeRole($role)
+    {
+        $this->originalRemoveRole($role);
+
+        $this->fireRoleRemovedEvent($role);
+
+        return $this;
+    }
+
+    /**
+     * @param $role
+     * @return bool
+     */
+    public function fireRoleRemovedEvent($role)
+    {
+        if (is_iterable($role)) {
+            return array_walk($role, [$this, 'fireRoleRemovedEvent']);
+        }
+
+        event(new RoleRemoved($this, $this->getStoredRole($role)));
+
+        return true;
+    }
+}

--- a/app/Models/Mship/Concerns/HasRoles.php
+++ b/app/Models/Mship/Concerns/HasRoles.php
@@ -2,8 +2,8 @@
 
 namespace App\Models\Mship\Concerns;
 
-use App\Events\Mship\Roles\RoleRemoved;
 use App\Events\Mship\Roles\RoleAssigned;
+use App\Events\Mship\Roles\RoleRemoved;
 use Spatie\Permission\Traits\HasRoles as OriginalHasRoles;
 
 /**

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -9,7 +9,6 @@ $factory->define(App\Models\Mship\Account::class, function (Faker\Generator $fak
         'name_last' => $faker->lastName,
         'email' => $faker->email,
         'is_invisible' => 0,
-        'discord_id' => rand(10000000, 99999999),
     ];
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -9,6 +9,7 @@ $factory->define(App\Models\Mship\Account::class, function (Faker\Generator $fak
         'name_last' => $faker->lastName,
         'email' => $faker->email,
         'is_invisible' => 0,
+        'discord_id' => rand(10000000, 99999999),
     ];
 });
 

--- a/tests/Unit/Account/Relationships/RoleTest.php
+++ b/tests/Unit/Account/Relationships/RoleTest.php
@@ -2,10 +2,14 @@
 
 namespace Tests\Unit\Account\Relationships;
 
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 use Tests\TestCase;
+use App\Models\Mship\Account;
+use Spatie\Permission\Models\Role;
+use Illuminate\Support\Facades\Event;
+use App\Events\Mship\Roles\RoleRemoved;
+use App\Events\Mship\Roles\RoleAssigned;
+use Spatie\Permission\Models\Permission;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class RoleTest extends TestCase
 {
@@ -82,5 +86,22 @@ class RoleTest extends TestCase
 
         $this->assertTrue($role->fresh()->hasPermissionTo($permissionA));
         $this->assertFalse($role->fresh()->hasPermissionTo($permissionB));
+    }
+
+    /** @test */
+    public function itFiresEventsWhenARoleIsAssignedAndRemoved()
+    {
+        Event::fake();
+
+        $role = factory(Role::class)->create();
+        $account = factory(Account::class)->create();
+
+        $account->assignRole($role);
+
+        Event::assertDispatched(RoleAssigned::class);
+
+        $account->removeRole($role);
+
+        Event::assertDispatched(RoleRemoved::class);
     }
 }

--- a/tests/Unit/Account/Relationships/RoleTest.php
+++ b/tests/Unit/Account/Relationships/RoleTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Unit\Account\Relationships;
 
-use Tests\TestCase;
-use App\Models\Mship\Account;
-use Spatie\Permission\Models\Role;
-use Illuminate\Support\Facades\Event;
-use App\Events\Mship\Roles\RoleRemoved;
 use App\Events\Mship\Roles\RoleAssigned;
-use Spatie\Permission\Models\Permission;
+use App\Events\Mship\Roles\RoleRemoved;
+use App\Models\Mship\Account;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Event;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
 
 class RoleTest extends TestCase
 {

--- a/tests/Unit/Account/Sync/AccountAlteredEventTest.php
+++ b/tests/Unit/Account/Sync/AccountAlteredEventTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Account\Sync;
 
 use App\Events\Mship\AccountAltered;
 use App\Jobs\Mship\SyncToCTS;
+use App\Jobs\Mship\SyncToDiscord;
 use App\Jobs\Mship\SyncToHelpdesk;
 use App\Jobs\Mship\SyncToMoodle;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -40,6 +41,7 @@ class AccountAlteredEventTest extends TestCase
         Queue::assertPushed(SyncToCTS::class);
         Queue::assertPushed(SyncToMoodle::class);
         Queue::assertPushed(SyncToHelpdesk::class);
+        Queue::assertNotPushed(SyncToDiscord::class);
         //Queue::assertPushed(SyncToForums::class);
     }
 
@@ -54,6 +56,7 @@ class AccountAlteredEventTest extends TestCase
         Queue::assertPushed(SyncToCTS::class, 1);
         Queue::assertPushed(SyncToMoodle::class, 1);
         Queue::assertPushed(SyncToHelpdesk::class, 1);
+        Queue::assertNotPushed(SyncToDiscord::class, 1);
         //Queue::assertPushed(SyncToForums::class, 1);
     }
 
@@ -69,6 +72,7 @@ class AccountAlteredEventTest extends TestCase
         Queue::assertNotPushed(SyncToCTS::class);
         Queue::assertNotPushed(SyncToMoodle::class);
         Queue::assertNotPushed(SyncToHelpdesk::class);
+        Queue::assertNotPushed(SyncToDiscord::class);
         //Queue::assertNotPushed(SyncToForums::class);
     }
 }

--- a/tests/Unit/Account/Sync/AccountAlteredEventTest.php
+++ b/tests/Unit/Account/Sync/AccountAlteredEventTest.php
@@ -2,16 +2,16 @@
 
 namespace Tests\Unit\Account\Sync;
 
-use Tests\TestCase;
+use App\Events\Mship\AccountAltered;
 use App\Jobs\Mship\SyncToCTS;
-use App\Jobs\Mship\SyncToMoodle;
 use App\Jobs\Mship\SyncToDiscord;
 use App\Jobs\Mship\SyncToHelpdesk;
-use App\Events\Mship\AccountAltered;
+use App\Jobs\Mship\SyncToMoodle;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
 
 class AccountAlteredEventTest extends TestCase
 {

--- a/tests/Unit/Account/Sync/AccountAlteredEventTest.php
+++ b/tests/Unit/Account/Sync/AccountAlteredEventTest.php
@@ -40,7 +40,6 @@ class AccountAlteredEventTest extends TestCase
     /** @test */
     public function itTriggersJobs()
     {
-        $this->withoutExceptionHandling();
         Queue::fake();
         event(new AccountAltered($this->user));
 

--- a/tests/Unit/Account/Sync/AccountAlteredEventTest.php
+++ b/tests/Unit/Account/Sync/AccountAlteredEventTest.php
@@ -22,7 +22,7 @@ class AccountAlteredEventTest extends TestCase
         parent::setUp();
 
         // Disable Discord connection
-        config(['services.discord' => []]);
+        config(['services.discord.token' => null]);
 
         Cache::flush(); // Remove time lockout cache
     }

--- a/tests/Unit/Account/Sync/AccountAlteredEventTest.php
+++ b/tests/Unit/Account/Sync/AccountAlteredEventTest.php
@@ -23,6 +23,8 @@ class AccountAlteredEventTest extends TestCase
 
         // Disable Discord connection
         config(['services.discord.token' => null]);
+        $this->user->discord_id = 1234;
+        $this->user->save();
 
         Cache::flush(); // Remove time lockout cache
     }

--- a/tests/Unit/Account/Sync/AccountAlteredEventTest.php
+++ b/tests/Unit/Account/Sync/AccountAlteredEventTest.php
@@ -4,7 +4,6 @@ namespace Tests\Unit\Account\Sync;
 
 use App\Events\Mship\AccountAltered;
 use App\Jobs\Mship\SyncToCTS;
-use App\Jobs\Mship\SyncToDiscord;
 use App\Jobs\Mship\SyncToHelpdesk;
 use App\Jobs\Mship\SyncToMoodle;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -41,7 +40,6 @@ class AccountAlteredEventTest extends TestCase
         Queue::assertPushed(SyncToCTS::class);
         Queue::assertPushed(SyncToMoodle::class);
         Queue::assertPushed(SyncToHelpdesk::class);
-        Queue::assertNotPushed(SyncToDiscord::class);
         //Queue::assertPushed(SyncToForums::class);
     }
 
@@ -56,7 +54,6 @@ class AccountAlteredEventTest extends TestCase
         Queue::assertPushed(SyncToCTS::class, 1);
         Queue::assertPushed(SyncToMoodle::class, 1);
         Queue::assertPushed(SyncToHelpdesk::class, 1);
-        Queue::assertNotPushed(SyncToDiscord::class, 1);
         //Queue::assertPushed(SyncToForums::class, 1);
     }
 
@@ -72,7 +69,6 @@ class AccountAlteredEventTest extends TestCase
         Queue::assertNotPushed(SyncToCTS::class);
         Queue::assertNotPushed(SyncToMoodle::class);
         Queue::assertNotPushed(SyncToHelpdesk::class);
-        Queue::assertNotPushed(SyncToDiscord::class);
         //Queue::assertNotPushed(SyncToForums::class);
     }
 }

--- a/tests/Unit/Account/Sync/RoleSyncTest.php
+++ b/tests/Unit/Account/Sync/RoleSyncTest.php
@@ -39,9 +39,11 @@ class RoleSyncTest extends TestCase
     public function itTriggersEvent()
     {
         Event::fake();
-        event(new RoleAssigned($this->user, $this->role));
-        event(new RoleRemoved($this->user, $this->role));
+
+        $this->user->assignRole($this->role);
         Event::assertDispatched(RoleAssigned::class);
+
+        $this->user->removeRole($this->role);
         Event::assertDispatched(RoleRemoved::class);
     }
 

--- a/tests/Unit/Account/Sync/RoleSyncTest.php
+++ b/tests/Unit/Account/Sync/RoleSyncTest.php
@@ -28,7 +28,7 @@ class RoleSyncTest extends TestCase
         $this->role = factory(Role::class)->create();
 
         // Disable Discord connection
-        config(['services.discord' => []]);
+        config(['services.discord.token' => null]);
 
         Cache::flush(); // Remove time lockout cache
     }

--- a/tests/Unit/Account/Sync/RoleSyncTest.php
+++ b/tests/Unit/Account/Sync/RoleSyncTest.php
@@ -2,18 +2,18 @@
 
 namespace Tests\Unit\Account\Sync;
 
-use Tests\TestCase;
+use App\Events\Mship\Roles\RoleAssigned;
+use App\Events\Mship\Roles\RoleRemoved;
 use App\Jobs\Mship\SyncToCTS;
-use App\Jobs\Mship\SyncToMoodle;
 use App\Jobs\Mship\SyncToDiscord;
 use App\Jobs\Mship\SyncToHelpdesk;
-use Spatie\Permission\Models\Role;
+use App\Jobs\Mship\SyncToMoodle;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
-use App\Events\Mship\Roles\RoleRemoved;
-use App\Events\Mship\Roles\RoleAssigned;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
 
 class RoleSyncTest extends TestCase
 {

--- a/tests/Unit/Account/Sync/RoleSyncTest.php
+++ b/tests/Unit/Account/Sync/RoleSyncTest.php
@@ -29,6 +29,8 @@ class RoleSyncTest extends TestCase
 
         // Disable Discord connection
         config(['services.discord.token' => null]);
+        $this->user->discord_id = 1234;
+        $this->user->save();
 
         Cache::flush(); // Remove time lockout cache
     }

--- a/tests/Unit/Account/Sync/RoleSyncTest.php
+++ b/tests/Unit/Account/Sync/RoleSyncTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit\Account\Sync;
+
+use Tests\TestCase;
+use App\Jobs\Mship\SyncToCTS;
+use App\Jobs\Mship\SyncToMoodle;
+use App\Jobs\Mship\SyncToHelpdesk;
+use Spatie\Permission\Models\Role;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use App\Events\Mship\Roles\RoleRemoved;
+use App\Events\Mship\Roles\RoleAssigned;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class RoleSyncTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $role;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->role = factory(Role::class)->create();
+
+        Cache::flush(); // Remove time lockout cache
+    }
+
+    /** @test */
+    public function itTriggersEvent()
+    {
+        Event::fake();
+        event(new RoleAssigned($this->user, $this->role));
+        event(new RoleRemoved($this->user, $this->role));
+        Event::assertDispatched(RoleAssigned::class);
+        Event::assertDispatched(RoleRemoved::class);
+    }
+
+    /** @test */
+    public function itTriggersJobsWhenARoleIsAssigned()
+    {
+        Queue::fake();
+
+        event(new RoleAssigned($this->user, $this->role));
+
+        Queue::assertPushed(SyncToCTS::class, 1);
+        Queue::assertPushed(SyncToMoodle::class, 1);
+        Queue::assertPushed(SyncToHelpdesk::class, 1);
+        //Queue::assertPushed(SyncToForums::class, 1);
+    }
+
+    /** @test */
+    public function itTriggersJobsWhenARoleIsRemoved()
+    {
+        Queue::fake();
+
+        event(new RoleRemoved($this->user, $this->role));
+
+        Queue::assertPushed(SyncToCTS::class, 1);
+        Queue::assertPushed(SyncToMoodle::class, 1);
+        Queue::assertPushed(SyncToHelpdesk::class, 1);
+        //Queue::assertPushed(SyncToForums::class, 1);
+    }
+}

--- a/tests/Unit/Account/Sync/RoleSyncTest.php
+++ b/tests/Unit/Account/Sync/RoleSyncTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Account\Sync;
 use Tests\TestCase;
 use App\Jobs\Mship\SyncToCTS;
 use App\Jobs\Mship\SyncToMoodle;
+use App\Jobs\Mship\SyncToDiscord;
 use App\Jobs\Mship\SyncToHelpdesk;
 use Spatie\Permission\Models\Role;
 use Illuminate\Support\Facades\Cache;
@@ -25,6 +26,9 @@ class RoleSyncTest extends TestCase
         parent::setUp();
 
         $this->role = factory(Role::class)->create();
+
+        // Disable Discord connection
+        config(['services.discord' => []]);
 
         Cache::flush(); // Remove time lockout cache
     }
@@ -49,6 +53,7 @@ class RoleSyncTest extends TestCase
         Queue::assertPushed(SyncToCTS::class, 1);
         Queue::assertPushed(SyncToMoodle::class, 1);
         Queue::assertPushed(SyncToHelpdesk::class, 1);
+        Queue::assertPushed(SyncToDiscord::class, 1);
         //Queue::assertPushed(SyncToForums::class, 1);
     }
 
@@ -62,6 +67,7 @@ class RoleSyncTest extends TestCase
         Queue::assertPushed(SyncToCTS::class, 1);
         Queue::assertPushed(SyncToMoodle::class, 1);
         Queue::assertPushed(SyncToHelpdesk::class, 1);
+        Queue::assertPushed(SyncToDiscord::class, 1);
         //Queue::assertPushed(SyncToForums::class, 1);
     }
 }


### PR DESCRIPTION
This PR;

- Introduces two new events that fire when a role is assigned or removed from a user
- Adds the two new events to the SyncSubscriber so that when a role is added or removed, it syncs the user to external services
- Adds some missing tests for Discord to assert that the job was added to the queue