### PR TITLE
refactor:Remove Date from VT Dashboard

### DIFF
--- a/resources/views/visit-transfer/site/application/terms.blade.php
+++ b/resources/views/visit-transfer/site/application/terms.blade.php
@@ -8,7 +8,7 @@
                     <p>
                         Before you can start your application, you must first read and agree to the terms and conditions of the
                         Visiting &amp; Transferring Controller Policy (VTCP).
-                        {!! link_to("https://www.vatsim.net/documents/transfer-and-visiting-controller-policy", "The VTCP can be located on the VATSIM.net website", ["target" => "_blank"]) !!}
+                        {!! link_to("https://www.vatsim.net/docs/policy/transfer-and-visiting-controller-policy", "The VTCP can be located on the VATSIM.net website", ["target" => "_blank"]) !!}
                     </p>
 
                 {!! Form::open(["route" => ["visiting.application.start.post", $applicationType, $trainingTeam], "method" => "POST"]) !!}

--- a/resources/views/visit-transfer/site/application/view.blade.php
+++ b/resources/views/visit-transfer/site/application/view.blade.php
@@ -130,10 +130,6 @@
                                 <p class="text-danger">
                                     Your application cannot be completed without receiving training from the {{ strtoupper($application->training_team) }} department.
                                     They will be in touch to discuss this with you.<br />
-                                    <strong>
-                                        You must engage with training before {{ $application->submitted_at->addDays(90)->toDateString() }} otherwise your
-                                        application will be terminated under section 1.9 of the Visiting & Transferring Policy.
-                                    </strong>
                                 </p>
                             @endif
                         </div>


### PR DESCRIPTION
Hi, 

We recently removed the date from the VT acceptance email that said "you must engage with training within 90 days (*this date)"
It's been pointed out that it was still on the website and was worrying some people. The 90 days starts from when we offer them training so this date from the dashboard should be removed.

Thanks,