### PR TITLE
Sync Scheduler on Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,15 +211,13 @@ jobs:
             cd $RELEASE_DIRECTORY
 
             # Stop Application / Services
-            $PHP_PATH artisan down
             sudo systemctl stop core-horizon
+            $PHP_PATH artisan down
 
             # Migrate Database
             $PHP_PATH artisan migrate --step --force -n
 
-            # Publish Assets
-            $PHP_PATH artisan telescope:publish
-            $PHP_PATH artisan horizon:publish
+            # Publish Public Assets
             $PHP_PATH artisan nova:publish
 
             # Link Storage
@@ -228,6 +226,10 @@ jobs:
             # Start Applications / Services
             $PHP_PATH artisan up
             sudo systemctl start core-horizon
+
+            # Publish Hidden Assets
+            $PHP_PATH artisan telescope:publish
+            $PHP_PATH artisan horizon:publish
 
             # Cache & Logs
             $PHP_PATH artisan route:cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,6 +232,7 @@ jobs:
             # Cache & Logs
             $PHP_PATH artisan route:cache
             $PHP_PATH artisan view:cache
+            $PHP_PATH artisan schedule-monitor:sync
             mv storage/logs/laravel.log storage/logs/laravel.log.`date +%s`; true
 
             # This will interpolate the values as --revision="vx.y.z" and --repository="vatsim-uk/core"

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -70,9 +70,6 @@ class Kernel extends ConsoleKernel
         // $schedule->command('DivMembers:CertUpdate')
         //    ->dailyAt('05:00');
 
-        $schedule->command('schedule-monitor:sync')
-            ->dailyAt('07:00');
-
         $schedule->command('schedule-monitor:clean')
             ->dailyAt('08:00');
 

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -45,7 +45,7 @@
     <body>
         <div class="container">
             <div class="content">
-                <div class="title">Loading...</div>
+                <div class="title">Be Right Back!</div>
             </div>
         </div>
     </body>


### PR DESCRIPTION
Rather than syncing the scheduled jobs (with Oh Dear) on a daily basis, we should just handle this as part of the deploy script - as that is the only time they will ever change.

Also in this PR;

- Rewording the 503 page to make it clear it is downtime
- Reworking the order of deployment steps whilst `artisan down` is in effect to minimise downtime