### PR TITLE
AFIS/AG Endorsement list AIRAC 2311

### DIFF
--- a/resources/views/site/atc/endorsements.blade.php
+++ b/resources/views/site/atc/endorsements.blade.php
@@ -113,27 +113,68 @@
                         <li>Bembridge (EGHJ)</li>
                         <li>Blackbushe (EGLK)</li>
                         <li>Bodmin (EGLA)</li>
+                        <li>Caernarfon (EGCK)</li>
+                        <li>Campbeltown (EGEC)</li>
+                        <li>Chalgrove (EGLJ)</li>
                         <li>Chichester Goodwood (EGHR)</li>
                         <li>Clacton (EGSQ)</li>
+                        <li>Coll (EGEL)</li>
+                        <li>Colonsay (EGEY)</li>
+                        <li>Compton Abbas (EGHA)</li>
                         <li>Coventry (EGBE)</li>
                         <li>Cumbernauld (EGPG)</li>
+                        <li>Cumbernauld (EGPG)</li>
+                        <li>Denham (EGLD)</li>
+                        <li>Derby (EGBD)</li>
                         <li>Dunkeswell (EGTU)</li>
                         <li>Duxford (EGSU)</li>
+                        <li>Earls Colne (EGSR)</li>
                         <li>Elstree (EGTR)</li>
+                        <li>Enniskillen/St Angelo (EGAB)</li>
+                        <li>Fair Isle (EGEF)</li>
                         <li>Fairoaks (EGTF)</li>
+                        <li>Fenland (EGCL)</li>
                         <li>Gamston (EGNE)</li>
                         <li>Haverfordwest (EGFE)</li>
+                        <li>Islay (EGPI)</li>
                         <li>Kemble (EGBP)</li>
+                        <li>Lashenden/Headcorn (EGKH)</li>
+                        <li>Lee-on-Solent (EGHF)</li>
+                        <li>Leeds East/Fenton (EGCM)</li>
+                        <li>Leicester (EGBG)</li>
+                        <li>Lerwick/Tingwall (EGET)</li>
                         <li>Manchester Barton (EGCB)</li>
                         <li>Netherthorpe (EGNF)</li>
                         <li>Newtownards (EGAD)</li>
+                        <li>Northampton/Sywell (EGBK)</li>
+                        <li>Nottingham (EGBN)</li>
+                        <li>Oban (EGEO)</li>
+                        <li>Old Buckenham (EGSV)</li>
                         <li>Old Sarum (EGLS)</li>
+                        <li>Old Warden (EGTH)</li>
+                        <li>Penzance (EGHK)</li>
+                        <li>Perth (EGPT)</li>
+                        <li>Peterborough/Conington (EGSF)</li>
+                        <li>Portland (EGDP)</li>
                         <li>Rochester (EGTO)</li>
+                        <li>Sandtoft (EGCF)</li>
                         <li>Sherburn-in-Elmet (EGCJ)</li>
+                        <li>Shobdon (EGBS)</li>
+                        <li>Sleap (EGCV)</li>
                         <li>Stapleford (EGSG)</li>
                         <li>Swansea (EGFH)</li>
+                        <li>Tatenhill (EGBM)</li>
                         <li>Thruxton (EGHO)</li>
+                        <li>Tiree (EGPU)</li>
+                        <li>Tresco (EGHT)</li>
+                        <li>Walney (EGNL)</li>
+                        <li>Wellesbourne (EGBW)</li>
+                        <li>Welshpool (EGCW)</li>
+                        <li>West Wales/Aberporth (EGFA)</li>
+                        <li>White Waltham (EGLM)</li>
+                        <li>Wickenby (EGNW)</li>
                         <li>Wolverhampton / Halfpenny Green (EGBO)</li>
+                        <li>Wycombe Air Park/Booker (EGTB)</li>
                     </ul>
 
                     <h3>Get Started</h3>


### PR DESCRIPTION
Updates to the AFIS/AG endorsement list for 2311.

To be released/updated on 1st November please.