### PR TITLE
Handle Discord Name Limit

### DIFF
--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -383,17 +383,23 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
     /**
      * Get the user's full name.
      *
-     * If a nickname is set, that will be used in place of name_first.
-     *
      * @return mixed|string
      */
     public function getNameAttribute()
     {
-        if ($this->nickname != null) {
-            return $this->nickname.' '.$this->name_last;
-        }
+        return $this->firstName.' '.$this->name_last;
+    }
 
-        return $this->real_name;
+    /**
+     * Get the user's first name.
+     *
+     * If a nickname is set, that will be used in place of name_first.
+     *
+     * @return mixed|string
+     */
+    public function getFirstNameAttribute()
+    {
+        return $this->nickname ? $this->nickname : $this->name_first;
     }
 
     /**

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -387,7 +387,7 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
      */
     public function getNameAttribute()
     {
-        return $this->firstName.' '.$this->name_last;
+        return $this->name_preferred.' '.$this->name_last;
     }
 
     /**
@@ -397,7 +397,7 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
      *
      * @return mixed|string
      */
-    public function getFirstNameAttribute()
+    public function getNamePreferredAttribute()
     {
         return $this->nickname ? $this->nickname : $this->name_first;
     }

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -16,7 +16,7 @@ trait HasDiscordAccount
     public function getDiscordNameAttribute()
     {
         if (Str::length($this->name) >= 32) {
-            return $this->firstName.' '.substr($this->name_last, 0, 1);
+            return $this->name_preferred.' '.substr($this->name_last, 0, 1);
         }
 
         return $this->name;

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -2,16 +2,26 @@
 
 namespace App\Models\Mship\Concerns;
 
+use App\Libraries\Discord;
+use Illuminate\Support\Str;
+use App\Models\Discord\DiscordRole;
 use App\Events\Discord\DiscordUnlinked;
 use App\Exceptions\Discord\DiscordUserNotFoundException;
-use App\Libraries\Discord;
-use App\Models\Discord\DiscordRole;
 
 /**
  * Trait HasDiscordAccount.
  */
 trait HasDiscordAccount
 {
+    public function getDiscordNameAttribute()
+    {
+        if (Str::length($this->name) >= 32) {
+            return $this->firstName.' '.substr($this->name_last, 0, 1);
+        }
+
+        return $this->name;
+    }
+
     /**
      * Sync the current account to Discord.
      */
@@ -26,7 +36,7 @@ trait HasDiscordAccount
         $suspendedRoleId = config('services.discord.suspended_member_role_id');
 
         try {
-            $discord->setNickname($this, $this->name);
+            $discord->setNickname($this, $this->discordName);
         } catch (DiscordUserNotFoundException $e) {
             return event(new DiscordUnlinked($this));
         }

--- a/resources/views/teamspeak/new.blade.php
+++ b/resources/views/teamspeak/new.blade.php
@@ -40,7 +40,7 @@
                             Click the "More" tab so that you are presented with a connection settings screen
                             <blockquote style="font-size: 9pt;">
                                 Server Address: {{ $teamspeak_url }}<br />
-                                Nickname: {{ $_account->name_first . " " . $_account->name_last }}<br />
+                                Nickname: {{ $_account->firstName . " " . $_account->name_last }}<br />
                                 One-Time Privilege Key: {{ $confirmation->privilege_key }}
                             </blockquote>
                         </li>

--- a/resources/views/teamspeak/new.blade.php
+++ b/resources/views/teamspeak/new.blade.php
@@ -40,7 +40,7 @@
                             Click the "More" tab so that you are presented with a connection settings screen
                             <blockquote style="font-size: 9pt;">
                                 Server Address: {{ $teamspeak_url }}<br />
-                                Nickname: {{ $_account->firstName . " " . $_account->name_last }}<br />
+                                Nickname: {{ $_account->name }}<br />
                                 One-Time Privilege Key: {{ $confirmation->privilege_key }}
                             </blockquote>
                         </li>


### PR DESCRIPTION
Discord limits nicknames to a maximum of 32 characters. In the event that a full name (e.g. `name_first` and `name_last`) is greater than 32 characters, the API will throw an exception when attempting to set the nickname.

This PR;

- Introduces a method to get the user's first name; either the set `nickname` or `name_first`. This is accessed via `$account->firstName`.
- Refactors the `$account->name` to defer to the new `$account->firstName` to get either the `nickname` or `name_first`.
- Adds a method to the `HasDiscordAccount` trait to get the user's "Discord name". This will be their full name (either nickname or first name, space, then surname) or, in the event that this would be over 32 characters, it will replace their surname with their initial.

The hole in this PR will be that if the user has a long first name then changing their surname could still render them over 32 characters. Having reviewed our member list, I don't believe this will be an issue for now.

In the future, we should afford members the flexibility to change their nickname. More thought required here.