### PR TITLE
fix: Use null instead of empty date for joined_div in cts sync

### DIFF
--- a/app/Console/Commands/CtsMock.php
+++ b/app/Console/Commands/CtsMock.php
@@ -69,7 +69,7 @@ class CtsMock extends Command
               `admin_ex` tinyint(1) NOT NULL DEFAULT 0,
               `ins` int(1) NOT NULL DEFAULT 0,
               `joined` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-              `joined_div` datetime NOT NULL,
+              `joined_div` datetime DEFAULT NULL,
               `last_cert_check` datetime DEFAULT NULL,
               `verified` tinyint(1) unsigned DEFAULT 0,
               `deleted` tinyint(1) unsigned DEFAULT 0,

--- a/app/Models/Mship/Concerns/HasCTSAccount.php
+++ b/app/Models/Mship/Concerns/HasCTSAccount.php
@@ -55,7 +55,7 @@ use Illuminate\Support\Facades\DB;
                 $is_visitor = $this->primary_permanent_state->code != 'DIVISION';
                 $joined_div = ! $is_visitor
                     ? $this->primary_permanent_state->pivot->start_at
-                    : gmdate('Y-m-d H:i:s');
+                    : null;
 
                 $newMember = [
                     'old_rts_id' => 0,


### PR DESCRIPTION
Resolves Trello card 160
