### PR TITLE
fix: Network callsign length

### DIFF
--- a/database/migrations/2021_11_07_195238_modify_network_callsigns.php
+++ b/database/migrations/2021_11_07_195238_modify_network_callsigns.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModifyNetworkCallsigns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(
+            "networkdata_atc",
+            function (Blueprint $table) {
+                $table->string('callsign', 20)->change();
+            }
+        );
+
+        Schema::table(
+            "networkdata_pilots",
+            function (Blueprint $table) {
+                $table->string('callsign', 20)->change();
+            }
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(
+            "networkdata_atc",
+            function (Blueprint $table) {
+                $table->string('callsign', 10)->change();
+            }
+        );
+        Schema::table(
+            "networkdata_pilots",
+            function (Blueprint $table) {
+                $table->string('callsign', 10)->change();
+            }
+        );
+    }
+}

--- a/database/migrations/2021_11_07_195238_modify_network_callsigns.php
+++ b/database/migrations/2021_11_07_195238_modify_network_callsigns.php
@@ -14,14 +14,14 @@ class ModifyNetworkCallsigns extends Migration
     public function up()
     {
         Schema::table(
-            "networkdata_atc",
+            'networkdata_atc',
             function (Blueprint $table) {
                 $table->string('callsign', 20)->change();
             }
         );
 
         Schema::table(
-            "networkdata_pilots",
+            'networkdata_pilots',
             function (Blueprint $table) {
                 $table->string('callsign', 20)->change();
             }
@@ -36,13 +36,13 @@ class ModifyNetworkCallsigns extends Migration
     public function down()
     {
         Schema::table(
-            "networkdata_atc",
+            'networkdata_atc',
             function (Blueprint $table) {
                 $table->string('callsign', 10)->change();
             }
         );
         Schema::table(
-            "networkdata_pilots",
+            'networkdata_pilots',
             function (Blueprint $table) {
                 $table->string('callsign', 10)->change();
             }


### PR DESCRIPTION
Recently network callsign length restrictions were raised to 12 chars (from 10). This PR ups our internal DB fields to a max length of 20 - hopefully futureproofing against any other future changes to this.

Should fix the issues we have been seeing re:network data download failing - (see https://sentry.io/organizations/vatsim-uk/issues/2538159389/?project=5734564&query=is%3Aunresolved)