### PR TITLE
feat: Add base training place configuration and offer workflow

### DIFF
--- a/app/Events/Training/TrainingPlaceOffered.php
+++ b/app/Events/Training/TrainingPlaceOffered.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events\Training;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+
+class TrainingPlaceOffered
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    private $offer;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(TrainingPlaceOffer $offer)
+    {
+        $this->offer = $offer;
+    }
+
+    public function getTrainingPlaceOffer() : TrainingPlaceOffer
+    {
+        return $this->offer;
+    }
+}

--- a/app/Models/Training/TrainingPlace.php
+++ b/app/Models/Training/TrainingPlace.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\Training;
+
+use App\Models\Mship\Account;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+
+class TrainingPlace extends Model
+{
+    use HasFactory;
+
+    protected $casts = [
+        'places' => 'integer'
+    ];
+
+    protected $fillable = [
+        'training_position_id'
+    ];
+
+    public function account() : BelongsTo
+    {
+        return $this->belongsTo(Account::class);
+    }
+
+    public function trainingPosition() : BelongsTo
+    {
+        return $this->belongsTo(TrainingPosition::class);
+    }
+}

--- a/app/Models/Training/TrainingPlace/TrainingPlaceOffer.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlaceOffer.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models\Training\TrainingPlace;
+
+use App\Models\Mship\Account;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+
+class TrainingPlaceOffer extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $primaryKey = 'offer_id';
+
+    protected $fillable = [
+        'account_id',
+        'offer_id',
+        'offered_by',
+        'expires_at',
+        'reminder_sent_at',
+        'training_position_id',
+    ];
+
+    public function account() : BelongsTo
+    {
+        return $this->belongsTo(Account::class);
+    }
+
+    public function trainingPosition() : BelongsTo
+    {
+        return $this->belongsTo(TrainingPosition::class);
+    }
+}

--- a/app/Models/Training/TrainingPlace/TrainingPosition.php
+++ b/app/Models/Training/TrainingPlace/TrainingPosition.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models\Training\TrainingPlace;
+
+use App\Models\Station;
+use App\Models\Training\WaitingList;
+use App\Models\Training\TrainingPlace;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class TrainingPosition extends Model
+{
+    use HasFactory;
+
+    public function station() : BelongsTo
+    {
+        return $this->belongsTo(Station::class);
+    }
+
+    public function trainingPlaces() : HasMany
+    {
+        return $this->hasMany(TrainingPlace::class);
+    }
+
+    public function waitingList() : BelongsTo
+    {
+        return $this->belongsTo(WaitingList::class);
+    }
+
+    /**
+    * Generate a list of available training positions for a waiting list
+    * based upon the places configured and also related
+    *
+    * @return array
+    */
+    public static function availablePlacesForWaitingList(WaitingList $waitingList)
+    {
+        $positions = self::with('station')
+            ->withCount('trainingPlaces')
+            ->where('waiting_list_id', $waitingList->id)
+            ->get();
+
+        return $positions->reject(function ($position) {
+            return (int)$position->training_places_count === (int)$position->places;
+        })->map(function ($position) {
+            return ['id' => $position->id, 'callsign' => $position->station->callsign];
+        })->toArray();
+    }
+}

--- a/app/Notifications/Training/TrainingPlaceOffer.php
+++ b/app/Notifications/Training/TrainingPlaceOffer.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
+// TODO: Flesh out notification
 class TrainingPlaceOffer extends Notification
 {
     use Queueable;

--- a/app/Notifications/Training/TrainingPlaceOffer.php
+++ b/app/Notifications/Training/TrainingPlaceOffer.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Notifications\Training;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TrainingPlaceOffer extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->line('The introduction to the notification.')
+                    ->action('Notification Action', url('/'))
+                    ->line('Thank you for using our application!');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Nova/Station.php
+++ b/app/Nova/Station.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class Station extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var string
+     */
+    public static $model = \App\Models\Station::class;
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'callsign';
+
+    /**
+     * The columns that should be searched.
+     *
+     * @var array
+     */
+    public static $search = [
+        'id',
+    ];
+
+    /**
+     * Get the fields displayed by the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function fields(Request $request)
+    {
+        return [
+            ID::make(__('ID'), 'id')->sortable(),
+        ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function cards(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the filters available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function filters(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the lenses available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function lenses(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function actions(Request $request)
+    {
+        return [];
+    }
+}

--- a/app/Nova/TrainingPlace.php
+++ b/app/Nova/TrainingPlace.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Nova;
+
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class TrainingPlace extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var string
+     */
+    public static $model = \App\Models\Training\TrainingPlace::class;
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'id';
+
+    /**
+     * The columns that should be searched.
+     *
+     * @var array
+     */
+    public static $search = [
+        'id',
+    ];
+
+    /**
+     * Get the fields displayed by the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function fields(Request $request)
+    {
+        return [
+            ID::make(__('ID'), 'id')->sortable(),
+
+            BelongsTo::make('Account'),
+        ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function cards(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the filters available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function filters(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the lenses available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function lenses(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function actions(Request $request)
+    {
+        return [];
+    }
+
+    public static function authorizedToCreate(Request $request)
+    {
+        return false;
+    }
+}

--- a/app/Nova/TrainingPosition.php
+++ b/app/Nova/TrainingPosition.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Nova;
+
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Number;
+use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Fields\HasMany;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use App\Models\Cts\Position;
+
+class TrainingPosition extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var string
+     */
+    public static $model = \App\Models\Training\TrainingPlace\TrainingPosition::class;
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'id';
+
+    /**
+     * The columns that should be searched.
+     *
+     * @var array
+     */
+    public static $search = [
+        'id',
+    ];
+
+    public static $group = 'Training';
+
+    /**
+     * Get the fields displayed by the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function fields(Request $request)
+    {
+        return [
+            ID::make(__('ID'), 'id')->sortable(),
+
+            BelongsTo::make('Station')->nullable()->help('Station is required for an ATC position'),
+
+            BelongsTo::make('Waiting List', 'waitingList')->help('Waiting list from which places are offered.'),
+
+            Select::make('CTS Position', 'cts_position_id')->options(
+                Position::orderBy('callsign')->pluck('callsign', 'id')
+            )->displayUsingLabels(),
+
+            Number::make('Places', 'places')->placeholder('Number of Available Places'),
+
+            HasMany::make('Training Places', 'trainingPlaces'),
+        ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function cards(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the filters available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function filters(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the lenses available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function lenses(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function actions(Request $request)
+    {
+        return [];
+    }
+}

--- a/app/Services/Training/OfferTrainingPlace.php
+++ b/app/Services/Training/OfferTrainingPlace.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services\Training;
+
+use Carbon\Carbon;
+use Ramsey\Uuid\Uuid;
+use App\Models\Mship\Account;
+use App\Services\BaseService;
+use App\Events\Training\TrainingPlaceOffered;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+
+class OfferTrainingPlace implements BaseService
+{
+    private $trainingPosition;
+    private $account;
+    private $offeringAccount;
+    private $expiryHours;
+
+    public function __construct(TrainingPosition $trainingPosition, Account $account, Account $offeringAccount, int $expiryHours = 72)
+    {
+        $this->trainingPosition = $trainingPosition;
+        $this->account = $account;
+        $this->offeringAccount = $offeringAccount;
+        $this->expiryHours = $expiryHours;
+    }
+
+    public function handle()
+    {
+        $offer = TrainingPlaceOffer::create([
+            'account_id' => $this->account->id,
+            'offer_id' => Uuid::uuid4(),
+            'offered_by' => $this->offeringAccount->id,
+            'expires_at' => Carbon::now()->addHours($this->expiryHours),
+            'training_position_id' => $this->trainingPosition->id
+        ]);
+
+        event(new TrainingPlaceOffered($offer));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
         "planetteamspeak/ts3-php-framework": "dev-master#9e987b61b8e559b4219d30b140b8edbeb94edece",
         "predis/predis": "^1.1",
         "pusher/pusher-php-server": "~6.0",
+        "ramsey/uuid": "^4.2",
         "sentry/sentry-laravel": "^2.4",
         "sixlive/nova-text-copy-field": "^1.5",
         "spatie/laravel-cookie-consent": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "598e062e76e88602195e1d977be567b0",
+    "content-hash": "e3b5bd85fb11236cf98fd2dd6cd1755b",
     "packages": [
         {
             "name": "alawrence/laravel-ipboard",
@@ -6657,16 +6657,16 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.1.1",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "cd4032040a750077205918c86049aa0f43d22947"
+                "reference": "fe665a03df4f056aa65af552a96e1976df8c8dae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/cd4032040a750077205918c86049aa0f43d22947",
-                "reference": "cd4032040a750077205918c86049aa0f43d22947",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fe665a03df4f056aa65af552a96e1976df8c8dae",
+                "reference": "fe665a03df4f056aa65af552a96e1976df8c8dae",
                 "shasum": ""
             },
             "require": {
@@ -6680,26 +6680,26 @@
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "codeception/aspect-mock": "^3",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7.0",
+                "captainhook/captainhook": "^5.10",
+                "captainhook/plugin-composer": "^5.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
                 "doctrine/annotations": "^1.8",
-                "goaop/framework": "^2",
+                "ergebnis/composer-normalize": "^2.15",
                 "mockery/mockery": "^1.3",
                 "moontoast/math": "^1.1",
                 "paragonie/random-lib": "^2",
+                "php-mock/php-mock": "^2.2",
                 "php-mock/php-mock-mockery": "^1.3",
-                "php-mock/php-mock-phpunit": "^2.5",
                 "php-parallel-lint/php-parallel-lint": "^1.1",
-                "phpbench/phpbench": "^0.17.1",
+                "phpbench/phpbench": "^1.0",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^0.12",
                 "phpstan/phpstan-mockery": "^0.12",
                 "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^8.5",
-                "psy/psysh": "^0.10.0",
-                "slevomat/coding-standard": "^6.0",
+                "phpunit/phpunit": "^8.5 || ^9",
+                "slevomat/coding-standard": "^7.0",
                 "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "3.9.4"
+                "vimeo/psalm": "^4.9"
             },
             "suggest": {
                 "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
@@ -6712,7 +6712,10 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-main": "4.x-dev"
+                },
+                "captainhook": {
+                    "force-install": true
                 }
             },
             "autoload": {
@@ -6728,7 +6731,6 @@
                 "MIT"
             ],
             "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
-            "homepage": "https://github.com/ramsey/uuid",
             "keywords": [
                 "guid",
                 "identifier",
@@ -6736,16 +6738,19 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "rss": "https://github.com/ramsey/uuid/releases.atom",
-                "source": "https://github.com/ramsey/uuid"
+                "source": "https://github.com/ramsey/uuid/tree/4.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/ramsey",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ramsey/uuid",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2020-08-18T17:17:46+00:00"
+            "time": "2021-08-11T01:06:55+00:00"
         },
         {
             "name": "react/promise",

--- a/database/factories/Training/TrainingPlace/TrainingPlaceOfferFactory.php
+++ b/database/factories/Training/TrainingPlace/TrainingPlaceOfferFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories\Training\TrainingPlace;
+
+use Carbon\Carbon;
+use Ramsey\Uuid\Uuid;
+use App\Models\Mship\Account;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+
+class TrainingPlaceOfferFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = TrainingPlaceOffer::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'offer_id' => Uuid::uuid4()->toString(),
+            'account_id' => factory(Account::class)->create()->id,
+            'offered_by' => factory(Account::class)->create()->id,
+            'expires_at' => Carbon::now()->addHours(72),
+        ];
+    }
+}

--- a/database/factories/Training/TrainingPlace/TrainingPositionFactory.php
+++ b/database/factories/Training/TrainingPlace/TrainingPositionFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories\Training\TrainingPlace;
+
+use App\Models\Station;
+use App\Models\Cts\Position;
+use App\Models\Training\WaitingList;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+
+class TrainingPositionFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = TrainingPosition::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'station_id' => factory(Station::class)->create()->id,
+            'cts_position_id' => factory(Position::class)->create()->id,
+            'waiting_list_id' => factory(WaitingList::class)->create()->id,
+            'places' => 1
+        ];
+    }
+}

--- a/database/factories/Training/TrainingPlaceFactory.php
+++ b/database/factories/Training/TrainingPlaceFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories\Training;
+
+use Carbon\Carbon;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+
+class TrainingPlaceFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = TrainingPlace::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'training_position_id' => function() {
+                return TrainingPosition::factory()->create()->id;
+            },
+            'account_id' => factory(Account::class)->create()->id,
+            'offer_id' => TrainingPlaceOffer::factory()->create()->offer_id,
+            'accepted_at' => Carbon::now()
+        ];
+    }
+}

--- a/database/migrations/2021_08_27_125755_create_training_places_table.php
+++ b/database/migrations/2021_08_27_125755_create_training_places_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTrainingPlacesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('training_places', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('training_position_id');
+            $table->unsignedInteger('account_id');
+            $table->uuid('offer_id');
+            $table->timestamp('accepted_at');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('training_places');
+    }
+}

--- a/database/migrations/2021_08_27_130409_create_training_positions_table.php
+++ b/database/migrations/2021_08_27_130409_create_training_positions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTrainingPositionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('training_positions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('station_id')->nullable();
+            $table->unsignedInteger('cts_position_id');
+            $table->unsignedInteger('waiting_list_id');
+            $table->unsignedInteger('places')->comment('Maximum number of training places available for this position.');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('training_positions');
+    }
+}

--- a/database/migrations/2021_08_28_100948_create_training_place_offers_table.php
+++ b/database/migrations/2021_08_28_100948_create_training_place_offers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTrainingPlaceOffersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('training_place_offers', function (Blueprint $table) {
+            $table->uuid('offer_id');
+            $table->primary('offer_id');
+            $table->unsignedInteger('account_id');
+            $table->unsignedInteger('offered_by');
+            $table->unsignedInteger('training_position_id');
+            $table->timestamp('expires_at');
+            $table->timestamp('reminder_sent_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('training_place_offers');
+    }
+}

--- a/nova-components/WaitingListsManager/resources/js/components/Bucket.vue
+++ b/nova-components/WaitingListsManager/resources/js/components/Bucket.vue
@@ -17,6 +17,7 @@
                     <th class="text-left" v-if="showHourChecker">Hour Check</th>
                     <th>Status Change</th>
                     <th>Flags</th>
+                    <th v-if="eligibleList">Training Place</th>
                     <th></th>
                 </tr>
                 </thead>
@@ -61,6 +62,9 @@
                             @changeFlag="changeFlag"
                         ></flag-indicator>
                     </td>
+                    <td v-if="eligibleList">
+                        <button class="btn btn-sm btn-outline" @click="offerPlace(account.id)">Offer Training</button>
+                    </td>
                     <td>
                         <div class="flex justify-around">
                             <button class="cursor-pointer text-70 hover:text-primary mr-3"
@@ -81,7 +85,7 @@
     export default {
         name: "Bucket",
 
-        props: ['accounts', 'title', 'type'],
+        props: ['accounts', 'title', 'type', 'eligibleList'],
 
         data() {
             return {
@@ -100,6 +104,10 @@
 
             activeAccount(account) {
                 this.$emit('activeAccount', { account: account })
+            },
+
+            offerPlace(account) {
+                this.$emit('offerPlace', { account: account })
             },
 
             changeNote(account) {

--- a/nova-components/WaitingListsManager/resources/js/components/NoteIndicator.vue
+++ b/nova-components/WaitingListsManager/resources/js/components/NoteIndicator.vue
@@ -21,7 +21,6 @@
 
         methods: {
             changeNote(account) {
-                console.log('changed')
                 this.$emit('changeNote', { account: account })
             }
         }

--- a/nova-components/WaitingListsManager/resources/js/components/OfferTrainingPlaceModal.vue
+++ b/nova-components/WaitingListsManager/resources/js/components/OfferTrainingPlaceModal.vue
@@ -1,0 +1,82 @@
+<template>
+    <modal
+        role="dialog"
+    >
+        <loading-card :loading="loading">
+            <form
+                class="bg-white roudned-lg shadow-lg overflow-hidden w-action-fields"
+                @submit.prevent.stop="handleSubmit"
+            >
+                <heading :level="2" class="mb-2 p-8">Offer Training Place</heading>
+                <main class="p-8">
+                    <div class="flex items-center">
+                        <label for="" class="w-1/4 font-normal text-80">Position</label>
+                        <select class="form-control form-select" v-model="selectedPosition">
+                            <option value="default" disabled selected>Select Position</option>
+                            <option v-for="place in places" :key="place.id" :value="place.id">
+                                {{ place.callsign }}
+                            </option>
+                        </select>
+                    </div>
+                </main>
+                <footer class="bg-30 px-6 py-3 flex justify-end">
+                    <button
+                        type="reset"
+                        @click.prevent="handleClose"
+                        class="btn text-80 font-normal h-9 px-3 mr-3 btn-link"
+                    >
+                        {{ __('Cancel') }}
+                    </button>
+                    <button
+                        type="submit"
+                        class="btn btn-default btn-primary"
+                        :disabled="buttonDisabled"
+                    >
+                        {{ __('Submit') }}
+                    </button>
+                </footer>
+            </form>
+
+        </loading-card>
+    </modal>
+</template>
+
+<script>
+export default {
+    name: "OfferTrainingPlaceModal",
+
+    props: ['waitingList'],
+
+    data() {
+        return {
+            places: [],
+            selectedPosition: 'default',
+            loading: true
+        }
+    },
+
+    computed: {
+        buttonDisabled() {
+            return this.selectedPosition === 'default' || this.selectedPosition === null;
+        }
+    },
+
+    created() {
+        this.loading = true;
+        Nova.request().get(`/nova-vendor/waiting-lists-manager/waitingLists/${this.waitingList}/available-places`)
+            .then(response => {
+                this.places = response.data.places;
+                this.loading = false;
+            })
+    },
+
+    methods: {
+        handleSubmit() {
+            this.$emit('submit', { position: this.selectedPosition });
+        },
+        handleClose() {
+            this.$emit('close')
+        }
+    }
+}
+</script>

--- a/nova-components/WaitingListsManager/resources/js/tool.js
+++ b/nova-components/WaitingListsManager/resources/js/tool.js
@@ -1,6 +1,7 @@
 Nova.booting((Vue, router) => {
     Vue.component('waiting-lists-manager', require('./components/Tool').default),
     Vue.component('confirm-flag-change-modal', require('./components/ConfirmFlagChangeModal').default),
+    Vue.component('offer-training-place-modal', require('./components/OfferTrainingPlaceModal').default),
     Vue.component('text-input-modal', require('./components/TextInputModal').default),
     Vue.component('flag-indicator', require('./components/FlagIndicator').default),
     Vue.component('note-indicator', require('./components/NoteIndicator').default),

--- a/nova-components/WaitingListsManager/routes/api.php
+++ b/nova-components/WaitingListsManager/routes/api.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Facades\Route;
 
+Route::get('/waitingLists/{waitingList}/available-places', 'Vatsimuk\WaitingListsManager\Http\WaitingListsManagerController@getAvailablePlaces');
+
 Route::get('/accounts/{waitingList}', 'Vatsimuk\WaitingListsManager\Http\WaitingListsManagerController@index');
 Route::post('/accounts/{waitingList}/remove', 'Vatsimuk\WaitingListsManager\Http\WaitingListsManagerController@destroy');
 Route::post('/accounts/{waitingList}/promote', 'Vatsimuk\WaitingListsManager\Http\WaitingListsManagerController@promote');
@@ -13,3 +15,7 @@ Route::patch('/accounts/{waitingList}/active', 'Vatsimuk\WaitingListsManager\Htt
 Route::patch('/notes/{waitingListAccount}/create', 'Vatsimuk\WaitingListsManager\Http\WaitingListNoteController@create');
 
 Route::patch('/flag/{waitingListAccountFlag}/toggle', 'Vatsimuk\WaitingListsManager\Http\WaitingListFlagController@toggle');
+
+Route::post('/waitingLists/{waitingList}/position/{trainingPosition}/offer',
+    'Vatsimuk\WaitingListsManager\Http\WaitingListsManagerController@offerTrainingPlace'
+);

--- a/nova-components/WaitingListsManager/src/Http/WaitingListsManagerController.php
+++ b/nova-components/WaitingListsManager/src/Http/WaitingListsManagerController.php
@@ -81,7 +81,7 @@ class WaitingListsManagerController extends Controller
     {
         try {
             $account = Account::findOrFail($request->get('account_id'));
-        } catch (ModelNotFoundException) {
+        } catch (ModelNotFoundException $e) {
             return response()->json(['message' => 'Account not found'], 400);
         }
 

--- a/nova-components/WaitingListsManager/src/Http/WaitingListsManagerController.php
+++ b/nova-components/WaitingListsManager/src/Http/WaitingListsManagerController.php
@@ -2,19 +2,19 @@
 
 namespace Vatsimuk\WaitingListsManager\Http;
 
-use Illuminate\Http\Request;
-use App\Models\Mship\Account;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Routing\Controller;
-use App\Models\Training\WaitingList;
-use Illuminate\Support\Facades\Auth;
-use App\Services\Training\OfferTrainingPlace;
-use App\Models\Training\WaitingList\WaitingListStatus;
-use App\Models\Training\TrainingPlace\TrainingPosition;
-use App\Models\Training\WaitingList\WaitingListAccount;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Events\Training\AccountChangedStatusInWaitingList;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+use App\Models\Training\WaitingList;
+use App\Models\Training\WaitingList\WaitingListAccount;
+use App\Models\Training\WaitingList\WaitingListStatus;
+use App\Services\Training\OfferTrainingPlace;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
 
 class WaitingListsManagerController extends Controller
 {
@@ -73,11 +73,11 @@ class WaitingListsManagerController extends Controller
     public function getAvailablePlaces(WaitingList &$waitingList)
     {
         return response()->json([
-            'places' => TrainingPosition::availablePlacesForWaitingList($waitingList)
+            'places' => TrainingPosition::availablePlacesForWaitingList($waitingList),
         ]);
     }
 
-    public function offerTrainingPlace(WaitingList &$waitingList, TrainingPosition $trainingPosition, Request $request) : JsonResponse
+    public function offerTrainingPlace(WaitingList &$waitingList, TrainingPosition $trainingPosition, Request $request): JsonResponse
     {
         try {
             $account = Account::findOrFail($request->get('account_id'));
@@ -85,7 +85,7 @@ class WaitingListsManagerController extends Controller
             return response()->json(['message' => 'Account not found'], 400);
         }
 
-        if (!$this->getWaitingListAccounts($waitingList, true)->pluck('id')->contains($account->id)) {
+        if (! $this->getWaitingListAccounts($waitingList, true)->pluck('id')->contains($account->id)) {
             return response()->json(['message' => 'Account not eligible for training place.'], 403);
         }
 

--- a/nova-components/WaitingListsManager/src/ToolServiceProvider.php
+++ b/nova-components/WaitingListsManager/src/ToolServiceProvider.php
@@ -2,14 +2,15 @@
 
 namespace Vatsimuk\WaitingListsManager;
 
+use Laravel\Nova\Nova;
 use App\Models\Training\WaitingList;
-use App\Models\Training\WaitingList\WaitingListAccount;
-use App\Models\Training\WaitingList\WaitingListAccountFlag;
-use Illuminate\Routing\Middleware\SubstituteBindings;
+use Laravel\Nova\Events\ServingNova;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use Laravel\Nova\Events\ServingNova;
-use Laravel\Nova\Nova;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+use App\Models\Training\WaitingList\WaitingListAccount;
+use App\Models\Training\WaitingList\WaitingListAccountFlag;
 
 class ToolServiceProvider extends ServiceProvider
 {
@@ -40,6 +41,7 @@ class ToolServiceProvider extends ServiceProvider
         Route::model('waitingList', WaitingList::class);
         Route::model('waitingListAccount', WaitingListAccount::class);
         Route::model('waitingListAccountFlag', WaitingListAccountFlag::class);
+        Route::model('trainingPosition', TrainingPosition::class);
 
         if ($this->app->routesAreCached()) {
             return;

--- a/resources/views/vendor/nova/partials/meta.blade.php
+++ b/resources/views/vendor/nova/partials/meta.blade.php
@@ -1,8 +1,3 @@
 {{-- <link rel="icon" type="image/png" href="{{ asset('/img/favicon.png') }} "> --}}
 <style>
-{{-- styling to fix overflow issue in nova index tables --}}
-.flex-no-shrink {
-    flex-shrink: 1;
-    white-space: pre-line;
-}
 </style>

--- a/tests/Feature/Training/TrainingPlace/TrainingPlaceOfferUserTest.php
+++ b/tests/Feature/Training/TrainingPlace/TrainingPlaceOfferUserTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature\Training\TrainingPlace;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class TrainingPlaceOfferUserTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function test_example()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Training/TrainingPlace/TrainingPlaceOfferUserTest.php
+++ b/tests/Feature/Training/TrainingPlace/TrainingPlaceOfferUserTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Training\TrainingPlace;
 
 use Tests\TestCase;
 
+// TODO
 class TrainingPlaceOfferUserTest extends TestCase
 {
     /**

--- a/tests/Feature/Training/WaitingListFeatureTest.php
+++ b/tests/Feature/Training/WaitingListFeatureTest.php
@@ -2,16 +2,18 @@
 
 namespace Tests\Feature\Training;
 
-use App\Events\Training\AccountChangedStatusInWaitingList;
-use App\Events\Training\AccountNoteChanged;
+use Tests\TestCase;
 use App\Models\Mship\Account;
+use App\Models\NetworkData\Atc;
 use App\Models\Training\WaitingList;
-use App\Models\Training\WaitingList\WaitingListFlag;
-use App\Services\Training\AddToWaitingList;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
-use Tests\TestCase;
+use App\Events\Training\AccountNoteChanged;
+use App\Services\Training\AddToWaitingList;
+use App\Events\Training\TrainingPlaceOffered;
+use App\Models\Training\WaitingList\WaitingListFlag;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\Events\Training\AccountChangedStatusInWaitingList;
 
 class WaitingListFeatureTest extends TestCase
 {

--- a/tests/Feature/Training/WaitingListTrainingPlaceFeatureTest.php
+++ b/tests/Feature/Training/WaitingListTrainingPlaceFeatureTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature\Training;
+
+use Tests\TestCase;
+use App\Models\Mship\Account;
+use App\Models\NetworkData\Atc;
+use App\Models\Training\WaitingList;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Route;
+use App\Events\Training\TrainingPlaceOffered;
+use App\Models\Training\WaitingList\WaitingListStatus;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class WaitingListTrainingPlaceFeatureTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private $waitingList;
+    private $account;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $this->markNovaTest();
+
+        $this->waitingList = factory(WaitingList::class)->create();
+
+        $this->account = factory(Account::class)->create();
+
+        // add them to the waiting list
+        $this->waitingList->addToWaitingList($this->account, $this->privacc);
+
+        // stop nova middleware to test the endpoints in isolation
+        Route::middlewareGroup('nova', []);
+    }
+
+    public function testTrainingPlaceCanBeOfferedToStudentEligibleOnWaitingList()
+    {
+        // create a training position with no assigned training places
+        $trainingPosition = TrainingPosition::factory()->create(['waiting_list_id' => $this->waitingList->id, 'places' => 1]);
+
+        // find the active status for a waiting list account
+        $status = WaitingListStatus::find(WaitingListStatus::DEFAULT_STATUS);
+
+        // finds the account in the waiting list
+        $waitingListAccount = $this->waitingList->accounts()->findOrFail($this->account->id)->pivot;
+        // adds the status to make account eligible.
+        $waitingListAccount->addStatus($status);
+
+        // create valid network data to pass ATC hour check
+        factory(Atc::class)->create(['minutes_online' => 721, 'account_id' => $this->account->id, 'disconnected_at' => now()]);
+
+        Event::fakeFor(function() use ($trainingPosition) {
+            $this->actingAs($this->privacc)
+                ->post("nova-vendor/waiting-lists-manager/waitingLists/{$this->waitingList->id}/position/{$trainingPosition->id}/offer",
+                    [
+                        'account_id' => $this->account->id,
+                    ]
+                )
+                ->assertStatus(201);
+
+            Event::assertDispatched(TrainingPlaceOffered::class, function ($event) use ($trainingPosition) {
+                return $event->getTrainingPlaceOffer()->trainingPosition->id == $trainingPosition->id
+                    && $event->getTrainingPlaceOffer()->account->id == $this->account->id;
+            });
+        });
+    }
+
+    /** @test */
+    public function testTrainingPlaceCannotBeOfferedToIneligibleAccount()
+    {
+        $this->withoutExceptionHandling();
+        // create a training position with no assigned training places
+        $trainingPosition = TrainingPosition::factory()->create(['waiting_list_id' => $this->waitingList->id, 'places' => 1]);
+
+        // create an account without ATC hours and no valid status.
+        $differentAccountWithoutHours = factory(Account::class)->create();
+
+        $this->waitingList->addToWaitingList($differentAccountWithoutHours, $this->privacc);
+
+        Event::fakeFor(function() use ($trainingPosition) {
+            $this->actingAs($this->privacc)
+            ->post("nova-vendor/waiting-lists-manager/waitingLists/{$this->waitingList->id}/position/{$trainingPosition->id}/offer",
+                [
+                    'account_id' => $this->account->id,
+                ]
+            )
+            ->assertStatus(403);
+
+            Event::assertNotDispatched(TrainingPlaceOffered::class);
+        });
+    }
+
+    /** @test */
+    public function testReturns400StatusCodeWhenInvalidAccountGivenInBody()
+    {
+        $trainingPosition = TrainingPosition::factory()->create(['waiting_list_id' => $this->waitingList->id, 'places' => 1]);
+
+        $this->actingAs($this->privacc)
+            ->post("nova-vendor/waiting-lists-manager/waitingLists/{$this->waitingList->id}/position/{$trainingPosition->id}/offer", [
+                'account_id' => 0
+            ])
+            ->assertStatus(400);
+    }
+}

--- a/tests/Unit/Training/TrainingPlace/OfferTrainingPlaceServiceTest.php
+++ b/tests/Unit/Training/TrainingPlace/OfferTrainingPlaceServiceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Training\TrainingPlace;
+
+use Tests\TestCase;
+use App\Models\Mship\Account;
+use Illuminate\Support\Facades\Notification;
+use App\Services\Training\OfferTrainingPlace;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class OfferTrainingPlaceServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        Notification::fake();
+    }
+
+    /** @test */
+    public function itShouldCreateNewOffer()
+    {
+        $trainingPosition = TrainingPosition::factory()->create();
+        $offeringAccount = factory(Account::class)->create();
+
+        handleService(new OfferTrainingPlace(
+            $trainingPosition,
+            $this->user,
+            $offeringAccount,
+        ));
+
+        $this->assertDatabaseHas('training_place_offers', [
+            'account_id' => $this->user->id,
+            'offered_by' => $offeringAccount->id
+        ]);
+    }
+
+    /** @test */
+    public function itShouldDispatchTheRightNotificationToTheOfferedUser()
+    {
+        $trainingPosition = TrainingPosition::factory()->create();
+        $offeringAccount = factory(Account::class)->create();
+
+        handleService(new OfferTrainingPlace(
+            $trainingPosition,
+            $this->user,
+            $offeringAccount,
+        ));
+
+        Notification::assertSentTo([$this->user], TrainingPlaceOffer::class);
+    }
+}

--- a/tests/Unit/Training/TrainingPlace/TrainingPositionTest.php
+++ b/tests/Unit/Training/TrainingPlace/TrainingPositionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Training\TrainingPlace;
+
+use Tests\TestCase;
+use App\Models\Station;
+use App\Models\Training\WaitingList;
+use App\Models\Training\TrainingPlace;
+use App\Models\Training\TrainingPlace\TrainingPosition;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class TrainingPositionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $this->waitingList = factory(WaitingList::class)->create();
+    }
+
+    /** @test */
+    public function itShouldGenerateArrayOfavailablePlacesForWaitingList()
+    {
+        $station = factory(Station::class)->create();
+        $trainingPosition = TrainingPosition::factory()->create([
+            'places' => 3,
+            'station_id' => $station->id,
+            'waiting_list_id' => $this->waitingList->id
+        ]);
+
+        $this->assertEquals([
+            'callsign' => $station->callsign,
+            'id' => $trainingPosition->id,
+        ], TrainingPosition::availablePlacesForWaitingList($this->waitingList)[0]);
+    }
+
+    /** @test */
+    public function itShouldNotShowAvailablePlacesWhenAllFull()
+    {
+        $trainingPosition = TrainingPosition::factory()->create([
+            'places' => 1,
+            'waiting_list_id' => $this->waitingList->id,
+        ]);
+
+        // create an active training place on the training position registered.
+        TrainingPlace::factory()->create([
+            'training_position_id' => $trainingPosition->id
+        ]);
+
+
+        $this->assertEquals([], TrainingPosition::availablePlacesForWaitingList($this->waitingList));
+    }
+
+    /** @test */
+    public function itShouldHandlePlacesAcrossMultipleTrainingPositions()
+    {
+        [$firstPosition, $secondPosition] = TrainingPosition::factory()->count(2)->create([
+            'places' => 1,
+            'waiting_list_id' => $this->waitingList->id,
+        ]);
+
+        $this->assertEquals([
+            ['id' => $firstPosition->id, 'callsign' => $firstPosition->station->callsign],
+            ['id' => $secondPosition->id, 'callsign' => $secondPosition->station->callsign]
+        ], TrainingPosition::availablePlacesForWaitingList($this->waitingList));
+    }
+}


### PR DESCRIPTION
This PR addresses the basic needs of the training place automation workflow. PR was created at this stage to help with PR review
size going forward, and ensure bad decisions aren't taken early on in development.

Split into distinct sections to make clear what is implemented.

*Nova*:
- Adds TrainingPlace, TrainingPosition & Station resources, with relevant relationship form fields for WaitingList, Station and CTS Position
- Adds button to eligible Waiting List bucket to offer a training place to a user
- Adds modal component to provide dropdown for selecting available positions
- Removes style override in place for Feedback Message content - looking into replacing this with a package (https://github.com/tylernathanreed/nova-textwrap-field)

*Data Model & Process*:
- Adds tables and models for TrainingPlace, TrainingPosition, TrainingPlaceOffer
- Adds service for handling dispatching an offer to an account.
- Adds event framework for dispatching offer, designed to be consumed by several listeners for notifications etc.
- Adds method to TrainingPosition model to get available places for a given waiting list

*Implementation Notes*
- TrainingPlaceOffer uses a UUID as it will be used in future as a public-facing identifier linked
via email.
- TrainingPositions are linked to a cts position to facilitate automating granting permissions for a session.
This might also need to be linked to a CTS RTS ID in order to manage memberships

Note: some boilerplate might still be present in the code (e.g. notifications), thus why it is only going to a feature branch. 
