### PR TITLE
feat: add job to remove non-home members from lists

### DIFF
--- a/app/Console/Commands/Training/CheckHomeMembersInWaitingLists.php
+++ b/app/Console/Commands/Training/CheckHomeMembersInWaitingLists.php
@@ -34,7 +34,7 @@ class CheckHomeMembersInWaitingLists extends Command
 
         // for each ATC list, check for home members
         $waitingLists->each(function ($waitingList) {
-            $waitingList->accounts->each(function ($account) use($waitingList) {
+            $waitingList->accounts->each(function ($account) use ($waitingList) {
                 CheckHomeMemberInWaitingList::dispatch($waitingList, $account);
             });
         });

--- a/app/Console/Commands/Training/CheckHomeMembersInWaitingLists.php
+++ b/app/Console/Commands/Training/CheckHomeMembersInWaitingLists.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands\Training;
+
+use App\Jobs\Training\CheckHomeMemberInWaitingList;
+use App\Models\Training\WaitingList;
+use Illuminate\Console\Command;
+
+class CheckHomeMembersInWaitingLists extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'training:check-home-members';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check that only home members are included in waiting lists.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // only check ATC lists
+        $waitingLists = WaitingList::where(['department' => WaitingList::ATC_DEPARTMENT])->get()->load('accounts');
+
+        // for each ATC list, check for home members
+        $waitingLists->each(function ($waitingList) {
+            $waitingList->accounts->each(function ($account) use($waitingList) {
+                CheckHomeMemberInWaitingList::dispatch($waitingList, $account);
+            });
+        });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -68,8 +68,8 @@ class Kernel extends ConsoleKernel
         $schedule->command('schedule-monitor:clean')
             ->dailyAt('08:00');
 
-        $schedule->command("training:check-home-members")
-            ->dailyAt("05:00");
+        $schedule->command('training:check-home-members')
+            ->dailyAt('05:00');
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -67,6 +67,9 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('schedule-monitor:clean')
             ->dailyAt('08:00');
+
+        $schedule->command("training:check-home-members")
+            ->dailyAt("05:00");
     }
 
     /**

--- a/app/Jobs/Training/CheckHomeMemberInWaitingList.php
+++ b/app/Jobs/Training/CheckHomeMemberInWaitingList.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Jobs\Training;
+
+use App\Models\Mship\Account;
+use App\Models\Training\WaitingList;
+use App\Notifications\Training\RemovedFromWaitingListNonHomeMember;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class CheckHomeMemberInWaitingList implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    private WaitingList $waitingList;
+    private Account $account;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(WaitingList $waitingList, Account $account)
+    {
+        $this->waitingList = $waitingList;
+        $this->account = $account;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        try {
+            $this->waitingList->accounts()->find($this->account->id);
+        } catch (ModelNotFoundException) {
+            Log::warning("Account {$this->account->id} not in waiting list.");
+            return;
+        }
+
+        if (!$this->account->primary_state->isDivision) {
+            $this->waitingList->removeFromWaitingList($this->account);
+            $this->account->notify(new RemovedFromWaitingListNonHomeMember);
+        }
+    }
+}

--- a/app/Jobs/Training/CheckHomeMemberInWaitingList.php
+++ b/app/Jobs/Training/CheckHomeMemberInWaitingList.php
@@ -6,7 +6,6 @@ use App\Models\Mship\Account;
 use App\Models\Training\WaitingList;
 use App\Notifications\Training\RemovedFromWaitingListNonHomeMember;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -43,10 +42,11 @@ class CheckHomeMemberInWaitingList implements ShouldQueue
             $this->waitingList->accounts()->find($this->account->id);
         } catch (ModelNotFoundException) {
             Log::warning("Account {$this->account->id} not in waiting list.");
+
             return;
         }
 
-        if (!$this->account->primary_state->isDivision) {
+        if (! $this->account->primary_state->isDivision) {
             $this->waitingList->removeFromWaitingList($this->account);
             $this->account->notify(new RemovedFromWaitingListNonHomeMember);
         }

--- a/app/Notifications/Training/RemovedFromWaitingListNonHomeMember.php
+++ b/app/Notifications/Training/RemovedFromWaitingListNonHomeMember.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Notifications\Training;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class RemovedFromWaitingListNonHomeMember extends Notification
+{
+    use Queueable;
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->from("support@vatsim.uk", "VATSIM UK - Member Services")
+                    ->subject("UK ATC training waiting list removal")
+                    ->view("emails.training.waiting_list_non_home_removal", ['recipient' => $notifiable]);
+    }
+}

--- a/app/Notifications/Training/RemovedFromWaitingListNonHomeMember.php
+++ b/app/Notifications/Training/RemovedFromWaitingListNonHomeMember.php
@@ -3,7 +3,6 @@
 namespace App\Notifications\Training;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
@@ -31,8 +30,8 @@ class RemovedFromWaitingListNonHomeMember extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-                    ->from("support@vatsim.uk", "VATSIM UK - Member Services")
-                    ->subject("UK ATC training waiting list removal")
-                    ->view("emails.training.waiting_list_non_home_removal", ['recipient' => $notifiable]);
+                    ->from('support@vatsim.uk', 'VATSIM UK - Member Services')
+                    ->subject('UK ATC training waiting list removal')
+                    ->view('emails.training.waiting_list_non_home_removal', ['recipient' => $notifiable]);
     }
 }

--- a/resources/views/emails/training/waiting_list_non_home_removal.blade.php
+++ b/resources/views/emails/training/waiting_list_non_home_removal.blade.php
@@ -1,0 +1,9 @@
+@extends('emails.messages.post')
+
+@section('body')
+
+<p>As you have changed your VATSIM Division away from the UK Division you are no longer eligible to receive ATC training in the UK. You were on one of the waiting lists for ATC training in the UK and as such as you are no longer a member of the UK Division you have been removed from the waiting list.</p>
+
+<p>If you believe this to be in error, then please get in contact with the Member Services team via the helpdesk.</p>
+
+@stop

--- a/tests/Unit/Training/WaitingList/CheckHomeMemberscCommandTest.php
+++ b/tests/Unit/Training/WaitingList/CheckHomeMemberscCommandTest.php
@@ -12,6 +12,7 @@ use Tests\TestCase;
 class CheckHomeMemberscCommandTest extends TestCase
 {
     use DatabaseTransactions;
+
     /** @test */
     public function itShouldSendAJobForAllMembersOfWaitingList()
     {
@@ -24,7 +25,7 @@ class CheckHomeMemberscCommandTest extends TestCase
 
         Queue::fake();
 
-        $this->artisan("training:check-home-members");
+        $this->artisan('training:check-home-members');
 
         Queue::assertPushed(CheckHomeMemberInWaitingList::class, $accounts->count());
     }

--- a/tests/Unit/Training/WaitingList/CheckHomeMemberscCommandTest.php
+++ b/tests/Unit/Training/WaitingList/CheckHomeMemberscCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Training\WaitingList;
+
+use App\Jobs\Training\CheckHomeMemberInWaitingList;
+use App\Models\Mship\Account;
+use App\Models\Training\WaitingList;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class CheckHomeMemberscCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+    /** @test */
+    public function itShouldSendAJobForAllMembersOfWaitingList()
+    {
+        $accounts = factory(Account::class, 3)->create();
+        $waitingList = factory(WaitingList::class)->create();
+
+        $accounts->each(function ($account) use ($waitingList) {
+            $waitingList->addToWaitingList($account, $this->privacc);
+        });
+
+        Queue::fake();
+
+        $this->artisan("training:check-home-members");
+
+        Queue::assertPushed(CheckHomeMemberInWaitingList::class, $accounts->count());
+    }
+}

--- a/tests/Unit/Training/WaitingList/RemoveNonHomeMembersTest.php
+++ b/tests/Unit/Training/WaitingList/RemoveNonHomeMembersTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit\Training\WaitingList;
+
+use App\Jobs\Training\CheckHomeMemberInWaitingList;
+use App\Models\Mship\Account;
+use App\Models\Mship\State;
+use App\Models\Training\WaitingList;
+use App\Notifications\Training\RemovedFromWaitingListNonHomeMember;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class RemoveNonHomeMembersTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private $waitingList;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->waitingList = factory(WaitingList::class)->create();
+    }
+    /** @test * */
+    public function itWillRemoveMemberFromWaitingListWhenNotHomeMember()
+    {
+        $account = factory(Account::class)->create();
+        $visitingState = State::findByCode("VISITING");
+        $account->addState($visitingState);
+
+        $this->waitingList->addToWaitingList($account->refresh(), $this->privacc);
+
+        (new CheckHomeMemberInWaitingList($this->waitingList, $account))->handle();
+
+        $this->assertFalse($this->waitingList->accounts->contains($account));
+    }
+
+    /** @test * */
+    public function itWillNotRemoveHomeMembersFromWaitingList()
+    {
+        $account = factory(Account::class)->create();
+        $visitingState = State::findByCode("DIVISION");
+        $account->addState($visitingState);
+
+        $this->waitingList->addToWaitingList($account->refresh(), $this->privacc);
+
+        $job = new CheckHomeMemberInWaitingList($this->waitingList, $account);
+        $job->handle();
+
+        $this->assertTrue($this->waitingList->accounts->contains($account));
+    }
+
+        /** @test * */
+    public function itWillDispatchNotificationWhenRemovingNonHomeMember()
+    {
+        $account = factory(Account::class)->create();
+        $visitingState = State::findByCode("VISITING");
+        $account->addState($visitingState);
+
+        $this->waitingList->addToWaitingList($account->refresh(), $this->privacc);
+
+        Notification::fake();
+
+        $job = new CheckHomeMemberInWaitingList($this->waitingList, $account);
+        $job->handle();
+
+        Notification::assertSentTo($account, RemovedFromWaitingListNonHomeMember::class);
+    }
+}

--- a/tests/Unit/Training/WaitingList/RemoveNonHomeMembersTest.php
+++ b/tests/Unit/Training/WaitingList/RemoveNonHomeMembersTest.php
@@ -23,11 +23,12 @@ class RemoveNonHomeMembersTest extends TestCase
 
         $this->waitingList = factory(WaitingList::class)->create();
     }
+
     /** @test * */
     public function itWillRemoveMemberFromWaitingListWhenNotHomeMember()
     {
         $account = factory(Account::class)->create();
-        $visitingState = State::findByCode("VISITING");
+        $visitingState = State::findByCode('VISITING');
         $account->addState($visitingState);
 
         $this->waitingList->addToWaitingList($account->refresh(), $this->privacc);
@@ -41,7 +42,7 @@ class RemoveNonHomeMembersTest extends TestCase
     public function itWillNotRemoveHomeMembersFromWaitingList()
     {
         $account = factory(Account::class)->create();
-        $visitingState = State::findByCode("DIVISION");
+        $visitingState = State::findByCode('DIVISION');
         $account->addState($visitingState);
 
         $this->waitingList->addToWaitingList($account->refresh(), $this->privacc);
@@ -52,11 +53,11 @@ class RemoveNonHomeMembersTest extends TestCase
         $this->assertTrue($this->waitingList->accounts->contains($account));
     }
 
-        /** @test * */
+    /** @test * */
     public function itWillDispatchNotificationWhenRemovingNonHomeMember()
     {
         $account = factory(Account::class)->create();
-        $visitingState = State::findByCode("VISITING");
+        $visitingState = State::findByCode('VISITING');
         $account->addState($visitingState);
 
         $this->waitingList->addToWaitingList($account->refresh(), $this->privacc);


### PR DESCRIPTION
Trello: 233

This establishes logic to remove any existing members from the list where they are no longer members of the UK division. They will be directly removed from the waiting list and then an email sent directly to the user. 

Few things to note:
- This relies on their state being updated either via a login or via the discovery scripts (which could be a maximum of 7 days lag time depending on where they have come in the import scripts)
- I decided to do this via queues just because this scales much more efficiently for the larger waiting lists, even if the messages will for the most part just be discarded from the queue.
- A command will run once daily at 5am to check all ATC waiting lists

Complements #2671 