### PR TITLE
perf: add database level indexes for networkdata_atc table

### DIFF
--- a/database/migrations/2022_12_13_131128_index_networkdata_for_account_disconnected_and_callsign.php
+++ b/database/migrations/2022_12_13_131128_index_networkdata_for_account_disconnected_and_callsign.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('networkdata_atc', function (Blueprint $table) {
+            // index to allow query pattern which retrieves an accounts ATC sessions by their disconnected timestamp
+            // and then callsign.
+            $table->index(['account_id', 'disconnected_at', 'callsign']);
+
+            // index to allow query pattern which retrieves an accounts ATC sessions first by the callsign
+            // and then by the disconnected timestamp
+            $table->index(['account_id', 'callsign', 'disconnected_at']);
+
+            // index to allow endorsement conditions to retrieve network data by account, callsign, connected_at,
+            // qualification_id and deleted_at which helps boost performance
+            // when a condition has a requirement for ATC sessions to be completed with a particular qualification
+            // and within a particular number of months.
+            // Deleted_at is included as the Networkdata/Atc model has soft deletes.
+            $table->index(['account_id', 'callsign', 'connected_at', 'qualification_id', 'deleted_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('networkdata_atc', function (Blueprint $table) {
+            $table->dropIndex(['account_id', 'disconnected_at', 'callsign']);
+            $table->dropIndex(['account_id', 'callsign', 'disconnected_at']);
+            $table->dropIndex(['account_id', 'callsign', 'connected_at', 'qualification_id', 'deleted_at']);
+        });
+    }
+};

--- a/database/migrations/2022_12_13_131128_index_networkdata_for_account_disconnected_and_callsign.php
+++ b/database/migrations/2022_12_13_131128_index_networkdata_for_account_disconnected_and_callsign.php
@@ -16,18 +16,19 @@ return new class extends Migration
         Schema::table('networkdata_atc', function (Blueprint $table) {
             // index to allow query pattern which retrieves an accounts ATC sessions by their disconnected timestamp
             // and then callsign.
-            $table->index(['account_id', 'disconnected_at', 'callsign']);
+            $table->index(['account_id', 'disconnected_at', 'callsign'], 'networkdata_atc_by_date_callsign');
 
             // index to allow query pattern which retrieves an accounts ATC sessions first by the callsign
-            // and then by the disconnected timestamp
-            $table->index(['account_id', 'callsign', 'disconnected_at']);
+            // and then by the disconnected timestamp. (Name specified for index due to name length limit)
+            $table->index(['account_id', 'callsign', 'disconnected_at'], 'networkdata_atc_by_callsign_date');
 
             // index to allow endorsement conditions to retrieve network data by account, callsign, connected_at,
             // qualification_id and deleted_at which helps boost performance
             // when a condition has a requirement for ATC sessions to be completed with a particular qualification
             // and within a particular number of months.
             // Deleted_at is included as the Networkdata/Atc model has soft deletes.
-            $table->index(['account_id', 'callsign', 'connected_at', 'qualification_id', 'deleted_at']);
+            // (Name specified for index due to name length limit)
+            $table->index(['account_id', 'callsign', 'connected_at', 'qualification_id', 'deleted_at'], 'networkdata_endorsement_check_query');
         });
     }
 


### PR DESCRIPTION
This is an experiment to address long-standing performance issues with querying lots of network data at any time.

The three indexes added cover:
- Endorsement condition querying
- Waiting list base 12-hour check (think isUK() scope on the networkdata_atc model)
- Querying for UK network data in any other (before or after the disconnected_at check) usecase

There is a potential this will increase disk usage.

The main motivation for these changes is to potentially remove the need for caching on the waiting list eligibility checking
and thus reducing the overall complexity of this bit of the application.

Relevant Sentry Tracing:
- https://sentry.io/organizations/vatsim-uk/performance/summary/spans/db.sql.query:a24f8f1356d21c38/?project=5734564&query=http.method%3AGET&statsPeriod=24h&transaction=%2Fnova-vendor%2Fwaiting-lists-manager%2Faccounts%2F%7BwaitingList%7D%2Factive%2Findex
- https://sentry.io/organizations/vatsim-uk/performance/summary/spans/db.sql.query:3f9aef01b76f6de3/?project=5734564&query=http.method%3AGET&statsPeriod=24h&transaction=%2Fnova-vendor%2Fwaiting-lists-manager%2Faccounts%2F%7BwaitingList%7D

(Percentile performance influenced by the caching taking over in the relevant time periods)
