### PR TITLE
feat: add required qualification to condition

### DIFF
--- a/app/Models/Atc/Endorsement/Condition.php
+++ b/app/Models/Atc/Endorsement/Condition.php
@@ -16,7 +16,6 @@ class Condition extends Model
         'required_hours',
         'type',
         'within_months',
-        'qualification_id'
     ];
 
     protected $casts = [

--- a/app/Models/Atc/Endorsement/Condition.php
+++ b/app/Models/Atc/Endorsement/Condition.php
@@ -16,6 +16,7 @@ class Condition extends Model
         'required_hours',
         'type',
         'within_months',
+        'qualification_id'
     ];
 
     protected $casts = [
@@ -86,6 +87,11 @@ class Condition extends Model
         if ($this->within_months) {
             $sessions = $sessions->whereBetween('connected_at', [Carbon::now()->subMonths($this->within_months), Carbon::now()]);
         }
+
+        if ($this->required_qualification) {
+            $sessions = $sessions->where('qualification_id', $this->required_qualification);
+        }
+
         $sessions = $sessions->get(['minutes_online', 'callsign']);
 
         // Map into groups of positions

--- a/database/factories/EndorsementFactory.php
+++ b/database/factories/EndorsementFactory.php
@@ -15,5 +15,6 @@ $factory->define(\App\Models\Atc\Endorsement\Condition::class, function ($faker)
         'required_hours' => $faker->numberBetween(1, 100),
         'type' => 1,
         'within_months' => $faker->optional(0.5)->randomDigit,
+        'required_qualification' => null,
     ];
 });

--- a/database/migrations/2021_08_05_165824_add_required_qualification_column_to_endorsement_criteria.php
+++ b/database/migrations/2021_08_05_165824_add_required_qualification_column_to_endorsement_criteria.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddRequiredQualificationColumnToEndorsementCriteria extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('endorsement_conditions', function (Blueprint $table) {
+            $table->unsignedInteger('required_qualification')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('endorsement_conditions', function (Blueprint $table) {
+            $table->dropColumn('required_qualification');
+        });
+    }
+}

--- a/tests/Unit/Endorsements/ConditionModelTest.php
+++ b/tests/Unit/Endorsements/ConditionModelTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Unit\Endorsements;
 
-use App\Models\Atc\Endorsement;
-use App\Models\Atc\Endorsement\Condition;
-use App\Models\NetworkData\Atc;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
+use App\Models\Atc\Endorsement;
+use App\Models\NetworkData\Atc;
+use App\Models\Mship\Qualification;
+use App\Models\Atc\Endorsement\Condition;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class ConditionModelTest extends TestCase
 {
@@ -166,6 +167,54 @@ class ConditionModelTest extends TestCase
 
         $session->minutes_online = 5 * 60;
         $session->save();
+        $this->assertTrue($condition->fresh()->isMetForUser($this->user));
+    }
+
+    /** @test */
+    public function itCorrectlyChecksForQualificationWhenPresent()
+    {
+        $requiredQualification = Qualification::code('S3')->get()->first()->id;
+
+        $condition = factory(Endorsement\Condition::class)->create([
+            'positions' => ['ESSEX_APP'],
+            'required_hours' => 10,
+            'within_months' => 2,
+            'type' => Endorsement\Condition::TYPE_ON_SINGLE_AIRFIELD,
+            'required_qualification' => $requiredQualification,
+        ]);
+
+        // create a session short of the requirement at the rating required
+        factory(Atc::class)->create([
+            'account_id' => $this->user->id,
+            'callsign' => 'ESSEX_APP',
+            'minutes_online' => 9 * 60, // 9 hours
+            'connected_at' => Carbon::now()->subMonths(1),
+            'disconnected_at' => Carbon::now()->subMonths(1),
+            'qualification_id' => $requiredQualification,
+        ]);
+
+        // create a session which would meet the hours criteria, but not at the right rating
+        factory(Atc::class)->create([
+            'account_id' => $this->user->id,
+            'callsign' => 'ESSEX_APP',
+            'minutes_online' => 4 * 60, // 4 hours
+            'connected_at' => Carbon::now()->subMonths(1),
+            'disconnected_at' => Carbon::now()->subMonths(1),
+            'qualification_id' => Qualification::code('S2')->get()->first()->id
+        ]);
+
+        $this->assertFalse($condition->fresh()->isMetForUser($this->user));
+
+        // create a session to meet requirement at the rating required
+        factory(Atc::class)->create([
+            'account_id' => $this->user->id,
+            'callsign' => 'ESSEX_APP',
+            'minutes_online' => 3 * 60, // 3 hours
+            'connected_at' => Carbon::now()->subMonths(1),
+            'disconnected_at' => Carbon::now()->subMonths(1),
+            'qualification_id' => $requiredQualification,
+        ]);
+
         $this->assertTrue($condition->fresh()->isMetForUser($this->user));
     }
 }


### PR DESCRIPTION
This adds a column to the endorsement condition table to mandate that the sessions take place when the user has a specific rating. e.g. 10 hours in 6 months when the session has an S3.


For this to take effect in production, you will need to clear the cache and load the waiting lists page. 
