### PR TITLE
feat: Add more informative 403 messages

### DIFF
--- a/app/Http/Controllers/Auth/LocalBanDisplayController.php
+++ b/app/Http/Controllers/Auth/LocalBanDisplayController.php
@@ -16,12 +16,13 @@ class LocalBanDisplayController extends BaseController
      */
     public function __invoke()
     {
-        if (!Auth::user()->is_system_banned) {
+        if (! Auth::user()->is_system_banned) {
             // don't allow non-banned users to see the contents of the view.
             return redirect()->route('mship.manage.dashboard');
         }
 
         $localBan = Auth::user()->system_ban->load('reason');
+
         return $this->viewMake('errors.banned-local')->with(['ban' => $localBan]);
     }
 }

--- a/app/Http/Controllers/Auth/LocalBanDisplayController.php
+++ b/app/Http/Controllers/Auth/LocalBanDisplayController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\BaseController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LocalBanDisplayController extends BaseController
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke()
+    {
+        if (!Auth::user()->is_system_banned) {
+            // don't allow non-banned users to see the contents of the view.
+            return redirect()->route('mship.manage.dashboard');
+        }
+
+        $localBan = Auth::user()->system_ban->load('reason');
+        return $this->viewMake('errors.banned-local')->with(['ban' => $localBan]);
+    }
+}

--- a/app/Http/Middleware/DenyIfBanned.php
+++ b/app/Http/Middleware/DenyIfBanned.php
@@ -21,6 +21,14 @@ class DenyIfBanned
                 return response()->json(['error' => 'You are currently banned.'], 403);
             }
 
+            if (Auth::user()->is_network_banned) {
+                return redirect()->route('banned.network');
+            }
+
+            if (Auth::user()->is_system_banned) {
+                return redirect()->route('banned.local');
+            }
+
             abort(403, 'You are currently banned.');
         }
 

--- a/resources/views/errors/banned-local.blade.php
+++ b/resources/views/errors/banned-local.blade.php
@@ -1,0 +1,12 @@
+@extends('layout', ['shellOnly' => true])
+
+@section('content')
+    <h1>You are currently suspended from VATSIM UK systems.</h1>
+    <h2>Reason</h2>
+    <p>{{ $ban->reason->reason_text }}
+    <h3>Since</h2>
+    <p>{{ $ban->period_start->toDayDateTimeString() }} ({{ $ban->period_start->diffForHumans() }}).</p>
+    <h3>Expiry</h2>
+    <p>Your ban is due to expire on {{ $ban->period_finish->toDayDateTimeString() }} UTC ({{ $ban->period_finish->diffForHumans() }})</p>
+    <p>If you believe this to be an error, please contact the VATSIM UK Membership Services team at <a href="https://helpdesk.vatsim.uk">https://helpdesk.vatsim.uk</a> who will be able to assist further.</p>
+@stop

--- a/resources/views/errors/banned-network.blade.php
+++ b/resources/views/errors/banned-network.blade.php
@@ -1,0 +1,7 @@
+@extends('layout', ['shellOnly' => true])
+
+@section('content')
+    <h1>You are currently suspended from the VATSIM Network.</h1>
+    <p>As your account is suspended by the central VATSIM.net team, you will need to follow the instructions listed on this page: <a>https://www.vatsim.net/members/member-help.</a></p>
+    <p>As a Division, we are unable to provide any details on why your account is suspended.</p>
+@stop

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -10,6 +10,9 @@ Route::get('login-secondary')->uses('Auth\LoginController@showLoginForm')->middl
 Route::post('login-secondary')->uses('Auth\SecondaryLoginController@loginSecondary')->middleware('auth:vatsim-sso')->name('auth-secondary.post');
 Route::post('logout')->uses('Auth\LogoutController')->name('logout');
 
+Route::view('banned-network', 'errors.banned-network')->name('banned.network');
+Route::get('banned-local')->uses('Auth\LocalBanDisplayController')->name('banned.local');
+
 // Password
 Route::group([
     'as'     => 'password.',

--- a/tests/Feature/Middleware/BannedMiddlewareTest.php
+++ b/tests/Feature/Middleware/BannedMiddlewareTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Middleware;
+
+use App\Models\Mship\Account;
+use App\Models\Mship\Ban\Reason;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class BannedMiddlewareTest extends TestCase
+{
+    use DatabaseTransactions;
+    /** @test */
+    public function testNetworkBannedUserIsRedirectedToCorrectRoute()
+    {
+       $account = factory(Account::class)->create();
+
+       $account->addNetworkBan();
+
+       $account->refresh();
+
+       $this->actingAs($account)
+            ->get(route('mship.manage.dashboard'))
+            ->assertRedirect(route('banned.network'));
+    }
+
+    /** @test */
+    public function testLocalBannedUserIsRedirectedToCorrectRoute()
+    {
+        $account = factory(Account::class)->create();
+        $banReason = factory(Reason::class)->create();
+
+        $account->addBan($banReason, 'Local ban', 'Ban note.');
+
+        $this->actingAs($account)
+            ->get(route('mship.manage.dashboard'))
+            ->assertRedirect(route('banned.local'));
+    }
+}

--- a/tests/Feature/Middleware/BannedMiddlewareTest.php
+++ b/tests/Feature/Middleware/BannedMiddlewareTest.php
@@ -5,23 +5,22 @@ namespace Tests\Feature\Middleware;
 use App\Models\Mship\Account;
 use App\Models\Mship\Ban\Reason;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class BannedMiddlewareTest extends TestCase
 {
     use DatabaseTransactions;
+
     /** @test */
     public function testNetworkBannedUserIsRedirectedToCorrectRoute()
     {
-       $account = factory(Account::class)->create();
+        $account = factory(Account::class)->create();
 
-       $account->addNetworkBan();
+        $account->addNetworkBan();
 
-       $account->refresh();
+        $account->refresh();
 
-       $this->actingAs($account)
+        $this->actingAs($account)
             ->get(route('mship.manage.dashboard'))
             ->assertRedirect(route('banned.network'));
     }


### PR DESCRIPTION
Adds context to the banned screen for members who have a network or local VATSIM UK ban.

This is designed to help members contact the right people more readily should they need, and ultimately leave them more informed about their membership status.

Preview Local Ban:

<img width="1909" alt="image" src="https://user-images.githubusercontent.com/6240877/150200380-0096e6dd-9a00-40ce-af69-ff6b82bd4afc.png">
