### PR TITLE
fix: handle -1 pilotrating bitmask and pilot rating revokation

### DIFF
--- a/app/Models/Mship/Qualification.php
+++ b/app/Models/Mship/Qualification.php
@@ -92,9 +92,26 @@ class Qualification extends Model
     {
         $ratingsOutput = [];
 
+        // -1 will be returned as the pilot rating before the user has completed the P0 exam
+        // should they log into our system before completing the exam.
+        if ($network == -1) {
+            return $ratingsOutput;
+        }
+
         // A P0 will not be picked up in the bitmap
         if ($network >= 0) {
             array_push($ratingsOutput, self::ofType('pilot')->networkValue(0)->first());
+        }
+
+        // if network is not an even bitmask number parse as a 'special' rating
+        // where only one rating would be assigned to the user.
+        if ($network % 2 !== 0) {
+            $ro = self::ofType('pilot')->networkValue($network)->first();
+            if ($ro) {
+                array_push($ratingsOutput, $ro);
+            }
+
+            return $ratingsOutput;
         }
 
         // Let's check each bitmask....

--- a/tests/Unit/Mship/QualificationDetectionTest.php
+++ b/tests/Unit/Mship/QualificationDetectionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Unit\Mship;
+
+use App\Models\Mship\Qualification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class QualificationDetectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function itHandlesMinus1ReportedAsP0()
+    {
+        $qualifications = Qualification::parseVatsimPilotQualifications(-1);
+
+        $p0_qualification = Qualification::where('code', 'P0')->first();
+
+        $this->assertTrue(collect($qualifications)->pluck('code')->contains($p0_qualification->code));
+    }
+
+    /** @test */
+    public function itHandlesFlightInstructorRating()
+    {
+        $flightInstructorQualification = Qualification::where('code', 'FI')->first();
+
+        $qualifications = Qualification::parseVatsimPilotQualifications($flightInstructorQualification->vatsim);
+
+        $this->assertTrue(collect($qualifications)->pluck('code')->contains($flightInstructorQualification->code));
+    }
+
+    /** @test */
+    public function itHandlesFlightExaminerRating()
+    {
+        $flightExaminerQualification = Qualification::where('code', 'FE')->first();
+
+        $qualifications = Qualification::parseVatsimPilotQualifications($flightExaminerQualification->vatsim);
+
+        $this->assertTrue(collect($qualifications)->pluck('code')->contains($flightExaminerQualification->code));
+    }
+
+    /** @test @dataProvider pilotRatingsTestData */
+    public function itHandlesNormalPilotRatings($networkBitmask, $expectedCode)
+    {
+        $qualifications = Qualification::parseVatsimPilotQualifications($networkBitmask);
+
+        $this->assertTrue(collect($qualifications)->pluck('code')->contains($expectedCode));
+    }
+
+    protected function pilotRatingsTestData()
+    {
+        return [
+            // [Bitmask, Expected Code]
+            [1, 'P1'],
+            [2, 'P2'],
+            [4, 'P3'],
+            [8, 'P4'],
+            [16, 'P5'],
+        ];
+    }
+}

--- a/tests/Unit/Mship/QualificationDetectionTest.php
+++ b/tests/Unit/Mship/QualificationDetectionTest.php
@@ -11,13 +11,11 @@ class QualificationDetectionTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function itHandlesMinus1ReportedAsP0()
+    public function itHandlesMinus1ByNotAssigningPilotRatings()
     {
         $qualifications = Qualification::parseVatsimPilotQualifications(-1);
 
-        $p0_qualification = Qualification::where('code', 'P0')->first();
-
-        $this->assertTrue(collect($qualifications)->pluck('code')->contains($p0_qualification->code));
+        $this->assertEmpty($qualifications);
     }
 
     /** @test */


### PR DESCRIPTION
This fixes the reported trello bug where P0 members were being granted pilot ratings upto P5. This was due to the bitmask logic when parsing the ratings squaring a negative number (-1) and then shifting all the way upto P5.

This also supports pilot ratings for Flight Instructor & Flight Examiner via UpdateMember and allows the new behaviour when these ratings are revoked in favour of previous permeanant pilot ratings.
