### PR TITLE
Add historical booking api with 12 hour cache

### DIFF
--- a/app/Repositories/Cts/BookingRepository.php
+++ b/app/Repositories/Cts/BookingRepository.php
@@ -41,6 +41,16 @@ class BookingRepository
         return $this->formatBookings($bookings);
     }
 
+    public function getHistoricalBookings()
+    {
+        $bookings = Booking::where('date', '<', Carbon::now()->toDateString())
+            ->with('member')
+            ->orderBy('from')
+            ->get();
+
+        return $this->formatBookings($bookings);
+    }
+
     private function formatBookings(Collection $bookings)
     {
         $bookings->transform(function ($booking) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,17 @@
 <?php
+use Illuminate\Support\Facades\Cache;
 
 Route::get('validations')->uses('Api\CTS\ValidationsController@view')->name('api.validations');
 Route::get('metar/{airportIcao}')->uses('Site\MetarController@get')->name('api.metar');
+Route::get('/bookings', function () {
+    $bookings = Cache::remember('bookings', 720, function () {
+        $bookings = new BookingRepository();
+        return $bookings->getHistoricalBookings();
+    });
+
+    return response()->json($bookings);
+});
+
 
 Route::group([
     'middleware' => 'api_auth',


### PR DESCRIPTION
I've added a route to retrieve all historical atc bookings with a 12 hour cache to not stress the database with every request.
Probably would like to allow some kind of params in the api request as well to only retrieve specific data but I am not sure what the best approach to this would be.