### PR TITLE
Import Member Re-Write

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,28 @@ jobs:
           mysql -e 'CREATE DATABASE IF NOT EXISTS cts;' -h127.0.0.1 -uroot -proot
 
       #
+      # ENV SETUP
+      #
+
+      # Environment Configuration
+      - name: Create empty Environment File
+        run: touch .env
+
+      - name: Set Environment Variables
+        uses: allenevans/set-env@v2.0.0
+        with:
+          APP_ENV: testing
+          APP_KEY: base64:wx/g4ayECKlSzOYSguRFoCrsd+KSbAyEiy0J8zWxxyU=
+          APP_URL: 127.0.0.1
+          CACHE_DRIVER: array
+          DB_MYSQL_HOST: localhost
+          DB_MYSQL_PORT: 3306
+          DB_MYSQL_USER: root
+          DB_MYSQL_PASS: root
+          DB_MYSQL_NAME: core
+          CTS_DATABASE: cts
+
+      #
       # COMPOSER DEPENDENICES
       #
 
@@ -135,24 +157,6 @@ jobs:
       #
       # APPLICATION SETUP
       #
-
-      # Environment Configuration
-      - name: Create empty Environment File
-        run: touch .env
-
-      - name: Set Environment Variables
-        uses: allenevans/set-env@v2.0.0
-        with:
-          APP_ENV: testing
-          APP_KEY: base64:wx/g4ayECKlSzOYSguRFoCrsd+KSbAyEiy0J8zWxxyU=
-          APP_URL: 127.0.0.1
-          CACHE_DRIVER: array
-          DB_MYSQL_HOST: localhost
-          DB_MYSQL_PORT: 3306
-          DB_MYSQL_USER: root
-          DB_MYSQL_PASS: root
-          DB_MYSQL_NAME: core
-          CTS_DATABASE: cts
 
       # Publish Packages
       - name: Publish Horizon

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,28 +63,6 @@ jobs:
           mysql -e 'CREATE DATABASE IF NOT EXISTS cts;' -h127.0.0.1 -uroot -proot
 
       #
-      # ENV SETUP
-      #
-
-      # Environment Configuration
-      - name: Create empty Environment File
-        run: touch .env
-
-      - name: Set Environment Variables
-        uses: allenevans/set-env@v2.0.0
-        with:
-          APP_ENV: testing
-          APP_KEY: base64:wx/g4ayECKlSzOYSguRFoCrsd+KSbAyEiy0J8zWxxyU=
-          APP_URL: 127.0.0.1
-          CACHE_DRIVER: array
-          DB_MYSQL_HOST: localhost
-          DB_MYSQL_PORT: 3306
-          DB_MYSQL_USER: root
-          DB_MYSQL_PASS: root
-          DB_MYSQL_NAME: core
-          CTS_DATABASE: cts
-
-      #
       # COMPOSER DEPENDENICES
       #
 
@@ -157,6 +135,24 @@ jobs:
       #
       # APPLICATION SETUP
       #
+
+      # Environment Configuration
+      - name: Create empty Environment File
+        run: touch .env
+
+      - name: Set Environment Variables
+        uses: allenevans/set-env@v2.0.0
+        with:
+          APP_ENV: testing
+          APP_KEY: base64:wx/g4ayECKlSzOYSguRFoCrsd+KSbAyEiy0J8zWxxyU=
+          APP_URL: 127.0.0.1
+          CACHE_DRIVER: array
+          DB_MYSQL_HOST: localhost
+          DB_MYSQL_PORT: 3306
+          DB_MYSQL_USER: root
+          DB_MYSQL_PASS: root
+          DB_MYSQL_NAME: core
+          CTS_DATABASE: cts
 
       # Publish Packages
       - name: Publish Horizon

--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -2,14 +2,14 @@
 
 namespace App\Console\Commands\Members;
 
-use App\Models\Mship\Account;
-use Illuminate\Support\Carbon;
 use App\Console\Commands\Command;
+use App\Models\Mship\Account;
+use App\Notifications\Mship\WelcomeMember;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Validator;
-use App\Notifications\Mship\WelcomeMember;
-use Illuminate\Support\Collection;
 
 class ImportMembers extends Command
 {
@@ -65,7 +65,7 @@ class ImportMembers extends Command
 
         $response = Http::withHeaders([
             'Authorization' => "Token {$this->apiToken}",
-        ])->get(config('vatsim-api.base') . 'divisions/GBR/members');
+        ])->get(config('vatsim-api.base').'divisions/GBR/members');
 
         // Process first page of results
         foreach ($response->collect()->get('results') as $result) {
@@ -95,7 +95,7 @@ class ImportMembers extends Command
                 'name_last' => $member['name_last'],
                 'email' => $member['email'],
                 'joined_at' => Carbon::create($member['reg_date']),
-                'inactive' => (int) $member['rating'] < 0
+                'inactive' => (int) $member['rating'] < 0,
             ]
         );
 

--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -26,17 +26,12 @@ class ImportMembers extends Command
     protected int $countUpdated = 0;
     protected int $countSkipped = 0;
 
-    public function __construct()
+    public function handle()
     {
         $this->apiToken = config('vatsim-api.key');
         $this->existingMembers = DB::table('mship_account')->pluck('id');
         $this->importedMembers = collect();
 
-        parent::__construct();
-    }
-
-    public function handle()
-    {
         $this->getMembers();
 
         $this->info('Processing members...');

--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -2,216 +2,104 @@
 
 namespace App\Console\Commands\Members;
 
-use App\Console\Commands\Command;
 use App\Models\Mship\Account;
-use App\Models\Mship\Qualification;
-use App\Models\Mship\State;
-use App\Notifications\Mship\WelcomeMember;
-use DB;
-use Exception;
 use Illuminate\Support\Carbon;
+use App\Console\Commands\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Validator;
+use App\Notifications\Mship\WelcomeMember;
+use Illuminate\Support\Collection;
 
-/**
- * Utilizes the CERT divdb file to import new users and update existing user emails.
- */
 class ImportMembers extends Command
 {
-    /**
-     * The console command name.
-     *
-     * @var string
-     */
-    protected $signature = 'Members:CertImport {--full}';
+    protected $signature = 'Members:CertImport';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
-    protected $description = 'Import/update member emails from VATSIM API';
+    protected $description = 'Import VATSIM UK members from the VATSIM API.';
 
-    protected $count_new = 0;
-    protected $count_emails = 0;
-    protected $count_none = 0;
-    protected $member_list;
-    protected $member_email_list;
+    protected string $apiToken;
 
-    /**
-     * Execute the console command.
-     *
-     * @return mixed
-     */
+    protected Collection $existingMembers;
+    protected Collection $importedMembers;
+
+    protected int $countNewlyCreated = 0;
+    protected int $countUpdated = 0;
+    protected int $countSkipped = 0;
+
+    public function __construct()
+    {
+        $this->apiToken = config('vatsim-api.key');
+        $this->existingMembers = DB::table('mship_account')->pluck('id');
+        $this->importedMembers = collect();
+
+        parent::__construct();
+    }
+
     public function handle()
     {
-        $this->member_list = $this->getMemberIdAndEmail();
+        $this->getMembers();
 
-        foreach ($this->getMembers() as $member) {
-            $this->log("Processing {$member['cid']} {$member['name_first']} {$member['name_last']}: ", null, false);
+        $this->info('Processing members...');
 
-            DB::transaction(function () use ($member) {
-                $this->processMember($member);
-            });
-        }
+        $this->withProgressBar($this->importedMembers, function ($member) {
+            $validator = Validator::make($member, [
+                'id' => 'required|integer',
+                'rating' => 'required|integer',
+                'name_first' => 'required|string',
+                'name_last' => 'required|string',
+                'email' => 'required|email',
+                'reg_date' => 'required|date',
+            ]);
+
+            $validator->fails() ? $this->countSkipped++ : $this->processMember($member);
+        });
+
+        $this->newLine();
+
+        $this->info("Successfully created {$this->countNewlyCreated} new, updated {$this->countUpdated} and skipped {$this->countSkipped} members.");
     }
 
     protected function getMembers()
     {
-        $processResult = function (array $result) {
-            return [
-                'cid' => $result['id'],
-                'rating_atc' => $result['rating'],
-                'rating_pilot' => $result['pilotrating'],
-                'name_first' => $result['name_first'],
-                'name_last' => $result['name_last'],
-                'email' => $result['email'],
-                'age_band' => $result['age'],
-                'city' => $result['countystate'],
-                'country' => $result['country'],
-                'experience' => '',
-                'unknown' => '',
-                'reg_date' => Carbon::parse($result['reg_date'])->toDateTimeString(),
-                'region' => $result['region'],
-                'division' => $result['division'],
-            ];
-        };
+        $this->info('Fetching members from VATSIM API...');
 
-        // TODO: possibly add some OhDear functionality if this request fails?
-        $url = config('vatsim-api.base').'divisions/GBR/members';
-        $apiToken = config('vatsim-api.key');
         $response = Http::withHeaders([
-            'Authorization' => "Token {$apiToken}",
-        ])->get($url)->json();
+            'Authorization' => "Token {$this->apiToken}",
+        ])->get(config('vatsim-api.base') . 'divisions/GBR/members');
 
-        $memberCollection = collect();
-
-        // process the first page of results.
-        foreach ($response['results'] as $result) {
-            $memberCollection->push($processResult($result));
+        // Process first page of results
+        foreach ($response->collect()->get('results') as $result) {
+            $this->importedMembers->push($result);
         }
 
-        // process any paginated results from the API.
-        while ($response['next'] != null) {
+        // Process paginated results
+        while ($response->successful() && $response->collect()->get('next') != null) {
             $response = Http::withHeaders([
-                'Authorization' => "Token {$apiToken}",
-            ])->get($response['next'])->json();
+                'Authorization' => "Token {$this->apiToken}",
+            ])->get($response->collect()->get('next'));
 
-            foreach ($response['results'] as $result) {
-                $memberCollection->push($processResult($result));
+            foreach ($response->collect()->get('results') as $result) {
+                $this->importedMembers->push($result);
             }
         }
 
-        return $memberCollection;
+        $this->info("{$this->importedMembers->count()} members obtained from VATSIM API.");
     }
 
-    protected function processMember($member)
+    protected function processMember(array $member)
     {
-        if (array_get($this->member_list, $member['cid'], 'unknown') != 'unknown') {
-            if (strcasecmp($this->member_list[$member['cid']], $member['email']) !== 0) {
-                $this->updateMember($member);
-                $this->log('updated member');
-                $this->count_emails++;
+        $account = Account::updateOrCreate(
+            ['id' => $member['id']],
+            [
+                'name_first' => $member['name_first'],
+                'name_last' => $member['name_last'],
+                'email' => $member['email'],
+                'joined_at' => Carbon::create($member['reg_date']),
+                'inactive' => (int) $member['rating'] < 0
+            ]
+        );
 
-                return;
-            }
-
-            $this->log('no important changes required.');
-            $this->count_none++;
-
-            return;
-        }
-
-        $this->createNewMember($member);
-        $this->log('created new account');
-        $this->count_new++;
-    }
-
-    protected function createNewMember($member_data)
-    {
-        $validator = Validator::make($member_data, [
-            'cid' => 'required|integer',
-            'name_first' => 'required|string',
-            'name_last' => 'required|string',
-            'email' => 'required|email',
-            'reg_date' => 'required|date',
-            'rating_atc' => 'required|integer',
-        ]);
-
-        if ($validator->fails()) {
-            // Incorrectly formatted response from CERT
-            return;
-        }
-
-        $member = new Account([
-            'id' => $member_data['cid'],
-            'name_first' => $member_data['name_first'],
-            'name_last' => $member_data['name_last'],
-            'email' => $member_data['email'],
-            'joined_at' => $member_data['reg_date'],
-        ]);
-        $member->is_inactive = (bool) ($member_data['rating_atc'] < 0);
-        $member->save();
-
-        $member->addState(State::findByCode('DIVISION'), 'EMEA', 'GBR');
-
-        // if they have an extra rating, log their previous rating first,
-        // regardless of whether it will be overwritten
-        if ($member_data['rating_atc'] >= 8) {
-            // This user has an admin rating but there is currently no support
-            // for fetching their real rating via the VATSIM API. For
-            // reference, the old AT code is below.
-
-            // try {
-            //     $_prevRat = VatsimXML::getData($member->id, 'idstatusprat');
-            // } catch (Exception $e) {
-            //     if (strpos($e->getMessage(), 'Name or service not known') !== false) {
-            //         // CERT unavailable. Not our fault, so will ignore.
-            //         return;
-            //     }
-
-            //     return;
-            // }
-
-            // if (isset($_prevRat->PreviousRatingInt)) {
-            //     $prevAtcRating = Qualification::parseVatsimATCQualification($_prevRat->PreviousRatingInt);
-
-            //     if ($prevAtcRating) {
-            //         $member->addQualification($prevAtcRating);
-            //     }
-            // }
-        }
-
-        // if they're a division member, or their current rating isn't instructor, log their 'main' rating
-        if (($member_data['rating_atc'] < 8) || $member->hasState('DIVISION')) {
-            $atcRating = Qualification::parseVatsimATCQualification($member_data['rating_atc']);
-
-            if ($atcRating) {
-                $member->addQualification($atcRating);
-            }
-        }
-
-        // anything else is processed by the Members:CertUpdate script
-
-        if ($member->hasState('DIVISION') && $member->email) {
-            $member->notify(new WelcomeMember());
-        }
-    }
-
-    protected function updateMember($member_data)
-    {
-        $member = Account::find($member_data['cid']);
-        $member->name_first = $member_data['name_first'];
-        $member->name_last = $member_data['name_last'];
-        $member->email = $member_data['email'];
-        $member->save();
-
-        $member->addState(State::findByCode('DIVISION'), 'EMEA', 'GBR');
-    }
-
-    protected function getMemberIdAndEmail()
-    {
-        return DB::table('mship_account')
-            ->pluck('email', 'id');
+        $account->wasRecentlyCreated ?? $account->notify(new WelcomeMember());
+        $account->wasRecentlyCreated ? $this->countNewlyCreated++ : $this->countUpdated++;
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -69,10 +69,6 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('schedule-monitor:clean')
             ->dailyAt('08:00');
-
-        $schedule->command('members:certimport', ['--full'])
-            ->twiceDaily(4, 15)
-            ->graceTimeInMinutes(30);
     }
 
     /**

--- a/app/Listeners/Mship/SyncSubscriber.php
+++ b/app/Listeners/Mship/SyncSubscriber.php
@@ -11,7 +11,6 @@ use App\Jobs\Mship\SyncToForums;
 use App\Jobs\Mship\SyncToHelpdesk;
 use App\Jobs\Mship\SyncToMoodle;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Log;
 
 class SyncSubscriber
 {

--- a/app/Listeners/Mship/SyncSubscriber.php
+++ b/app/Listeners/Mship/SyncSubscriber.php
@@ -37,8 +37,6 @@ class SyncSubscriber
         if ($event->account->discord_id) {
             SyncToDiscord::dispatch($event->account);
         }
-
-        Log::debug($event->account->real_name.' ('.$event->account->id.') was queued to sync to external services');
     }
 
     /**

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -192,6 +192,7 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
         'password',
         'password_set_at',
         'password_expires_at',
+        'joined_at',
     ];
     protected $attributes = [
         'name_first'    => '',

--- a/app/Models/Mship/Concerns/HasQualifications.php
+++ b/app/Models/Mship/Concerns/HasQualifications.php
@@ -58,8 +58,8 @@ trait HasQualifications
     /**
      * Add qualifications to the account, calculated from the VATSIM identifiers.
      *
-     * @param int $atcRating The VATSIM ATC rating
-     * @param int $pilotRating The VATSIM pilot rating
+     * @param int|null $atcRating The VATSIM ATC rating
+     * @param int|null $pilotRating The VATSIM pilot rating
      */
     public function updateVatsimRatings(?int $atcRating, ?int $pilotRating)
     {

--- a/app/Models/Mship/Concerns/HasQualifications.php
+++ b/app/Models/Mship/Concerns/HasQualifications.php
@@ -61,7 +61,7 @@ trait HasQualifications
      * @param int $atcRating The VATSIM ATC rating
      * @param int $pilotRating The VATSIM pilot rating
      */
-    public function updateVatsimRatings(int $atcRating, int $pilotRating)
+    public function updateVatsimRatings(?int $atcRating, ?int $pilotRating)
     {
         if ($atcRating === 0) {
             $this->addNetworkBan('Network ban discovered via Cert login.');


### PR DESCRIPTION
The current `ImportMember` script was disabled in production. Upon enabling it, I found a few issues and rather than digging into each one decided to try and clean it up a tad.

Given that we now have the `AccountAltered` event, the only thing this command needs to do is create the initial account with the minimum information required. Everything else (qualifications, states etc) will be handled by the subsequent run of the `SyncSubscriber`.

To use this command, you will need;

- A VATSIM API key for GBR
- To ensure that your database is running with the timezone of +00:00 (SELECT @@global.time_zone; / SET GLOBAL time_zone = '+00:00';) as some users have a registration date that is in a time that doesn't exist in BST (e.g. 01:05AM on the day clocks change)

The command will;

- Fetch all users from the VATSIM API that belong to GBR
- Honour the pagniation of this endpoint to ensure all users are obtained
- Handle any API downtime during the command running by exiting the while loop and proceeding with the members it has at the point the API goes down
- Validate the data for each member prior to proceeding to ensure the data is in the format we expect, skipping any that return unexpected data
- Create or update (depending on whether the id currently exists) an `Account`
- For newly created accounts, dispatch the `WelcomeMember` notification
- Not touch any qualifications, ratings or other data that is handled by the update process that follows a change in the account via model events
- Output helpful information on the progress of the command

The command is fairly slow on the first run on a fresh database as you are importing every single member. Subsequent runs that are mostly performing updates are much quicker.