### PR TITLE
Training teams: General Manager to ATC/Pilot Training Manager

### DIFF
--- a/resources/views/site/atc/newcontroller.blade.php
+++ b/resources/views/site/atc/newcontroller.blade.php
@@ -21,7 +21,7 @@
 					</p>
 
 					<p>
-					If you’re not already a member of VATSIM’s UK division, the first step is to follow the instructions on the <a href="https://www.vatsim.uk/join" rel="external nofollow">Join Us</a> page – you’ll need to ensure that your division is set to ‘United Kingdom’. If you need to make a change, this may take up to 24 hours to process. <b>If you transfer to another division, you be unable to undertake training in VATSIM UK and will lose your place on the waiting list.</b>
+					If you’re not already a member of VATSIM’s UK division, the first step is to follow the instructions on the <a href="https://www.vatsim.uk/join" rel="external nofollow">Join Us</a> page – you’ll need to ensure that your division is set to ‘United Kingdom’. If you need to make a change, this may take up to 24 hours to process. <b>You will lose your place on the waiting list if you transfer to another division, and will be unable to undertake training in VATSIM UK.</b>
 					</p>
 
                     <h2>

--- a/resources/views/site/atc/newcontroller.blade.php
+++ b/resources/views/site/atc/newcontroller.blade.php
@@ -21,7 +21,7 @@
 					</p>
 
 					<p>
-					If you’re not already a member of VATSIM’s UK division, the first step is to follow the instructions on the <a href="https://www.vatsim.uk/join" rel="external nofollow">Join Us</a> page – you’ll need to ensure that your division is set to ‘United Kingdom’. If you need to make a change, this may take up to 24 hours to process. <b>You will lose your place on the waiting list if you transfer to another division, and will be unable to undertake training in VATSIM UK.</b>
+					If you’re not already a member of VATSIM’s UK division, the first step is to follow the instructions on the <a href="https://www.vatsim.uk/join" rel="external nofollow">Join Us</a> page – you’ll need to ensure that your division is set to ‘United Kingdom’. If you need to make a change, this may take up to 24 hours to process. <b>You will lose your place on the waiting list if you later transfer to another division, and will be unable to undertake training in VATSIM UK.</b>
 					</p>
 
                     <h2>

--- a/resources/views/site/atc/newcontroller.blade.php
+++ b/resources/views/site/atc/newcontroller.blade.php
@@ -21,7 +21,7 @@
 					</p>
 
 					<p>
-					If you’re not already a member of VATSIM’s UK division, the first step is to follow the instructions on the <a href="https://www.vatsim.uk/join" rel="external nofollow">Join Us</a> page – you’ll need to ensure that your division is set to ‘United Kingdom’. If you need to make a change, this may take up to 24 hours to process.
+					If you’re not already a member of VATSIM’s UK division, the first step is to follow the instructions on the <a href="https://www.vatsim.uk/join" rel="external nofollow">Join Us</a> page – you’ll need to ensure that your division is set to ‘United Kingdom’. If you need to make a change, this may take up to 24 hours to process. <b>If you transfer to another division, you be unable to undertake training in VATSIM UK and will lose your place on the waiting list.</b>
 					</p>
 
                     <h2>

--- a/resources/views/site/staff.blade.php
+++ b/resources/views/site/staff.blade.php
@@ -210,7 +210,7 @@
                         <h4 class="text-center">ATC Training Team</h4>
                         <table class="table">
                             <tr>
-                                <td>General Manager</td>
+                                <td>ATC Training Manager</td>
                                 <td>Oliver Rhodes</td>
                             </tr>
                             <tr>
@@ -291,7 +291,7 @@
                         <h4 class="text-center">Pilot Training Team</h4>
                         <table class="table">
                             <tr>
-                                <td>General Manager</td>
+                                <td>Pilot Training Manager</td>
                                 <td>Vacant</td>
                             </tr>
                             <tr>


### PR DESCRIPTION
Just noticed this on the website; the role titles for the ATC/Pilot Training Manager changed away from 'General Manager' ~two years ago (see for example Discord roles).