### PR TITLE
Add callsign to viewable feedback

### DIFF
--- a/app/Models/Mship/Feedback/Feedback.php
+++ b/app/Models/Mship/Feedback/Feedback.php
@@ -110,6 +110,13 @@ class Feedback extends Model
         return $this->hasMany(\App\Models\Mship\Feedback\Answer::class);
     }
 
+    public function position()
+    {
+        return $this->hasOne(\App\Models\Mship\Feedback\Answer::class)->whereHas('question', function ($query) {
+            $query->where('slug', ['callsign3', 'sessionposition2']);
+        });
+    }
+
     public function account()
     {
         return $this->belongsTo(\App\Models\Mship\Account::class);

--- a/resources/views/mship/feedback/view.blade.php
+++ b/resources/views/mship/feedback/view.blade.php
@@ -4,25 +4,24 @@
 <div class="panel panel-ukblue">
 	<div class="panel-heading"> My Feedback</div>
 	<div class="panel-body">
-		<p>Here, you can view feedback that has been sent to you by the VATSIM UK training departments.</p>
+		<p>Here, you can view feedback that has been sent to you by the VATSIM UK staff team.</p>
 
 		<table class="table">
 			<tr>
 				<th>Type</th>
 				<th>Feedback Left At</th>
+				<th>Callsign</th>
 				<th>Message</th>
-				<th>Message From</th>
 			</tr>
 			@foreach($feedback as $item)
 				<tr>
 					<td>{{ $item->form->name }}</td>
 					<td>{{ $item->created_at->format('d M Y') }}</td>
+					<td>{{ $item->position->response }}</td>
 					@if($item->sent_comment)
 						<td>{{ $item->sent_comment }}</td>
-						<td>{{ $item->sender->real_name }} ({{ $item->sender->id }})</td>
 					@else
-						<td>The training department wanted to make you aware of some positive feedback that was left for you.</td>
-						<td>Automatic</td>
+						<td>The staff team wanted to make you aware of some positive feedback that was left for you.</td>
 				</tr>
 				@endif
 			@endforeach

--- a/resources/views/mship/feedback/view.blade.php
+++ b/resources/views/mship/feedback/view.blade.php
@@ -17,7 +17,11 @@
 				<tr>
 					<td>{{ $item->form->name }}</td>
 					<td>{{ $item->created_at->format('d M Y') }}</td>
-					<td>{{ $item->position->response }}</td>
+					@if($item->position && $item->position->response !== null)
+						<td>{{ $item->position->response }}</td>
+					@else
+						<td>N/A</td>
+				@endif
 					@if($item->sent_comment)
 						<td>{{ $item->sent_comment }}</td>
 					@else


### PR DESCRIPTION
Hi,

I have made a few changes to the publicly accessible feedback page. This is my first 'play around' with core so I'm still learning, any feedback/comments with improvements for next time are much appreciated.

<hr />

I propose we remove the "Message From" which displays the staff member who sent the feedback (which seems to confuse some members) with a more useful "Callsign" to display the position the user was on when the feedback was received. 

![image](https://github.com/VATSIM-UK/core/assets/39245501/00467d3e-7607-4471-9887-f70230818aaf)

All the best!