### PR TITLE
fix: Discord Role Rule Deprecation

### DIFF
--- a/app/Models/Discord/DiscordRoleRule.php
+++ b/app/Models/Discord/DiscordRoleRule.php
@@ -87,7 +87,7 @@ class DiscordRoleRule extends Model
         }
 
         $ctsMember = Member::where('cid', $account->getKey())->first();
-        if (! $ctsMember) {
+        if (! $ctsMember || ! $ctsMember->visit_may_control) {
             return false;
         }
 


### PR DESCRIPTION
Str::contains run with null if the user's CTS record has no CTS_VISIT_CONTROL column. Implements a check for this