### PR TITLE
Ukcp dashboard revamp

### DIFF
--- a/app/Http/Controllers/UKCP/Token.php
+++ b/app/Http/Controllers/UKCP/Token.php
@@ -20,7 +20,7 @@ class Token extends BaseController
         parent::__construct();
     }
 
-    public function refresh()
+    public function invalidate()
     {
         $currentTokens = $this->ukcp->getValidTokensFor(auth()->user());
 
@@ -28,24 +28,11 @@ class Token extends BaseController
             $this->ukcp->deleteToken($token->id, auth()->user());
         }
 
-        $newToken = $this->ukcp->createTokenFor(auth()->user());
-
-        if (! $newToken) {
-            return Redirect::route('mship.manage.dashboard')
-                ->withError('An unknown error occured, please contact Web Services.');
-        }
-
-        return redirect()->route('ukcp.guide')->withSuccess('Tokens Updated!');
+        return redirect()->route('ukcp.guide')->withSuccess('Tokens Invalidated!');
     }
 
     public function show()
     {
-        $latestId = $this->ukcp->getValidTokensFor(auth()->user());
-
-        if ($latestId->isEmpty()) {
-            return Redirect::route('ukcp.token.refresh');
-        }
-
-        return $this->viewMake('ukcp.token.guide')->with('newToken', $latestId->first()->id);
+        return $this->viewMake('ukcp.token.guide');
     }
 }

--- a/app/Http/Controllers/UKCP/Token.php
+++ b/app/Http/Controllers/UKCP/Token.php
@@ -4,9 +4,6 @@ namespace App\Http\Controllers\UKCP;
 
 use App\Http\Controllers\BaseController;
 use App\Libraries\UKCP as UKCPLibrary;
-use Illuminate\Support\Facades\Redirect;
-use Illuminate\Support\Facades\Storage;
-use League\Flysystem\FileNotFoundException;
 
 class Token extends BaseController
 {

--- a/app/Http/Controllers/UKCP/Token.php
+++ b/app/Http/Controllers/UKCP/Token.php
@@ -48,20 +48,4 @@ class Token extends BaseController
 
         return $this->viewMake('ukcp.token.guide')->with('newToken', $latestId->first()->id);
     }
-
-    public function download($tokenId)
-    {
-        try {
-            return Storage::disk('local')
-                ->download(
-                    $this->ukcp::getPathForToken($tokenId, auth()->user()),
-                    "{$this->ukcp::getKeyForToken($tokenId)}.json",
-                    [
-                        'Content-Type: application/json',
-                    ]
-                );
-        } catch (FileNotFoundException $e) {
-            return redirect()->back()->with('error', 'There was an issue downloading your file. Please contact Web Services.');
-        }
-    }
 }

--- a/app/Libraries/UKCP.php
+++ b/app/Libraries/UKCP.php
@@ -61,34 +61,6 @@ class UKCP
     }
 
     /**
-     * @return object|null
-     */
-    public function createTokenFor(Account $account)
-    {
-        $pluginAccount = collect($this->getAccountFor($account));
-
-        if ($pluginAccount->isEmpty()) {
-            $result = $this->createAccountFor($account);
-        } else {
-            try {
-                $response = $this->client->post(config('services.ukcp.url').'/api/user/'.$account->id.'/token', ['headers' => [
-                    'Authorization' => 'Bearer '.$this->apiKey,
-                ]]);
-                $result = $response->getBody()->getContents();
-            } catch (ClientException $e) {
-                Log::warning("UKCP Client Error {$e->getMessage()} failed to create UKCP Token for {$account->id}");
-
-                return;
-            }
-        }
-
-        $token = $this->getValidTokensFor($account)->first();
-        Storage::disk('local')->put(self::getPathForToken($token->id, $account), $result);
-
-        return $token;
-    }
-
-    /**
      * @return bool
      */
     public function deleteToken(string $tokenId, Account $account)

--- a/app/Libraries/UKCP.php
+++ b/app/Libraries/UKCP.php
@@ -32,21 +32,6 @@ class UKCP
         $this->client = $client;
     }
 
-    public function createAccountFor(Account $account)
-    {
-        try {
-            $result = $this->client->post(config('services.ukcp.url').'/api/user/'.$account->id, ['headers' => [
-                'Authorization' => 'Bearer '.$this->apiKey,
-            ]]);
-        } catch (ClientException $e) {
-            Log::warning("UKCP Client Error {$e->getMessage()} when creating account {$account->id}");
-
-            return;
-        }
-
-        return $result->getBody()->getContents();
-    }
-
     /**
      * @return array|Collection|mixed|ResponseInterface
      */

--- a/app/Libraries/UKCP.php
+++ b/app/Libraries/UKCP.php
@@ -75,9 +75,6 @@ class UKCP
             return false;
         }
 
-        // Delete local file
-        Storage::disk('local')->delete(self::getPathForToken($tokenId, $account));
-
         return true;
     }
 

--- a/app/Libraries/UKCP.php
+++ b/app/Libraries/UKCP.php
@@ -9,7 +9,6 @@ use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 use Psr\Http\Message\ResponseInterface;
 
 class UKCP

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -432,7 +432,7 @@
                             <b>UK CONTROLLER<br/>PLUGIN KEYS</b>
                             @if(count($pluginKeys))
                                 <div class="text-center pt-4">
-                                    <a class="btn btn-warning btn-sm" href="{{ route('ukcp.token.refresh') }}">
+                                    <a class="btn btn-warning btn-sm" href="{{ route('ukcp.token.invalidate') }}">
                                         Invalidate Token(s)
                                     </a>
                                     </br>

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -433,10 +433,12 @@
                             @if(count($pluginKeys))
                                 <div class="text-center pt-4">
                                     <a class="btn btn-warning btn-sm" href="{{ route('ukcp.token.refresh') }}">
-                                        Refresh Token(s)
+                                        Invalidate Token(s)
                                     </a>
                                     </br>
-                                    <small>Note: Will invalidate all current tokens</small>
+                                    <small>
+                                        Note: If you are currently online, some operations, such as squawk assignments, will fail.
+                                    </small>
                                 </div>
                             @endif
                         </div>

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -458,13 +458,10 @@
                                             <em>{{ \Carbon\Carbon::createFromTimeString($key->expires_at)->diffForHumans() }}</em>
                                         </a>
                                         <br/>
-                                        [ <a href="{{ route('ukcp.token.download', $key->id) }}">Download Key</a> ]
                                     </div>
                                 @empty
                                     <p>
                                         No keys found.</br>
-                                        <a class="btn btn-sm btn-info" href="{{ route('ukcp.token.refresh') }}">Create
-                                            UKCP Token</a>
                                     </p>
                                 @endforelse
                             </div>

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -475,6 +475,14 @@
                                 your keys</b> as actions taken with these keys are logged against your account.
                         </div>
                     </div>
+                    <br/>
+                    <div class="row">
+                        <div class="col-xs-12">
+                            When you start EuroScope, the plugin will automatically take you through the process
+                            to set up a new key, if required. You can find more information about this process in the
+                            UK Controller Plugin guide.
+                        </div>
+                    </div>
                 </div>
                 <div class="panel-footer panel-footer-primary">
                     <div class="row">

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -130,7 +130,6 @@ Route::group([
 ], function () {
     Route::get('/')->uses('Token@show')->name('guide');
     Route::get('/token/refresh')->uses('Token@refresh')->name('token.refresh');
-    Route::get('token/{id}/download')->uses('Token@download')->name('token.download');
 });
 
 // Controllers

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -129,7 +129,7 @@ Route::group([
     'middleware' => 'auth_full_group',
 ], function () {
     Route::get('/')->uses('Token@show')->name('guide');
-    Route::get('/token/refresh')->uses('Token@refresh')->name('token.refresh');
+    Route::get('/token/invalidate')->uses('Token@invalidate')->name('token.invalidate');
 });
 
 // Controllers

--- a/tests/Unit/UKCPLibraryTest.php
+++ b/tests/Unit/UKCPLibraryTest.php
@@ -32,10 +32,6 @@ class UKCPLibraryTest extends TestCase
     {
         $currentTokenID = '1234567891234abcd';
 
-        // Put in a fake existing token
-        Storage::fake('local');
-        Storage::disk('local')->put(UKCP::getPathForToken($currentTokenID, $this->user), '');
-
         $this->mock(Client::class, function (MockInterface $mock) {
             $mock->shouldReceive('delete')
                 ->andReturn(new \GuzzleHttp\Psr7\Response(200, [], true));

--- a/tests/Unit/UKCPLibraryTest.php
+++ b/tests/Unit/UKCPLibraryTest.php
@@ -9,7 +9,6 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Storage;
 use Mockery\MockInterface;
 use Tests\TestCase;
 

--- a/tests/Unit/UKCPLibraryTest.php
+++ b/tests/Unit/UKCPLibraryTest.php
@@ -43,8 +43,6 @@ class UKCPLibraryTest extends TestCase
 
         $ukcp = resolve(UKCP::class);
         $ukcp->deleteToken($currentTokenID, $this->user);
-
-        Storage::disk('local')->assertMissing(UKCP::getPathForToken($currentTokenID, $this->user));
     }
 
     public function testItReturnsCachedStandStatus()

--- a/tests/Unit/UKCPLibraryTest.php
+++ b/tests/Unit/UKCPLibraryTest.php
@@ -28,40 +28,6 @@ class UKCPLibraryTest extends TestCase
     }
 
     /** @test */
-    public function itCanCreateAToken()
-    {
-        $token = json_encode([
-            'api-url' => 'http://awebaddress.test',
-            'api-key' => '1234',
-        ]);
-
-        $this->mock(Client::class, function (MockInterface $mock) use ($token) {
-            $mock->shouldReceive('get')
-                ->andReturn(
-                    new \GuzzleHttp\Psr7\Response(200, [], json_encode([
-                        'id' => $this->user->id,
-                        'tokens' => [],
-                    ])),
-                    new \GuzzleHttp\Psr7\Response(200, [], json_encode([
-                        'id' => $this->user->id,
-                        'tokens' => [
-                            ['id' => '1234abc', 'revoked' => false],
-                        ],
-                    ])));
-
-            $mock->shouldReceive('post')
-                ->andReturn(new \GuzzleHttp\Psr7\Response(200, [], $token));
-        })->makePartial();
-
-        Storage::fake('local');
-
-        $ukcp = resolve(UKCP::class);
-        $ukcp->createTokenFor($this->user);
-
-        Storage::disk('local')->assertExists(UKCP::getPathForToken('1234abc', $this->user));
-    }
-
-    /** @test */
     public function itCanDeleteTokens()
     {
         $currentTokenID = '1234567891234abcd';


### PR DESCRIPTION
Revamps the dashboard for UKCP to make it consistent with the new setup method. Removes manually creating and downloading keys via Core.

![image](https://github.com/VATSIM-UK/core/assets/6977297/def670cf-8ae1-40a0-90b0-d6cbea23e88d)

![image](https://github.com/VATSIM-UK/core/assets/6977297/152fe556-6ec3-4757-9e5f-aedc94ebf140)
