### PR TITLE
Extend Time of Discord Sync

### DIFF
--- a/app/Jobs/Mship/SyncToDiscord.php
+++ b/app/Jobs/Mship/SyncToDiscord.php
@@ -3,7 +3,6 @@
 namespace App\Jobs\Mship;
 
 use App\Jobs\Job;
-use App\Jobs\Middleware\RateLimited;
 use App\Models\Mship\Account;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -24,10 +23,5 @@ class SyncToDiscord extends Job implements ShouldQueue
     public function handle()
     {
         $this->account->syncToDiscord();
-    }
-
-    public function middleware()
-    {
-        return [new RateLimited('discord_api_call', 3, 10)];
     }
 }

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -46,6 +46,7 @@ trait HasDiscordAccount
             })->each(function (DiscordRole $role) use ($currentRoles, $discord) {
                 if (! $currentRoles->contains($role->discord_id)) {
                     $discord->grantRoleById($this, $role->discord_id);
+                    usleep(500000);
                 }
             });
 
@@ -59,8 +60,11 @@ trait HasDiscordAccount
             })->each(function (DiscordRole $role) use ($currentRoles, $discord) {
                 if ($currentRoles->contains($role->discord_id)) {
                     $discord->removeRoleById($this, $role->discord_id);
+                    usleep(500000);
                 }
             });
         }
+
+        usleep(500000);
     }
 }

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -36,6 +36,7 @@ trait HasDiscordAccount
 
             $currentRoles->each(function (int $role) use ($discord) {
                 $discord->removeRoleById($this, $role);
+                sleep(1);
             });
 
             $discord->grantRoleById($this, $this->suspendedRoleId);
@@ -46,7 +47,7 @@ trait HasDiscordAccount
             })->each(function (DiscordRole $role) use ($currentRoles, $discord) {
                 if (! $currentRoles->contains($role->discord_id)) {
                     $discord->grantRoleById($this, $role->discord_id);
-                    usleep(500000);
+                    sleep(1);
                 }
             });
 
@@ -60,11 +61,11 @@ trait HasDiscordAccount
             })->each(function (DiscordRole $role) use ($currentRoles, $discord) {
                 if ($currentRoles->contains($role->discord_id)) {
                     $discord->removeRoleById($this, $role->discord_id);
-                    usleep(500000);
+                    sleep(1);
                 }
             });
         }
 
-        usleep(500000);
+        sleep(1);
     }
 }


### PR DESCRIPTION
At present, jobs are backing up in the queue because we are rate limiting very generously to avoid hitting issues with Discord API limits.

Instead, we'll just reintroduce the delays between Discord API calls and allow the jobs to run for slightly longer periods of time on the queue.

This shouldn't cause us great numbers of issues now that we are syncing Discord users whenever the user changes, rather than all ~2000 users at once.