### PR TITLE
Feat: Waiting list home members only flag

### DIFF
--- a/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
+++ b/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
@@ -21,7 +21,7 @@ class CheckWaitingListAccountMshipState
         // ensure we have the latest data
         $account = $event->account->refresh();
 
-        $accountsWaitingList = $account->currentWaitingLists->filter(function($waitingList) {
+        $accountsWaitingList = $account->currentWaitingLists->filter(function ($waitingList) {
             return $waitingList->home_members_only;
         });
 

--- a/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
+++ b/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
@@ -21,7 +21,9 @@ class CheckWaitingListAccountMshipState
         // ensure we have the latest data
         $account = $event->account->refresh();
 
-        $accountsWaitingList = $account->currentWaitingLists;
+        $accountsWaitingList = $account->currentWaitingLists->filter(function($waitingList) {
+            return $waitingList->home_members_only === 1;
+        });
 
         if ($account->hasState(State::findByCode('DIVISION'))) {
             Log::debug("Account {$account->id} has DIVISION state, skipping removal from waiting list");
@@ -30,7 +32,7 @@ class CheckWaitingListAccountMshipState
         }
 
         if ($accountsWaitingList->count() == 0) {
-            Log::debug("Account {$account->id} is not in a waiting list, skipping");
+            Log::debug("Account {$account->id} is not in a 'home members only' waiting list, skipping");
 
             return;
         }

--- a/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
+++ b/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
@@ -21,8 +21,8 @@ class CheckWaitingListAccountMshipState
         // ensure we have the latest data
         $account = $event->account->refresh();
 
-        $accountsWaitingList = $account->currentWaitingLists->filter(function ($waitingList) {
-            return $waitingList->home_members_only === 1;
+        $accountsWaitingList = $account->currentWaitingLists->filter(function($waitingList) {
+            return $waitingList->home_members_only;
         });
 
         if ($account->hasState(State::findByCode('DIVISION'))) {

--- a/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
+++ b/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
@@ -21,7 +21,7 @@ class CheckWaitingListAccountMshipState
         // ensure we have the latest data
         $account = $event->account->refresh();
 
-        $accountsWaitingList = $account->currentWaitingLists->filter(function($waitingList) {
+        $accountsWaitingList = $account->currentWaitingLists->filter(function ($waitingList) {
             return $waitingList->home_members_only === 1;
         });
 

--- a/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
+++ b/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
@@ -32,7 +32,7 @@ class CheckWaitingListAccountMshipState
         }
 
         if ($accountsWaitingList->count() == 0) {
-            Log::debug("Account {$account->id} is not in a 'home members only' waiting list, skipping");
+            Log::debug("Account {$account->id} is not in a 'home members only' waiting list, skipping.");
 
             return;
         }

--- a/app/Nova/Actions/Training/AddStudentToWaitingList.php
+++ b/app/Nova/Actions/Training/AddStudentToWaitingList.php
@@ -39,7 +39,7 @@ class AddStudentToWaitingList extends Action
             return $this->dangerAction('The specified CID was not found.');
         }
 
-        if (! $account->primary_state->isDivision) {
+        if ($waitingList->home_members_only === 1 && ! $account->primary_state->isDivision) {
             return $this->dangerAction('The specified member is not a home UK member.');
         }
 

--- a/app/Nova/Actions/Training/AddStudentToWaitingList.php
+++ b/app/Nova/Actions/Training/AddStudentToWaitingList.php
@@ -39,7 +39,7 @@ class AddStudentToWaitingList extends Action
             return $this->dangerAction('The specified CID was not found.');
         }
 
-        if ($waitingList->home_members_only === 1 && ! $account->primary_state->isDivision) {
+        if ($waitingList->home_members_only && ! $account->primary_state->isDivision) {
             return $this->dangerAction('The specified member is not a home UK member.');
         }
 

--- a/database/migrations/2023_03_24_165127_waiting_lists_home_members_only_flag.php
+++ b/database/migrations/2023_03_24_165127_waiting_lists_home_members_only_flag.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('training_waiting_list', function (Blueprint $table) {
+            $table->smallInteger('home_members_only')->default(1)->after('flags_check');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('training_waiting_list', function (Blueprint $table) {
+            $table->dropColumn('home_members_only');
+        });
+    }
+};

--- a/database/migrations/2023_03_24_165127_waiting_lists_home_members_only_flag.php
+++ b/database/migrations/2023_03_24_165127_waiting_lists_home_members_only_flag.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('training_waiting_list', function (Blueprint $table) {
-            $table->smallInteger('home_members_only')->default(1)->after('flags_check');
+            $table->boolean('home_members_only')->default(1)->after('flags_check');
         });
     }
 


### PR DESCRIPTION
This PR:

- Creates a flag which can be set per waiting list, which determines if accounts must be a home member to join the list
- Updates the AccountAltered event listener to respect the above flag
- Updates the Waiting List Manager controller to respect the new flag when adding an account
- Updates / creates tests relevant for this task