### PR TITLE
feat: stand guide

### DIFF
--- a/app/Http/Controllers/Site/PilotPagesController.php
+++ b/app/Http/Controllers/Site/PilotPagesController.php
@@ -41,4 +41,12 @@ class PilotPagesController extends \App\Http\Controllers\BaseController
 
         return $this->viewMake('site.pilots.oceanic');
     }
+
+    public function viewStandGuide()
+    {
+        $this->setTitle('Stand Guide');
+        $this->addBreadcrumb('Stand Guide', route('site.pilots.stands'));
+
+        return $this->viewMake('site.pilots.stands');
+    }
 }

--- a/resources/views/site/home.blade.php
+++ b/resources/views/site/home.blade.php
@@ -118,6 +118,9 @@
                             <a class="nav-link" href="{{ route('site.airports') }}">Airports</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ route('site.pilots.stands') }}">Stand Guide</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ route('site.operations.sectors') }}">Area Sectors</a>
                         </li>
                         <li class="nav-item">

--- a/resources/views/site/pilots/stands.blade.php
+++ b/resources/views/site/pilots/stands.blade.php
@@ -8,8 +8,8 @@
                 </div>
                 <div class="panel-body">
                     <p>
-                        Stand allocation in VATSIM UK is fully automated via the UK Controller Plugin. The system uses
-                        real-world combined with VATSIM network data to ensure that every flight is assigned the most realistic stand possible. The system
+                        Stand allocation at VATSIM UK is fully automated via the UK Controller Plugin. The system uses
+                        real-world and VATSIM network data to ensure that every flight is assigned the most realistic stand possible. The system
                         is reactive to network events such as pilots connecting on the stand and will re-assign stands accordingly.
                     </p>
                     <p>

--- a/resources/views/site/pilots/stands.blade.php
+++ b/resources/views/site/pilots/stands.blade.php
@@ -77,7 +77,7 @@
                     </p>
                     <p>
                         Please note that stand requests <strong>are not a reservation</strong> and do not give you exclusive use of a stand.
-                        Other members are welcome to request the same stand and may also choose to spawn up on it. Stand requests are honoured
+                        Other members are welcome to request the same stand and may also choose to connect onto it. Stand requests are honoured
                         on a "first arrival first served" basis.
                     </p>
                     <p>

--- a/resources/views/site/pilots/stands.blade.php
+++ b/resources/views/site/pilots/stands.blade.php
@@ -1,0 +1,92 @@
+@extends('layout')
+
+@section('content')
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2 ">
+            <div class="panel panel-ukblue">
+                <div class="panel-heading"><i class="glyphicon glyphicon-plane"></i> &thinsp; Stand Allocation in the UK
+                </div>
+                <div class="panel-body">
+                    <p>
+                        Stand allocation in VATSIM UK is fully automated via the UK Controller Plugin. The system uses
+                        real-world combined with VATSIM network data to ensure that every flight is assigned the most realistic stand possible. The system
+                        is reactive to network events such as pilots connecting on the stand and will re-assign stands accordingly.
+                    </p>
+                    <p>
+                        The ultimate authority for stand assignment rests with the controllers and they have the ability to override the system
+                        assignments where required.
+                    </p>
+                    <p>
+                        There are a number of features available to pilots to enhance their experience of arriving into
+                        UK airports on the VATSIM network.
+                    </p>
+                </div>
+            </div>
+            <div class="panel panel-ukblue">
+                <div class="panel-heading"><i class="glyphicon glyphicon-plane"></i> &thinsp; Assignment Timings
+                </div>
+                <div class="panel-body">
+                    <p>
+                        Stand assignments for arriving aircraft are made approximately <strong>15 minutes prior to arrival.</strong>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-4 col-md-offset-2">
+            <div class="panel panel-ukblue">
+                <div class="panel-heading"><i class="glyphicon glyphicon-plane"></i> &thinsp; Stand Assignments over ACARS
+                </div>
+                <div class="panel-body">
+                    <p>
+                        ACARS stands for <strong>Aircraft Communication Addressing and Reporting System</strong> and is a datalink that transmits
+                        messages between aircraft and ground stations. The system is used by airlines to relay operational information, and is used
+                        in some countries as an alternative to voice communication for ATC clearances.
+                    </p>
+                    <p>
+                        VATSIM UK provides a stand assignment over ACARS service to pilots. When an arrival stand assignment is made,
+                        the system will send an ACARS message over <strong>Hoppie's ACARS Network</strong> if the user is logged in. This will be received 
+                        and displayed by the pilots ACARS client. This system can be helpful in preparing to arrive at a busy airport, or to enhance
+                        the realism of your arrival.
+                    </p>
+                    <p>
+                        The system configurable for each user - you can opt to always receive your stand assignment via ACARS
+                        (the system always assigns you a stand, even if there's no controllers online!), or you can opt to only receive it when
+                        there's someone controlling at your destination airfield.
+                    </p>
+                    <p>
+                        To enable this feature, please visit
+                        the <strong><a href="https://ukcp.vatsim.uk/admin/my-preferences">UK Controller Plugin preferences page</a></strong> and select your preffered options.
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="panel panel-ukblue">
+                <div class="panel-heading"><i class="glyphicon glyphicon-plane"></i> &thinsp; Request a Stand
+                </div>
+                <div class="panel-body">
+                    <p>
+                        VATSIM UK also offers pilots the ability to request a stand for arrival. This allows pilots to indicate
+                        their preferences to the stand allocator, which will then attempt to assign them that stand for arrival.
+                    </p>
+                    <p>
+                        To request a stand, make sure that you're logged into the VATSIM network and have filed your flightplan.
+                        Once you've done this, please fill in the <strong><a href="https://ukcp.vatsim.uk/admin/request-a-stand">stand request form</a></strong>.
+                    </p>
+                    <p>
+                        Please note that stand requests <strong>are not a reservation</strong> and do not give you exclusive use of a stand.
+                        Other members are welcome to request the same stand and may also choose to spawn up on it. Stand requests are honoured
+                        on a "first arrival first served" basis.
+                    </p>
+                    <p>
+                        When allocating stands to other aircraft, the stand allocator will always try to assign the most
+                        realistic stand for that flight, even if there is an active request. However, where multiple options
+                        exist, then it will favour non-requested stands.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+@stop

--- a/routes/web-public.php
+++ b/routes/web-public.php
@@ -31,6 +31,7 @@ Route::group([
         Route::get('/ratings')->uses('PilotPagesController@viewRatings')->name('ratings');
         Route::get('/becoming-a-mentor')->uses('PilotPagesController@viewBecomingAMentor')->name('mentor');
         Route::get('/oceanic')->uses('PilotPagesController@viewOceanic')->name('oceanic');
+        Route::get('/stand-guide')->uses('PilotPagesController@viewStandGuide')->name('stands');
     });
 
     Route::group([

--- a/tests/Feature/Site/PilotPagesTest.php
+++ b/tests/Feature/Site/PilotPagesTest.php
@@ -29,4 +29,10 @@ class PilotPagesTest extends TestCase
     {
         $this->get(route('site.pilots.oceanic'))->assertOk();
     }
+
+        /** @test */
+    public function testItLoadsTheStandGuidePage()
+    {
+        $this->get(route('site.pilots.stands'))->assertOk();
+    }
 }

--- a/tests/Feature/Site/PilotPagesTest.php
+++ b/tests/Feature/Site/PilotPagesTest.php
@@ -30,7 +30,7 @@ class PilotPagesTest extends TestCase
         $this->get(route('site.pilots.oceanic'))->assertOk();
     }
 
-        /** @test */
+    /** @test */
     public function testItLoadsTheStandGuidePage()
     {
         $this->get(route('site.pilots.stands'))->assertOk();


### PR DESCRIPTION
Adds a guide for pilots regarding how stands are assigned in VATUK and the features of UKCP available to them.

![image](https://github.com/VATSIM-UK/core/assets/6977297/eb30b82e-f831-4f63-a627-1c2a0262ae49)
