### PR TITLE
feature: Allow searching of Discord ID in Account list

### DIFF
--- a/app/Filament/Resources/AccountResource.php
+++ b/app/Filament/Resources/AccountResource.php
@@ -117,7 +117,8 @@ class AccountResource extends Resource implements DefinesGatedAttributes
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('id')->sortable()->searchable()->label('ID'),
+                Tables\Columns\TextColumn::make('id')->sortable()->searchable()->label('CID'),
+                Tables\Columns\TextColumn::make('discord_id')->searchable()->label('Discord ID')->toggleable(),
                 Tables\Columns\TextColumn::make('name')->sortable()->searchable(['name_first', 'name_last']),
                 Tables\Columns\TextColumn::make('qualification_atc')->sortable()->label('ATC Rating'),
                 Tables\Columns\TextColumn::make('qualification_pilot')->sortable()->label('Pilot Rating'),


### PR DESCRIPTION
The Discord ID column is now toggleable on the Account list admin page. It defaults to hidden but allows searching by Discord ID