### PR TITLE
feat: Add Area hour checker

### DIFF
--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -26,4 +26,41 @@ class EndorsementController extends BaseController
             ->with('conditions', $endorsement->conditions)
             ->with('hours', $hours->all());
     }
+
+    public function getAreaIndex()
+    {
+        $endorsements = Endorsement::whereIn('name', ['LON_S_CTR', 'LON_C_CTR', 'LON_N_CTR','SCO_CTR'])->get();
+
+        if ($endorsements->count() < 1) {
+            return Redirect::route('mship.manage.dashboard')
+                ->withError('Endorsements improperly configured');
+        }
+
+        if (!$this->account->qualificationAtc->isS3) {
+            return Redirect::route('mship.manage.dashboard')
+                ->withError('Only S3 rated controllers can see their C1 Training Place eligibility.');
+        }
+
+        $endorsements = $endorsements->load('conditions')->map(function ($endorsement) {
+            $conditions = $endorsement->conditions->map(function ($condition) use ($endorsement) {
+                return [
+                    'endorsement_id' => $endorsement->id,
+                    // extract the likely position name from the criterion loaded into the database.
+                    'position' => str_replace('%', '_', $condition->positions[0]),
+                    'required_hours' => $condition->required_hours,
+                    'within_months' => $condition->within_months,
+                    'progress' => round($condition->progressForUser($this->account)->sum(), 1),
+                    'complete' => $condition->isMetForUser($this->account)
+                ];
+            });
+
+            return [
+                'name' => $endorsement->name,
+                'conditions' => $conditions
+            ];
+        });
+
+        return $this->viewMake('controllers.endorsements.area')
+            ->with('endorsements', $endorsements);
+    }
 }

--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -29,14 +29,14 @@ class EndorsementController extends BaseController
 
     public function getAreaIndex()
     {
-        $endorsements = Endorsement::whereIn('name', ['LON_S_CTR', 'LON_C_CTR', 'LON_N_CTR','SCO_CTR'])->get();
+        $endorsements = Endorsement::whereIn('name', ['LON_S_CTR', 'LON_C_CTR', 'LON_N_CTR', 'SCO_CTR'])->get();
 
         if ($endorsements->count() < 1) {
             return Redirect::route('mship.manage.dashboard')
                 ->withError('Endorsements improperly configured');
         }
 
-        if (!$this->account->qualificationAtc->isS3) {
+        if (! $this->account->qualificationAtc->isS3) {
             return Redirect::route('mship.manage.dashboard')
                 ->withError('Only S3 rated controllers can see their C1 Training Place eligibility.');
         }
@@ -50,13 +50,13 @@ class EndorsementController extends BaseController
                     'required_hours' => $condition->required_hours,
                     'within_months' => $condition->within_months,
                     'progress' => round($condition->progressForUser($this->account)->sum(), 1),
-                    'complete' => $condition->isMetForUser($this->account)
+                    'complete' => $condition->isMetForUser($this->account),
                 ];
             });
 
             return [
                 'name' => $endorsement->name,
-                'conditions' => $conditions
+                'conditions' => $conditions,
             ];
         });
 

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -78,6 +78,13 @@
                                 <li>{!! link_to_route("controllers.endorsements.gatwick_ground", "Gatwick Ground") !!}</li>
                             </ul>
                         </li>
+                        <li class="col-sm-12">
+                            <ul>
+                                <li class="divider"></li>
+                                <li class="dropdown-header">Hour Checker</li>
+                                <li>{!! link_to_route("controllers.hour_check.area", "C1 Training Place") !!}</li>
+                            </ul>
+                        </li>
                     </ul>
                 </li>
 

--- a/resources/views/controllers/endorsements/area.blade.php
+++ b/resources/views/controllers/endorsements/area.blade.php
@@ -1,0 +1,51 @@
+@extends('layout')
+
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <h3>C1 Training Place - Hour Checker</h3>
+        <p>At least 12 hours on UK ATC positions in the three months before a place is offered</p>
+        <p>When a training place becomes available on a certain sector, the first eligible student who meets the requirements for that sector will be offered the place. You will only be offered a place on a sector for which you meet the requirements. You are not required to notify us when you meet the requirements for any of the above sectors.</p>
+        <p>Below you can view your progress towards, and an overview of the required criteria for each enroute sector.</p>
+    </div>
+</div>
+<div class="row">
+    @foreach ($endorsements as $endorsement)
+        <div class="col-md-6">
+            <div class="panel panel-ukblue">
+                <div class="panel-heading">
+                    <i class="fas fa-headset"></i>&nbsp;{{ $endorsement['name'] }}
+                </div>
+                <div class="panel-body">
+                    <header>
+                        <h4>Required Hours</h4>
+                        <span>The following hours are required on the corresponding positions</span>
+                        <ul>
+                            @foreach($endorsement['conditions'] as $condition)
+                                <li>{{ $condition['position'] }} - {{ $condition['required_hours'] }} hours within the last {{ $condition['within_months'] }} months.</li>
+                            @endforeach
+                        </ul>
+                    </header>
+                    <main>
+                        <h4>Your Progress</h4>
+
+                        @foreach($endorsement['conditions'] as $condition)
+                        {{ $condition['position'] }}
+                        <div class="progress">
+                            @if ($condition['complete'])
+                                <div class="progress-bar progress-bar-success" role="progressbar" style="width: 100%">{{ $condition['progress']}} hours</div>
+                            @else
+                                <div class="progress-bar" role="progressbar" style="width: {{ ($condition['progress'] / $condition['required_hours']) * 100 }}%" aria-valuemin="0" aria-valuemax="{{ $condition['required_hours'] }}">
+                                    {{ $condition['progress'] }} hours
+                                </div>
+                            @endif
+                        </div>
+                         @endforeach
+
+                    </main>
+                </div>
+            </div>
+        </div>
+    @endforeach
+</div>
+@endsection

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -131,6 +131,7 @@ Route::group([
     'middleware' => 'auth_full_group',
 ], function () {
     Route::get('endorsements/gatwick')->uses('EndorsementController@getGatwickGroundIndex')->name('endorsements.gatwick_ground');
+    Route::get('hour-check/area')->uses('EndorsementController@getAreaIndex')->name('hour_check.area');
 });
 
 // Network data

--- a/tests/Feature/Atc/AreaHourCheckTest.php
+++ b/tests/Feature/Atc/AreaHourCheckTest.php
@@ -2,12 +2,11 @@
 
 namespace Tests\Feature\Atc;
 
-use Tests\TestCase;
-use App\Models\Mship\Account;
 use App\Models\Atc\Endorsement;
+use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
 
 class AreaHourCheckTest extends TestCase
 {

--- a/tests/Feature/Atc/AreaHourCheckTest.php
+++ b/tests/Feature/Atc/AreaHourCheckTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Atc;
+
+use Tests\TestCase;
+use App\Models\Mship\Account;
+use App\Models\Atc\Endorsement;
+use App\Models\Mship\Qualification;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class AreaHourCheckTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $hourCheckRoute = 'controllers.hour_check.area';
+
+    /** @test */
+    public function testRedirectsAwayIfUserNotS3()
+    {
+        $account = factory(Account::class)->create();
+
+        $qualification = Qualification::code('S2')->first();
+        $account->addQualification($qualification);
+        $account->save();
+
+        $this->actingAs($account->fresh())
+            ->get(route($this->hourCheckRoute))
+            ->assertRedirect(route('mship.manage.dashboard'));
+    }
+
+    /** @test */
+    public function testSuccessfulNavigationIfUserIsS3()
+    {
+        // create relevant endorsement.
+        factory(Endorsement::class)->create(['name' => 'LON_S_CTR']);
+        $account = factory(Account::class)->create();
+
+        $qualification = Qualification::code('S3')->first();
+        $account->addQualification($qualification);
+        $account->save();
+
+        $this->actingAs($account->fresh())
+            ->get(route($this->hourCheckRoute))
+            ->assertOk();
+    }
+
+    /** @test */
+    public function testRedirectsAwayIfNoRelevantEndorsementsCreated()
+    {
+        $account = factory(Account::class)->create();
+
+        $qualification = Qualification::code('S3')->first();
+        $account->addQualification($qualification);
+        $account->save();
+
+        $this->actingAs($account->fresh())
+            ->get(route($this->hourCheckRoute))
+            ->assertRedirect(route('mship.manage.dashboard'));
+    }
+}


### PR DESCRIPTION
Uses existing endorsement mechanism for checking conditions in line with the same checks the waiting lists uses.

The only 'caveat' is that it will never work with checks which have '_APP' as the callsign.
