### PR TITLE
feat: Prefill usercid in feedback forms

### DIFF
--- a/app/Http/Controllers/Mship/Feedback.php
+++ b/app/Http/Controllers/Mship/Feedback.php
@@ -199,4 +199,9 @@ class Feedback extends \App\Http\Controllers\BaseController
 
         return response()->json($this->returnList);
     }
+
+    public function redirectNewAtc(Request $request)
+    {
+        return redirect()->route('mship.feedback.new.form', array_merge(['atc'], $request->query->all()));
+    }
 }

--- a/app/Http/Controllers/Mship/Feedback.php
+++ b/app/Http/Controllers/Mship/Feedback.php
@@ -44,8 +44,9 @@ class Feedback extends \App\Http\Controllers\BaseController
     public function getFeedback(Form $form, Request $request)
     {
         // Get a list of "pre-fillable" questions from the request, based on question slug
-        // To allow direct links from e.g euroscope profiles via vats.im/atcfb?usercid=12345
-        $preFillable = $request->only(['usercid']);
+        // To allow direct links from e.g euroscope profiles via vatsim.uk/atcfb?cid=12345
+        $preFillable = $request->only(['cid']);
+        $preFilled = ['usercid' => array_get($preFillable, 'cid')];
 
         /** @var Question[] $questions */
         $questions = $form->questions()->orderBy('sequence')->get();
@@ -75,7 +76,8 @@ class Feedback extends \App\Http\Controllers\BaseController
                 continue;
             }
 
-            $question->form_html .= sprintf($question->type->code, $question->slug, old($question->slug, array_get($preFillable, $question->slug)));
+            $fromQuery = array_get($preFilled, $question->slug);
+            $question->form_html .= sprintf($question->type->code, $question->slug, old($question->slug, $fromQuery));
         }
 
         return $this->viewMake('mship.feedback.form')->with(['form' => $form, 'questions' => $questions]);

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -95,6 +95,13 @@ Route::group([
     });
 });
 
+// Special short ATC feedback link
+Route::get('atcfb', [
+    'middleware' => 'auth_full_group',
+    'as' => 'mship.feedback.atc-redirect',
+    'uses' => 'Mship\Feedback@redirectNewAtc'
+]);
+
 // TeamSpeak
 Route::group([
     'prefix' => 'mship/manage/teamspeak',

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -95,12 +95,13 @@ Route::group([
     });
 });
 
-// Special short ATC feedback link
-Route::get('atcfb', [
-    'middleware' => 'auth_full_group',
-    'as' => 'mship.feedback.atc-redirect',
-    'uses' => 'Mship\Feedback@redirectNewAtc',
-]);
+Route::get('atcfb', function () {
+    return redirect()
+        ->route('mship.feedback.new.form', [
+            'form' => 'atc',
+            'cid' => request()->get('cid')
+        ]);
+})->name('mship.feedback.redirect.atc');
 
 // TeamSpeak
 Route::group([

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -99,7 +99,7 @@ Route::group([
 Route::get('atcfb', [
     'middleware' => 'auth_full_group',
     'as' => 'mship.feedback.atc-redirect',
-    'uses' => 'Mship\Feedback@redirectNewAtc'
+    'uses' => 'Mship\Feedback@redirectNewAtc',
 ]);
 
 // TeamSpeak

--- a/tests/Feature/Account/Feedback/FeedbackTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackTest.php
@@ -72,7 +72,7 @@ class FeedbackTest extends TestCase
         }
 
         $request = $this->actingAs($this->user, 'web')
-            ->call('GET', route('mship.feedback.atc-redirect'), ['cid' => 'mycidishere']);
+            ->call('GET', route('mship.feedback.redirect.atc'), ['cid' => 'mycidishere']);
 
         $request->assertRedirect(route('mship.feedback.new.form', [$form->slug, 'cid' => 'mycidishere']));
     }

--- a/tests/Feature/Account/Feedback/FeedbackTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackTest.php
@@ -58,7 +58,7 @@ class FeedbackTest extends TestCase
         }
 
         $request = $this->actingAs($this->user, 'web')
-            ->call('GET', route('mship.feedback.new.form', $form->slug), ['usercid' => 'mycidishere']);
+            ->call('GET', route('mship.feedback.new.form', $form->slug), ['cid' => 'mycidishere']);
 
         $request->assertSuccessful();
         $request->assertSee('mycidishere');
@@ -72,9 +72,9 @@ class FeedbackTest extends TestCase
         }
 
         $request = $this->actingAs($this->user, 'web')
-            ->call('GET', route('mship.feedback.atc-redirect'), ['usercid' => 'mycidishere']);
+            ->call('GET', route('mship.feedback.atc-redirect'), ['cid' => 'mycidishere']);
 
-        $request->assertRedirect(route('mship.feedback.new.form', [$form->slug, 'usercid' => 'mycidishere']));
+        $request->assertRedirect(route('mship.feedback.new.form', [$form->slug, 'cid' => 'mycidishere']));
     }
 
     //    /** @test */

--- a/tests/Feature/Account/Feedback/FeedbackTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackTest.php
@@ -64,6 +64,19 @@ class FeedbackTest extends TestCase
         $request->assertSee('mycidishere');
     }
 
+    public function testItRedirectsToAtcFeedback()
+    {
+        $form = Form::whereSlug('atc')->first();
+        if (!$form) {
+            $this->markTestSkipped('could not find atc form');
+        }
+
+        $request = $this->actingAs($this->user, 'web')
+            ->call('GET', route('mship.feedback.atc-redirect'), ['usercid' => 'mycidishere']);
+
+        $request->assertRedirect(route('mship.feedback.new.form', [$form->slug, 'usercid' => 'mycidishere']));
+    }
+
     //    /** @test */
     //    public function testItAllowsSubmission()
     //    {

--- a/tests/Feature/Account/Feedback/FeedbackTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackTest.php
@@ -53,7 +53,7 @@ class FeedbackTest extends TestCase
     public function testItFillsUserCidInAtcForm()
     {
         $form = Form::whereSlug('atc')->first();
-        if (!$form) {
+        if (! $form) {
             $this->markTestSkipped('could not find atc form');
         }
 
@@ -67,7 +67,7 @@ class FeedbackTest extends TestCase
     public function testItRedirectsToAtcFeedback()
     {
         $form = Form::whereSlug('atc')->first();
-        if (!$form) {
+        if (! $form) {
             $this->markTestSkipped('could not find atc form');
         }
 

--- a/tests/Feature/Account/Feedback/FeedbackTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackTest.php
@@ -49,6 +49,21 @@ class FeedbackTest extends TestCase
             ->assertSuccessful();
     }
 
+    /** @test */
+    public function testItFillsUserCidInAtcForm()
+    {
+        $form = Form::whereSlug('atc')->first();
+        if (!$form) {
+            $this->markTestSkipped('could not find atc form');
+        }
+
+        $request = $this->actingAs($this->user, 'web')
+            ->call('GET', route('mship.feedback.new.form', $form->slug), ['usercid' => 'mycidishere']);
+
+        $request->assertSuccessful();
+        $request->assertSee('mycidishere');
+    }
+
     //    /** @test */
     //    public function testItAllowsSubmission()
     //    {


### PR DESCRIPTION
A little poc for prefilling the usercid in e.g the atc feedback form.

Saw some discussion on discord about trying to search for a controller name in order to submit feedback, I know I've been asked by pilots what my CID is so they can submit feedback about me (good feedback I hope!)

This fills the `Question` with slug `usercid` if the `usercid` is present in the query params.

Because the link to the new atc feedback form is quite long and getting a query param through a url shortener (`vats.im/atcfb`) is challenging I've also added a short url to the atc feedback form (`vatsim.uk/atcfb`)

My intention would be to use it in euroscope profiles as `Submit feedback at vatsim.uk/atcfb?usercid=12345678`).

Keen to know your thoughts, further notes below.

-------------

I believe the url shortener is short.io? It would be possible to generate unique short urls for each controller, but this would be way more complex so I've just done this for now.

-------------

I tried using a redirect route but this had two problems:
1. I'm not sure if this would pass query params along, but couldn't test it as
2. Defining a top level redirect to a named route seems to be impossible when the route is defined in a group closure, guessing laravel evaluates redirects before groups.


