### PR TITLE
feat: add theory exam pass status to waiting list index

### DIFF
--- a/app/Models/Cts/TheoryResult.php
+++ b/app/Models/Cts/TheoryResult.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\Cts;
 
-use App\Models\Cts\Member;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -20,12 +19,13 @@ class TheoryResult extends Model
      * and handle the logic where a member_id in CTS is different to that
      * of the account_id in Core.
      */
-    public static function forAccount(int $account_id) : ?TheoryResult
+    public static function forAccount(int $account_id): ?TheoryResult
     {
         try {
             $memberId = Member::where('cid', $account_id)->firstOrFail()->id;
         } catch (ModelNotFoundException) {
             Log::warning("No member found for account_id ${$account_id}. Likely sync problems.");
+
             return null;
         }
 

--- a/app/Models/Cts/TheoryResult.php
+++ b/app/Models/Cts/TheoryResult.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models\Cts;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TheoryResult extends Model
+{
+    use HasFactory;
+
+    protected $connection = 'cts';
+    public $timestamps = false;
+}

--- a/app/Models/Cts/TheoryResult.php
+++ b/app/Models/Cts/TheoryResult.php
@@ -2,8 +2,11 @@
 
 namespace App\Models\Cts;
 
+use App\Models\Cts\Member;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Log;
 
 class TheoryResult extends Model
 {
@@ -11,4 +14,23 @@ class TheoryResult extends Model
 
     protected $connection = 'cts';
     public $timestamps = false;
+
+    /**
+     * Get result for the internal Core account_id, also their CId
+     * and handle the logic where a member_id in CTS is different to that
+     * of the account_id in Core.
+     */
+    public static function forAccount(int $account_id) : ?TheoryResult
+    {
+        try {
+            $memberId = Member::where('cid', $account_id)->firstOrFail()->id;
+        } catch (ModelNotFoundException) {
+            Log::warning("No member found for account_id ${$account_id}. Likely sync problems.");
+            return null;
+        }
+
+        // return the first part of a query to get results for a given member.
+        // providing a member_id is found, otherwise return null.
+        return self::where('student_id', $memberId)->first();
+    }
 }

--- a/app/Models/Training/WaitingList/WaitingListAccount.php
+++ b/app/Models/Training/WaitingList/WaitingListAccount.php
@@ -178,17 +178,19 @@ class WaitingListAccount extends Pivot
         return $this->atcHourCheck() && $this->allFlagsChecker() && $this->current_status->name == 'Active';
     }
 
-    public function getTheoryExamPassedAttribute(): bool
+    public function getTheoryExamPassedAttribute(): ?bool
     {
         if ($this->waitingList->department === WaitingList::PILOT_DEPARTMENT || ! $this->waitingList->cts_theory_exam_level) {
-            return false;
+            return null;
         }
 
-        // the internal CTS member column id not the same as the account id
-        // so search on the indexed column cid.
-        $memberId = Member::where('cid', $this->account_id)->first()->id;
+        $result = TheoryResult::forAccount($this->account_id);
 
-        return TheoryResult::where('student_id', $memberId)
+        if (!$result) {
+            return null;
+        }
+
+        return $result
             ->where('exam', $this->waitingList->cts_theory_exam_level)
             ->where('pass', true)->count() > 0;
     }

--- a/app/Models/Training/WaitingList/WaitingListAccount.php
+++ b/app/Models/Training/WaitingList/WaitingListAccount.php
@@ -2,6 +2,8 @@
 
 namespace App\Models\Training\WaitingList;
 
+use App\Models\Cts\Member;
+use App\Models\Cts\TheoryResult;
 use App\Models\Mship\Account;
 use App\Models\NetworkData\Atc;
 use App\Models\Training\WaitingList;
@@ -174,6 +176,21 @@ class WaitingListAccount extends Pivot
         // are all the flags true
         // and is the atc hour check true
         return $this->atcHourCheck() && $this->allFlagsChecker() && $this->current_status->name == 'Active';
+    }
+
+    public function getTheoryExamPassedAttribute() : bool
+    {
+        if ($this->waitingList->department === WaitingList::PILOT_DEPARTMENT || ! $this->waitingList->cts_theory_exam_level) {
+            return false;
+        }
+
+        // the internal CTS member column id not the same as the account id
+        // so search on the indexed column cid.
+        $memberId = Member::where('cid', $this->account_id)->first()->id;
+
+        return TheoryResult::where('student_id', $memberId)
+            ->where('exam', $this->waitingList->cts_theory_exam_level)
+            ->where('pass', true)->count() > 0;
     }
 
     public function setNotesAttribute($value)

--- a/app/Models/Training/WaitingList/WaitingListAccount.php
+++ b/app/Models/Training/WaitingList/WaitingListAccount.php
@@ -178,7 +178,7 @@ class WaitingListAccount extends Pivot
         return $this->atcHourCheck() && $this->allFlagsChecker() && $this->current_status->name == 'Active';
     }
 
-    public function getTheoryExamPassedAttribute() : bool
+    public function getTheoryExamPassedAttribute(): bool
     {
         if ($this->waitingList->department === WaitingList::PILOT_DEPARTMENT || ! $this->waitingList->cts_theory_exam_level) {
             return false;

--- a/app/Models/Training/WaitingList/WaitingListAccount.php
+++ b/app/Models/Training/WaitingList/WaitingListAccount.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\Training\WaitingList;
 
-use App\Models\Cts\Member;
 use App\Models\Cts\TheoryResult;
 use App\Models\Mship\Account;
 use App\Models\NetworkData\Atc;
@@ -186,7 +185,7 @@ class WaitingListAccount extends Pivot
 
         $result = TheoryResult::forAccount($this->account_id);
 
-        if (!$result) {
+        if (! $result) {
             return null;
         }
 

--- a/database/factories/Cts/TheoryResultFactory.php
+++ b/database/factories/Cts/TheoryResultFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories\Cts;
+
+use App\Models\Cts\Member;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Cts\TheoryResult>
+ */
+class TheoryResultFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'student_id' => factory(Member::class)->create()->id,
+            'exam' => $this->faker->randomElement(['S1', 'S2', 'S3']),
+            'pass' => 0
+        ];
+    }
+}

--- a/database/factories/Cts/TheoryResultFactory.php
+++ b/database/factories/Cts/TheoryResultFactory.php
@@ -20,7 +20,7 @@ class TheoryResultFactory extends Factory
         return [
             'student_id' => factory(Member::class)->create()->id,
             'exam' => $this->faker->randomElement(['S1', 'S2', 'S3']),
-            'pass' => 0
+            'pass' => 0,
         ];
     }
 }

--- a/database/factories/WaitingListFactory.php
+++ b/database/factories/WaitingListFactory.php
@@ -10,7 +10,7 @@ $factory->define(App\Models\Training\WaitingList::class, function (Faker $faker)
         'slug' => str_slug($name),
         'department' => 'atc',
         'flags_check' => 'all',
-        'cts_theory_exam_level' => null
+        'cts_theory_exam_level' => null,
     ];
 });
 

--- a/database/factories/WaitingListFactory.php
+++ b/database/factories/WaitingListFactory.php
@@ -10,6 +10,7 @@ $factory->define(App\Models\Training\WaitingList::class, function (Faker $faker)
         'slug' => str_slug($name),
         'department' => 'atc',
         'flags_check' => 'all',
+        'cts_theory_exam_level' => null
     ];
 });
 

--- a/database/migrations/2022_12_14_103127_add_cts_exam_column.php
+++ b/database/migrations/2022_12_14_103127_add_cts_exam_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('training_waiting_list', function (Blueprint $table) {
+            $table->string('cts_theory_exam_level')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('training_waiting_list', function (Blueprint $table) {
+            $table->dropColumn('cts_theory_exam_level');
+        });
+    }
+};

--- a/nova-components/WaitingListsManager/resources/js/components/BooleanIndicator.vue
+++ b/nova-components/WaitingListsManager/resources/js/components/BooleanIndicator.vue
@@ -1,0 +1,28 @@
+<template>
+    <span
+        class="inline-block rounded-full w-2 h-2"
+        :class="indicatorClass"
+    />
+</template>
+
+<script>
+export default {
+    name: "BooleanIndicator",
+
+    props: {
+        value: {
+            type: Boolean,
+            required: true
+        }
+    },
+
+    computed: {
+        indicatorClass() {
+            return {
+                'bg-success': this.value,
+                'bg-danger': !this.value
+            }
+        }
+    }
+}
+</script>

--- a/nova-components/WaitingListsManager/resources/js/components/Bucket.vue
+++ b/nova-components/WaitingListsManager/resources/js/components/Bucket.vue
@@ -1,6 +1,5 @@
 <template>
     <div>
-        <heading class="mb-6 py-3 px-6" v-text="title" />
         <p class="flex flex-col justify-center text-center p-2" v-if="numberOfAccounts < 1">
             There are no accounts assigned to this 'bucket'.
         </p>
@@ -14,8 +13,9 @@
                     <th class="text-left">CID</th>
                     <th class="text-left">Added On</th>
                     <th class="text-left">Notes</th>
-                    <th class="text-left" v-if="showHourChecker">Hour Check</th>
+                    <th class="text-left" v-if="isAtcList">Hour Check</th>
                     <th>Status Change</th>
+                    <th class="text-left" v-if="isAtcList">Theory Exam</th>
                     <th>Flags</th>
                     <th></th>
                 </tr>
@@ -35,10 +35,8 @@
                             :account="account"
                             @changeNote="changeNote"/>
                     </td>
-                    <td v-if="showHourChecker">
-                        <span class="inline-block rounded-full w-2 h-2"
-                              :class="{ 'bg-success': account.atcHourCheck, 'bg-danger': !account.atcHourCheck }"
-                        ></span>
+                    <td v-if="isAtcList">
+                        <boolean-indicator :value="account.atcHourCheck" />
                     </td>
                     <td>
                         <div class="flex justify-around">
@@ -54,12 +52,14 @@
 
                     </td>
                     <td>
+                        <boolean-indicator :value="account.theory_exam_passed" />
+                    <td>
                         <flag-indicator
                             v-for="flag in account.flags"
                             :key="flag.pivot.id"
                             :flag="flag"
                             @changeFlag="changeFlag"
-                        ></flag-indicator>
+                        />
                     </td>
                     <td>
                         <div class="flex justify-around">
@@ -78,10 +78,13 @@
 </template>
 
 <script>
+    import BooleanIndicator from "./BooleanIndicator";
     export default {
         name: "Bucket",
 
-        props: ['accounts', 'title', 'type'],
+        props: ['accounts', 'type'],
+
+        components: { BooleanIndicator },
 
         data() {
             return {
@@ -91,15 +94,15 @@
 
         methods: {
             removeAccount(account) {
-                this.$emit('removeAccount', { account: account })
+                this.$emit('removeAccount', { account })
             },
 
             deferAccount(account) {
-                this.$emit('deferAccount', { account: account })
+                this.$emit('deferAccount', { account })
             },
 
             activeAccount(account) {
-                this.$emit('activeAccount', { account: account })
+                this.$emit('activeAccount', { account })
             },
 
             changeNote(account) {
@@ -123,7 +126,7 @@
                 if (this.accounts) return this.$props.accounts.length
             },
 
-            showHourChecker () {
+            isAtcList() {
                 return this.type === 'atc'
             }
         },

--- a/nova-components/WaitingListsManager/resources/js/components/FlagIndicator.vue
+++ b/nova-components/WaitingListsManager/resources/js/components/FlagIndicator.vue
@@ -2,20 +2,23 @@
     <div class="flex-row">
         <p class="text-center">
             <span class="mr-1" :class="{ 'italic': automated }">{{ flag.name }}</span>
-            <span
-                class="inline-block rounded-full w-2 h-2"
-                :class="{ 'bg-success': flag.pivot.value, 'bg-danger': !flag.pivot.value, 'cursor-pointer': !automated }"
-                @click="changeFlag(flag)"
-            ></span>
+            <boolean-indicator
+                :value="flag.pivot.value"
+                :class="{ 'cursor-pointer': !automated }"
+                @click.native="changeFlag(flag)"
+            />
         </p>
     </div>
 </template>
 
 <script>
+    import BooleanIndicator from "./BooleanIndicator";
     export default {
         name: "FlagIndicator",
 
         props: ['flag'],
+
+        components: { BooleanIndicator },
 
         computed: {
             automated() {
@@ -25,6 +28,8 @@
 
         methods: {
             changeFlag(flag) {
+                if (this.automated) return;
+
                 this.$emit('changeFlag', flag)
             }
         }

--- a/nova-components/WaitingListsManager/resources/js/components/Tool.vue
+++ b/nova-components/WaitingListsManager/resources/js/components/Tool.vue
@@ -1,8 +1,15 @@
 <template>
     <div>
         <loading-card :loading="!loaded">
+            <div class="py-3 mx-6">
+                <heading class="mb-6">
+                Eligible Waiting List (EWL)
+                </heading>
+                <p>Note: Theory exam status does <strong>not</strong> influence overall eligibility in this list.
+                It is included for reference purposes.</p>
+            </div>
+
             <bucket
-                title="Eligible Waiting List (EWL)"
                 :accounts="eligibleAccounts"
                 :type="type"
                 @removeAccount="removeAccount"
@@ -11,8 +18,10 @@
                 @changeNote="openNotesModal"
                 @changeFlag="openFlagChangeModal"
             />
+            <heading class="mb-6 py-3 px-6">
+                Master Waiting List (MWL)
+            </heading>
             <bucket
-                title="Master Waiting List (MWL)"
                 :accounts="normalAccounts"
                 :type="type"
                 @removeAccount="removeAccount"
@@ -60,7 +69,6 @@
         mounted() {
             this.loadAccounts()
 
-            console.log(this.panel.fields[0].type)
             // required to detect any changes in the other buckets which might be present on the page.
             EventBus.$on('list-changed', this.loadAccounts)
         },

--- a/nova-components/WaitingListsManager/src/Http/WaitingListAccountResource.php
+++ b/nova-components/WaitingListsManager/src/Http/WaitingListAccountResource.php
@@ -21,6 +21,7 @@ class WaitingListAccountResource extends JsonResource
             'status' => new WaitingListStatusResource($this->pivot->status->first()),
             'flags' => $this->pivot->flags,
             'notes' => $this->pivot->notes,
+            'theory_exam_passed' => $this->pivot->theory_exam_passed,
         ];
     }
 }

--- a/tests/Database/MockCtsDatabase.php
+++ b/tests/Database/MockCtsDatabase.php
@@ -194,6 +194,29 @@ class MockCtsDatabase
                 PRIMARY KEY (`id`)
               );"
         );
+
+        DB::connection('cts')->statement(
+            "CREATE TABLE `theory_results` (
+                `id` mediumint unsigned NOT NULL AUTO_INCREMENT,
+                `exam` char(2) NOT NULL DEFAULT '',
+                `student_id` int unsigned NOT NULL DEFAULT '0',
+                `questions` tinyint unsigned NOT NULL DEFAULT '0',
+                `time_mins` tinyint unsigned NOT NULL DEFAULT '0',
+                `passmark` tinyint unsigned NOT NULL DEFAULT '0',
+                `correct` tinyint unsigned NOT NULL DEFAULT '0',
+                `pass` tinyint unsigned NOT NULL DEFAULT '0',
+                `started` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+                `expires` timestamp NULL DEFAULT '0000-00-00 00:00:00',
+                `submitted` tinyint(1) NOT NULL DEFAULT '0',
+                `submitted_time` timestamp NULL DEFAULT '0000-00-00 00:00:00',
+                `upgraded` tinyint unsigned DEFAULT '0',
+                `upgraded_by` int unsigned DEFAULT '0',
+                `upgraded_date` datetime DEFAULT NULL,
+                `old_type` tinyint NOT NULL DEFAULT '0',
+                PRIMARY KEY (`id`),
+                KEY `student_id` (`student_id`)
+              );"
+        );
     }
 
     public static function destroy()
@@ -232,6 +255,10 @@ class MockCtsDatabase
 
         DB::connection('cts')->statement(
             'DROP TABLE IF EXISTS `examinerSettings`;'
+        );
+
+        DB::connection('cts')->statement(
+            'DROP TABLE IF EXISTS `theory_results`;'
         );
     }
 }

--- a/tests/Unit/Training/WaitingList/WaitingListAccountCtsTheoryTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListAccountCtsTheoryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Unit\Training\WaitingList;
+
+use App\Models\Cts\Member;
+use App\Models\Cts\TheoryResult;
+use App\Models\Mship\Account;
+use App\Models\Mship\State;
+use App\Models\Training\WaitingList;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class WaitingListAccountCtsTheoryTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Member $member;
+    private Account $account;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // create the member first as for some reason the CID is not overwritten
+        // when using a factory
+        $this->member = factory(Member::class)->create();
+        $this->account = factory(Account::class)->create(['id' => $this->member->cid]);
+        $this->account->addState(State::findByCode('DIVISION'));
+    }
+
+    /** @test */
+    public function itShouldDetectWhenTheoryExamPassed()
+    {
+        $waitingList = factory(WaitingList::class)->create([
+            'cts_theory_exam_level' => 'S3'
+        ]);
+        $waitingList->addToWaitingList($this->account->fresh(), $this->privacc);
+
+        TheoryResult::factory()->create([
+            'student_id' => $this->member->id,
+            'exam' => 'S3',
+            'pass' => true
+        ]);
+
+
+        $this->assertTrue($waitingList->fresh()->accounts->find($this->account->id)->pivot->theoryExamPassed);
+    }
+
+    /** @test */
+    public function itShouldDetectWhenTheoryExamFailed()
+    {
+        $waitingList = factory(WaitingList::class)->create([
+            'cts_theory_exam_level' => 'S3'
+        ]);
+        $waitingList->addToWaitingList($this->account, $this->privacc);
+
+        TheoryResult::factory()->create([
+            'student_id' => $this->account->id,
+            'exam' => 'S3',
+            'pass' => false
+        ]);
+
+        $this->assertFalse($waitingList->accounts->find($this->account->id)->pivot->theoryExamPassed);
+    }
+
+    /** @test */
+    public function itShouldReturnFalseWhenPilotWaitingList()
+    {
+        $waitingList = factory(WaitingList::class)->create([
+            'cts_theory_exam_level' => null,
+            'department' => WaitingList::PILOT_DEPARTMENT,
+        ]);
+
+        $waitingList->addToWaitingList($this->account, $this->privacc);
+
+        $this->assertFalse($waitingList->accounts->find($this->account->id)->pivot->theoryExamPassed);
+    }
+
+    /** @test */
+    public function itShouldReturnFalseWhenNoExamConfigured()
+    {
+        $waitingList = factory(WaitingList::class)->create([
+            'cts_theory_exam_level' => null,
+        ]);
+
+        $waitingList->addToWaitingList($this->account, $this->privacc);
+
+        $this->assertFalse($waitingList->accounts->find($this->account->id)->pivot->theoryExamPassed);
+    }
+}

--- a/tests/Unit/Training/WaitingList/WaitingListAccountCtsTheoryTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListAccountCtsTheoryTest.php
@@ -54,7 +54,7 @@ class WaitingListAccountCtsTheoryTest extends TestCase
         $waitingList->addToWaitingList($this->account, $this->privacc);
 
         TheoryResult::factory()->create([
-            'student_id' => $this->account->id,
+            'student_id' => $this->member->id,
             'exam' => 'S3',
             'pass' => false,
         ]);
@@ -63,7 +63,7 @@ class WaitingListAccountCtsTheoryTest extends TestCase
     }
 
     /** @test */
-    public function itShouldReturnFalseWhenPilotWaitingList()
+    public function itShouldReturnNullWhenPilotWaitingList()
     {
         $waitingList = factory(WaitingList::class)->create([
             'cts_theory_exam_level' => null,
@@ -72,11 +72,11 @@ class WaitingListAccountCtsTheoryTest extends TestCase
 
         $waitingList->addToWaitingList($this->account, $this->privacc);
 
-        $this->assertFalse($waitingList->accounts->find($this->account->id)->pivot->theoryExamPassed);
+        $this->assertNull($waitingList->accounts->find($this->account->id)->pivot->theoryExamPassed);
     }
 
     /** @test */
-    public function itShouldReturnFalseWhenNoExamConfigured()
+    public function itShouldReturnNullWhenNoExamConfigured()
     {
         $waitingList = factory(WaitingList::class)->create([
             'cts_theory_exam_level' => null,
@@ -84,6 +84,18 @@ class WaitingListAccountCtsTheoryTest extends TestCase
 
         $waitingList->addToWaitingList($this->account, $this->privacc);
 
-        $this->assertFalse($waitingList->accounts->find($this->account->id)->pivot->theoryExamPassed);
+        $this->assertNull($waitingList->accounts->find($this->account->id)->pivot->theoryExamPassed);
+    }
+
+    /** @test */
+    public function itShouldReturnNullWhenNoTheoryResultFound()
+    {
+        $waitingList = factory(WaitingList::class)->create([
+            'cts_theory_exam_level' => 'S3',
+        ]);
+
+        $waitingList->addToWaitingList($this->account, $this->privacc);
+
+        $this->assertNull($waitingList->accounts->find($this->account->id)->pivot->theoryExamPassed);
     }
 }

--- a/tests/Unit/Training/WaitingList/WaitingListAccountCtsTheoryTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListAccountCtsTheoryTest.php
@@ -32,16 +32,15 @@ class WaitingListAccountCtsTheoryTest extends TestCase
     public function itShouldDetectWhenTheoryExamPassed()
     {
         $waitingList = factory(WaitingList::class)->create([
-            'cts_theory_exam_level' => 'S3'
+            'cts_theory_exam_level' => 'S3',
         ]);
         $waitingList->addToWaitingList($this->account->fresh(), $this->privacc);
 
         TheoryResult::factory()->create([
             'student_id' => $this->member->id,
             'exam' => 'S3',
-            'pass' => true
+            'pass' => true,
         ]);
-
 
         $this->assertTrue($waitingList->fresh()->accounts->find($this->account->id)->pivot->theoryExamPassed);
     }
@@ -50,14 +49,14 @@ class WaitingListAccountCtsTheoryTest extends TestCase
     public function itShouldDetectWhenTheoryExamFailed()
     {
         $waitingList = factory(WaitingList::class)->create([
-            'cts_theory_exam_level' => 'S3'
+            'cts_theory_exam_level' => 'S3',
         ]);
         $waitingList->addToWaitingList($this->account, $this->privacc);
 
         TheoryResult::factory()->create([
             'student_id' => $this->account->id,
             'exam' => 'S3',
-            'pass' => false
+            'pass' => false,
         ]);
 
         $this->assertFalse($waitingList->accounts->find($this->account->id)->pivot->theoryExamPassed);


### PR DESCRIPTION
Adds a field to the waiting list index page for ATC lists which indicates whether or not a theory exam
pass has been detected for the user in the list.

The waiting list detects which theory exam to look at via a nullable column in the `training_waiting_list`
table. This will need to be filled out on rollout for each respective level of a waiting list.
This relates to the `exam` field on the `theory_results` table.

The theory_results table in CTS is indexed first on student_id so that additional filtering will be done on
a small number of rows in the logic added to `WaitingListAccount`.

Other changes:
- Added a model for theory exam results which maps to the `theory_results` table in CTS.
- Refactored `Bucket.vue` to have a generic true/false indicator without having to rely on the object structure
of a flag
- Moved the title of a bucket outside the bucket component because I had no idea what I thought when I wrote this 3+ years ago. Some big tidy-up is required at some point in time before I have an effigy assembled in my name and placed on a raging bonfire in disgust. 

I decided against caching this immediately until we have real-world performance measurements on whether the additional complexity is needed. How agile of me!