### PR TITLE
Import Members Performance Improvements

### DIFF
--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -19,7 +19,6 @@ class ImportMembers extends Command
 
     protected string $apiToken;
 
-    protected Collection $existingMembers;
     protected Collection $importedMembers;
 
     protected int $countNewlyCreated = 0;
@@ -29,7 +28,6 @@ class ImportMembers extends Command
     public function handle()
     {
         $this->apiToken = config('vatsim-api.key');
-        $this->existingMembers = DB::table('mship_account')->pluck('id');
         $this->importedMembers = collect();
 
         $this->getMembers();

--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -89,6 +89,7 @@ class ImportMembers extends Command
                 'email' => $member['email'],
                 'joined_at' => Carbon::create($member['reg_date']),
                 'inactive' => (int) $member['rating'] < 0,
+                'cert_checked_at' => now()
             ]
         );
 

--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -43,6 +43,8 @@ class ImportMembers extends Command
                 'name_last' => 'required|string',
                 'email' => 'required|email',
                 'reg_date' => 'required|date',
+                'region' => 'required|string',
+                'division' => 'required|string',
             ]);
 
             $validator->fails() ? $this->countSkipped++ : $this->processMember($member);
@@ -95,8 +97,10 @@ class ImportMembers extends Command
         );
 
         $account->updateVatsimRatings($member['rating'], $member['pilotrating']);
+        $account->updateDivision($member['division'], $member['region']);
 
         $this->importedMembers->pull($member['id']);
+
         $account->wasRecentlyCreated ?? $account->notify(new WelcomeMember());
         $account->wasRecentlyCreated ? $this->countNewlyCreated++ : $this->countUpdated++;
     }

--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -38,6 +38,7 @@ class ImportMembers extends Command
             $validator = Validator::make($member, [
                 'id' => 'required|integer',
                 'rating' => 'required|integer',
+                'pilotrating' => 'required|int',
                 'name_first' => 'required|string',
                 'name_last' => 'required|string',
                 'email' => 'required|email',
@@ -93,6 +94,7 @@ class ImportMembers extends Command
             ]
         );
 
+        $account->updateVatsimRatings($member['rating'], $member['pilotrating']);
 
         $this->importedMembers->pull($member['id']);
         $account->wasRecentlyCreated ?? $account->notify(new WelcomeMember());

--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -92,6 +92,8 @@ class ImportMembers extends Command
             ]
         );
 
+
+        $this->importedMembers->pull($member['id']);
         $account->wasRecentlyCreated ?? $account->notify(new WelcomeMember());
         $account->wasRecentlyCreated ? $this->countNewlyCreated++ : $this->countUpdated++;
     }

--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -79,6 +79,8 @@ class ImportMembers extends Command
             }
         }
 
+        $this->importedMembers = $this->importedMembers->keyBy('id');
+
         $this->info("{$this->importedMembers->count()} members obtained from VATSIM API.");
     }
 

--- a/app/Console/Commands/Members/ImportMembers.php
+++ b/app/Console/Commands/Members/ImportMembers.php
@@ -36,7 +36,7 @@ class ImportMembers extends Command
         $response = $this->apiRequest->get(config('vatsim-api.base').'divisions/GBR/members/?paginated');
 
         $this->info("Total of {$response->collect()->get('count')} members to process.");
-        $this->totalPages = round($response->collect()->get('count') / 1000, 0, PHP_ROUND_HALF_UP);
+        $this->totalPages = round($response->collect()->get('count') / 1000, 0, PHP_ROUND_HALF_UP) + 1;
 
         $this->info("Processing page {$this->currentPage} of {$this->totalPages}...");
         $this->withProgressBar($response->collect()->get('results'), function ($member) {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -55,9 +55,9 @@ class Kernel extends ConsoleKernel
             ->hourlyAt(15)
             ->graceTimeInMinutes(15);
 
-        // $schedule->command('members:certimport')
-        //    ->everyTwoHours()
-        //    ->graceTimeInMinutes(15);
+        $schedule->command('members:certimport')
+           ->everyTwoHours()
+           ->graceTimeInMinutes(15);
 
         // === By Day === //
 

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -193,6 +193,7 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
         'password_set_at',
         'password_expires_at',
         'joined_at',
+        'cert_checked_at',
     ];
     protected $attributes = [
         'name_first'    => '',


### PR DESCRIPTION
Currently, the ImportMembers command gets all members from the API and loads them into memory. Tens of thousands of collections loaded does have an impact on memory usage.

My first thought was to discard each member from the collection as they are processed, but the first 2-3 minutes of the command being ran was still quite resource intensive.

I've now refactored the command so that instead of loading all of the members into memory, we process one page of the API at a time on the fly before returning back to the API for the next batch, processing them and repeating. I have also updated the console output to help show the progress across these calls as below.

<img width="475" alt="image" src="https://user-images.githubusercontent.com/7726792/129457164-7016422c-d826-492f-bb4a-3ad211b25812.png">

Also included within this PR is an update that now processes the member's ATC rating, Pilot rating, Division & Region. This means that if the user has a different rating it should update more quickly than currently & force an `AccountAltered` event to fire to cascade to other services.

Finally, this PR adds a stamp on `mship_account.cert_checked_at` when the user is processed via this command.