### PR TITLE
feat: Sync visiting controllrs to CTS when accepted

### DIFF
--- a/app/Listeners/VisitTransfer/SyncVisitingControllerToCts.php
+++ b/app/Listeners/VisitTransfer/SyncVisitingControllerToCts.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Listeners\VisitTransfer;
+
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Events\VisitTransfer\ApplicationAccepted;
+
+class SyncVisitingControllerToCts
+{
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle(ApplicationAccepted $event)
+    {
+        $event->application->account->syncToCTS();
+    }
+}

--- a/app/Listeners/VisitTransfer/SyncVisitingControllerToCts.php
+++ b/app/Listeners/VisitTransfer/SyncVisitingControllerToCts.php
@@ -2,8 +2,6 @@
 
 namespace App\Listeners\VisitTransfer;
 
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use App\Events\VisitTransfer\ApplicationAccepted;
 
 class SyncVisitingControllerToCts

--- a/app/Models/Mship/Concerns/HasCTSAccount.php
+++ b/app/Models/Mship/Concerns/HasCTSAccount.php
@@ -47,7 +47,7 @@ use Illuminate\Support\Facades\DB;
             // if no CTS account exists, lets sync to create a new one, and not update anything this time round.
             if (! $ctsAccount) {
                 // for a division member, use the join timestamp of them joining, else use an empty timestamp.
-                // this is how CTS in its wisdom puts this column on visiting controllers.
+                // this is how CTS puts this column on visiting controllers.
                 $is_visitor = $this->primary_permanent_state->code != 'DIVISION';
                 $joined_div = ! $is_visitor
                     ? $this->primary_permanent_state->pivot->start_at

--- a/app/Models/Mship/Concerns/HasCTSAccount.php
+++ b/app/Models/Mship/Concerns/HasCTSAccount.php
@@ -44,6 +44,9 @@ use Illuminate\Support\Facades\DB;
 
             $ctsAccount = DB::table("{$ctsDatabase}.members")->where('cid', $this->id)->first();
 
+            // if user has nickname, prefer that name; else use full qualified name.
+            $name = $this->nickname ?: $this->real_name;
+
             // if no CTS account exists, lets sync to create a new one, and not update anything this time round.
             if (! $ctsAccount) {
                 // for a division member, use the join timestamp of them joining, else use an empty timestamp.
@@ -57,7 +60,7 @@ use Illuminate\Support\Facades\DB;
                     'old_rts_id' => 0,
                     'id' => $this->generateCTSInternalID($this->id),
                     'cid' => $this->id,
-                    'name' => $this->real_name,
+                    'name' => $name,
                     'email' => $this->getEmailForService($ssoAccountId),
                     'rating' => ($this->network_banned || $this->inactive) ? 0 : $this->qualification_atc->vatsim,
                     'prating' => $this->qualifications_pilot->sum('vatsim'),
@@ -75,7 +78,7 @@ use Illuminate\Support\Facades\DB;
             }
 
             $data = [
-                'name' => $this->real_name,
+                'name' => $name,
                 'email' => $this->getEmailForService($ssoAccountId),
                 'rating' => ($this->network_banned || $this->inactive) ? 0 : $this->qualification_atc->vatsim,
                 'prating' => $this->qualifications_pilot->sum('vatsim'),

--- a/app/Models/Mship/Concerns/HasCTSAccount.php
+++ b/app/Models/Mship/Concerns/HasCTSAccount.php
@@ -10,6 +10,24 @@ use Illuminate\Support\Facades\DB;
     trait HasCTSAccount
     {
         /**
+         * Generate an internal identifier for the CTS user record.
+         * See CTS codebase (cts/scripts/member.php) for implementation details on Ids which don't equate
+         * to the CID of a user.
+         */
+        public function generateCTSInternalID(int $cid) : int // NOSONAR
+        {
+            if ($cid < 800000) {
+                return $cid + 2000000;
+            } elseif ($cid < 1323000) {
+                return $cid;
+            } elseif ($cid < 1800000) {
+                return $cid - 1000000;
+            } else {
+                return $cid + 2000000;
+            }
+        }
+
+        /**
          * Sync the current account to the CTS.
          */
         public function syncToCTS()
@@ -26,8 +44,33 @@ use Illuminate\Support\Facades\DB;
 
             $ctsAccount = DB::table("{$ctsDatabase}.members")->where('cid', $this->id)->first();
 
+            // if no CTS account exists, lets sync to create a new one, and not update anything this time round.
             if (! $ctsAccount) {
-                // No user exists. Abort.
+                // for a division member, use the join timestamp of them joining, else use an empty timestamp.
+                // this is how CTS in its wisdom puts this column on visiting controllers.
+                $is_visitor = $this->primary_permanent_state->code != 'DIVISION';
+                $joined_div = !$is_visitor
+                    ? $this->primary_permanent_state->pivot->start_at
+                    : gmdate("Y-m-d H:i:s");
+
+                $newMember = [
+                    'old_rts_id' => 0,
+                    'id' => $this->generateCTSInternalID($this->id),
+                    'cid' => $this->id,
+                    'name' => $this->real_name,
+                    'email' => $this->getEmailForService($ssoAccountId),
+                    'rating' => ($this->network_banned || $this->inactive) ? 0 : $this->qualification_atc->vatsim,
+                    'prating' => $this->qualifications_pilot->sum('vatsim'),
+                    'joined_div' => $joined_div,
+                    'visiting' => $is_visitor,
+                    'last_cert_check' => $this->cert_checked_at,
+                ];
+                if ($is_visitor) {
+                    // do a best guess on the division they are visiting from. Designed to be updated later by an admin.
+                    $newMember['visit_from'] = "{$this->primary_permanent_state->pivot->region} - {$this->primary_permanent_state->pivot->division}";
+                }
+                DB::table("{$ctsDatabase}.members")->insert($newMember);
+                // go no further.
                 return;
             }
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -59,6 +59,7 @@ class EventServiceProvider extends ServiceProvider
         \App\Events\VisitTransfer\ApplicationAccepted::class => [
             \App\Listeners\VisitTransfer\NotifyApplicantOfStatusChange::class,
             \App\Listeners\VisitTransfer\NotifyTrainingDepartmentOfAcceptedApplication::class,
+            \App\Listeners\VisitTransfer\SyncVisitingControllerToCts::class,
         ],
 
         \App\Events\VisitTransfer\ApplicationCompleted::class => [

--- a/resources/views/site/operations/sectors.blade.php
+++ b/resources/views/site/operations/sectors.blade.php
@@ -378,19 +378,19 @@
 
                     <ul>
                         <li>
-                            LON_S_CTR
-                        </li>
-                        <li>
-                            LON_C_CTR
-                        </li>
-                        <li>
-                            LON_W_CTR
-                        </li>
+                            SCO_CTR
+                        </li>                    
                         <li>
                             LON_N_CTR
                         </li>
                         <li>
-                            SCO_CTR
+                            LON_C_CTR
+                        </li>                        
+                        <li>
+                            LON_S_CTR
+                        </li>
+                        <li>
+                            LON_W_CTR
                         </li>
                     </ul>
 
@@ -400,22 +400,19 @@
 
                     <ul>
                         <li>
-                            LON_D_CTR
+                            LON_NW_CTR
+                        </li>
+                        <li>
+                            LON_NE_CTR
                         </li>
                         <li>
                             LON_M_CTR
                         </li>
                         <li>
                             LON_E_CTR
-                        </li>
+                        </li>                        
                         <li>
-                            LTC_S_CTR
-                        </li>
-                        <li>
-                            LTC_N_CTR
-                        </li>
-                        <li>
-                            MAN_CTR
+                            LON_D_CTR
                         </li>
                         <li>
                             STC_CTR
@@ -423,17 +420,34 @@
                         <li>
                             STC_A_CTR
                         </li>
+                        <li>
+                            MAN_W_CTR
+                        </li>
+                        <li>
+                            MAN_NE_CTR
+                        </li>
+                        <li>
+                            MAN_SE_CTR
+                        </li>                          
+                        <li>
+                            LTC_N_CTR
+                        </li>
+                        <li>
+                            LTC_S_CTR
+                        </li>                      
                     </ul>
 
                     <p>
                         Members may open either a single Primary or Secondary sector, or a valid combination of
-                        Primary (e.g. LON_SC_CTR) or Secondary (e.g. LTC_CTR) sectors.<br>
+                        Primary (e.g. LON_SC_CTR) or Secondary (e.g. LTC_CTR, MAN_CTR) sectors.<br>
                     </p>
 
                     <p>
                         Further splits require the remaining portion of the Primary or Secondary sector to be
                         staffed too - e.g. opening LTC_NE_CTR requires LTC_NW_CTR (as the remaining portion of
-                        LTC_N_CTR) to be online.
+                        LTC_N_CTR) to be online. Splits not defined in the London or Scottish FIR (EGTT) vMATS 
+                        Part II require specific approval from the Operations Department in the form of a 
+                        Temporary Instruction or Procedure Change.
                     </p>
 
                 </div>


### PR DESCRIPTION
Not the finest bit of code, but it does appear to work. I don't have a full live CTS to test against locally, but this matches what data is expected in the production system for a visiting controller.

The logic for the internal IDs is straight from CTS. I dare not simplify it in case it is somehow messed up (there is a refactoring opportunity I can spot straight away with the boolean logic.). 

Also, there are often things not worth unit testing. I firmly put this in that category. 
