### PR TITLE
update vatsim api url

### DIFF
--- a/config/vatsim-api.php
+++ b/config/vatsim-api.php
@@ -5,7 +5,7 @@ return [
     /*
      * The location of the VATSIM API
      */
-    'base' => env('VATSIM_API_BASE', 'https://apiv2.vatsim.dev/v2/'),
+    'base' => env('VATSIM_API_BASE', 'https://apiv2-dev.vatsim.net/v2/'),
 
     /*
      * The API key for the VATSIM API


### PR DESCRIPTION
we've lost access to the vatsim.dev domain name, so an update to the URL is required