### PR TITLE
feat: automatically add a member to the roster when they have been granted an S1

### DIFF
--- a/app/Listeners/Mship/AddNewlyQualifiedS1ToRoster.php
+++ b/app/Listeners/Mship/AddNewlyQualifiedS1ToRoster.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Listeners\Mship;
+
+use App\Events\Mship\Qualifications\QualificationAdded;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class AddNewlyQualifiedS1ToRoster
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(QualificationAdded $event): void
+    {
+        //
+    }
+}

--- a/app/Listeners/Mship/AddNewlyQualifiedS1ToRoster.php
+++ b/app/Listeners/Mship/AddNewlyQualifiedS1ToRoster.php
@@ -3,24 +3,40 @@
 namespace App\Listeners\Mship;
 
 use App\Events\Mship\Qualifications\QualificationAdded;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
+use App\Models\Roster;
+use App\Repositories\Cts\ExamResultRepository;
+use Illuminate\Support\Facades\Log;
 
 class AddNewlyQualifiedS1ToRoster
 {
-    /**
-     * Create the event listener.
-     */
-    public function __construct()
+    public function __construct(private ExamResultRepository $examResultRepository)
     {
-        //
     }
 
     /**
-     * Handle the event.
+     * If the member has recently passed the OBS exam, add them to the roster.
+     * It is important to check for the recent exam as this event will fire for any member logging
+     * in to VATSIM UK systems as an S1 and they are not necessarily a new S1.
      */
     public function handle(QualificationAdded $event): void
     {
-        //
+        $newQualification = $event->qualification;
+
+        if ($newQualification->code !== 'S1') {
+            return;
+        }
+
+        $hasPassedExam = $this->examResultRepository->getPassedExamResultsOfTypeForMember(
+            $event->account->id,
+            'OBS'
+        );
+
+        // If the member has passed the OBS exam in the last month, add them to the roster.
+        $hasRecentS1Exam = $hasPassedExam && $hasPassedExam->date->diffInMonths(now()) < 1;
+
+        if ($hasRecentS1Exam) {
+            Log::info("Adding {$event->account->id} to the roster as newly qualified S1");
+            Roster::create(['account_id' => $event->account->id]);
+        }
     }
 }

--- a/app/Models/Cts/PracticalResult.php
+++ b/app/Models/Cts/PracticalResult.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models\Cts;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PracticalResult extends Model
+{
+    use HasFactory;
+
+    protected $connection = 'cts';
+
+    public $timestamps = false;
+
+    public const PASSED = 'P';
+    public const FAILED = 'F';
+
+    protected $casts = [
+        'date' => 'datetime',
+    ];
+}

--- a/app/Models/Cts/PracticalResult.php
+++ b/app/Models/Cts/PracticalResult.php
@@ -14,6 +14,7 @@ class PracticalResult extends Model
     public $timestamps = false;
 
     public const PASSED = 'P';
+
     public const FAILED = 'F';
 
     protected $casts = [

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -26,7 +26,7 @@ class EventServiceProvider extends ServiceProvider
 
         \App\Events\Mship\Qualifications\QualificationAdded::class => [
             \App\Listeners\Mship\SendS1Email::class,
-            \App\Listeners\Mship\AddNewlyQualifiedS1ToRoster::class
+            \App\Listeners\Mship\AddNewlyQualifiedS1ToRoster::class,
         ],
 
         \App\Events\Mship\Bans\BanUpdated::class => [

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -26,6 +26,7 @@ class EventServiceProvider extends ServiceProvider
 
         \App\Events\Mship\Qualifications\QualificationAdded::class => [
             \App\Listeners\Mship\SendS1Email::class,
+            \App\Listeners\Mship\AddNewlyQualifiedS1ToRoster::class
         ],
 
         \App\Events\Mship\Bans\BanUpdated::class => [

--- a/app/Repositories/Cts/ExamResultRepository.php
+++ b/app/Repositories/Cts/ExamResultRepository.php
@@ -9,7 +9,7 @@ class ExamResultRepository
 {
     public function getPassedExamResultsOfTypeForMember(int $cid, string $type)
     {
-        $studentId = Member::where("cid", $cid)->firstOrFail()?->id;
+        $studentId = Member::where('cid', $cid)->firstOrFail()?->id;
 
         return PracticalResult::where('result', PracticalResult::PASSED)
             ->where('exam', $type)

--- a/app/Repositories/Cts/ExamResultRepository.php
+++ b/app/Repositories/Cts/ExamResultRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Repositories\Cts;
+
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalResult;
+
+class ExamResultRepository
+{
+    public function getPassedExamResultsOfTypeForMember(int $cid, string $type)
+    {
+        $studentId = Member::where("cid", $cid)->firstOrFail()?->id;
+
+        return PracticalResult::where('result', PracticalResult::PASSED)
+            ->where('exam', $type)
+            ->where('student_id', $studentId)
+            ->first();
+    }
+}

--- a/database/factories/Cts/PracticalResultFactory.php
+++ b/database/factories/Cts/PracticalResultFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories\Cts;
+
+use App\Models\Cts\Member;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Cts\PracticalResult>
+ */
+class PracticalResultFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'examid' => $this->faker->randomNumber(3),
+            'student_id' => factory(Member::class)->create()->id,
+            'exam' => $this->faker->randomElement(['OBS', 'TWR', 'APP', 'CTR']),
+            'result' => $this->faker->randomElement(['P', 'F']),
+            'date' => $this->faker->dateTime(),
+        ];
+    }
+}

--- a/tests/Database/MockCtsDatabase.php
+++ b/tests/Database/MockCtsDatabase.php
@@ -217,6 +217,23 @@ class MockCtsDatabase
                 KEY `student_id` (`student_id`)
               );"
         );
+
+        DB::connection('cts')->statement(
+            "CREATE TABLE `practical_results` (
+                `id` smallint unsigned NOT NULL AUTO_INCREMENT,
+                `examid` smallint unsigned NOT NULL DEFAULT '0',
+                `student_id` int unsigned NOT NULL DEFAULT '0',
+                `exam` enum('P1','P2','P3','P4','P5','P6','P7','P8','P9','OBS','TWR','APP','CTR','S3','C1','C3') NOT NULL DEFAULT 'TWR',
+                `notes` longtext,
+                `result` char(1) NOT NULL DEFAULT '',
+                `date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+                `cert_upgrade` tinyint unsigned DEFAULT '0',
+                `upgrade_by` int unsigned DEFAULT '0',
+                `upgrade_date` datetime DEFAULT NULL,
+                PRIMARY KEY (`id`),
+                KEY `student_id` (`student_id`)
+              );"
+        );
     }
 
     public static function destroy()

--- a/tests/Database/MockCtsDatabase.php
+++ b/tests/Database/MockCtsDatabase.php
@@ -277,5 +277,9 @@ class MockCtsDatabase
         DB::connection('cts')->statement(
             'DROP TABLE IF EXISTS `theory_results`;'
         );
+
+        DB::connection('cts')->statement(
+            'DROP TABLE IF EXISTS `practical_results`;'
+        );
     }
 }

--- a/tests/Unit/Account/Roster/NewlyQualifiedControllerTest.php
+++ b/tests/Unit/Account/Roster/NewlyQualifiedControllerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit\Account\Roster;
+
+use App\Events\Mship\Qualifications\QualificationAdded;
+use App\Listeners\Mship\AddNewlyQualifiedS1ToRoster;
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalResult;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use App\Repositories\Cts\ExamResultRepository;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class NewlyQualifiedControllerTest extends TestCase
+{
+    public function test_adds_newly_qualified_controller_to_roster()
+    {
+        $account = Account::factory()->create(['id' => 1111111]);
+        // make sure the QualificationAdded event doesn't fire for test setup.
+        Event::fakeFor(function () use ($account) {
+            $account->addQualification(Qualification::code('OBS')->first());
+        });
+
+        $newQualification = Qualification::code('S1')->first();
+
+        $ctsMember = factory(Member::class)->create([
+            'cid' => $account->id,
+        ]);
+        PracticalResult::factory()->create([
+            'student_id' => $ctsMember->id,
+            'exam' => 'OBS',
+            'result' => PracticalResult::PASSED,
+            'date' => now(),
+        ]);
+
+        $event = new QualificationAdded($account->fresh(), $newQualification);
+
+        $listener = new AddNewlyQualifiedS1ToRoster(new ExamResultRepository());
+        $listener->handle($event);
+
+        $this->assertDatabaseHas('roster', [
+            'account_id' => $account->id,
+        ]);
+    }
+
+    public function test_does_not_add_to_roster_if_member_logging_onto_core_without_recent_exam()
+    {
+        $account = Account::factory()->create(['id' => 1111112]);
+        // make sure the QualificationAdded event doesn't fire for test setup.
+        Event::fakeFor(function () use ($account) {
+            $account->addQualification(Qualification::code('OBS')->first());
+        });
+
+        $newQualification = Qualification::code('S1')->first();
+
+        $ctsMember = factory(Member::class)->create([
+            'cid' => $account->id,
+        ]);
+        PracticalResult::factory([
+            'student_id' => $ctsMember->id,
+            'exam' => 'OBS',
+            'result' => PracticalResult::PASSED,
+            'date' => now()->subMonths(2),
+        ])->create();
+
+        $event = new QualificationAdded($account->fresh(), $newQualification);
+
+        $listener = new AddNewlyQualifiedS1ToRoster(new ExamResultRepository());
+        $listener->handle($event);
+
+        $this->assertDatabaseMissing('roster', [
+            'account_id' => $account->id,
+        ]);
+    }
+
+    public function test_does_not_add_to_roster_when_new_qualification_is_not_s1()
+    {
+        $account = Account::factory()->create(['id' => 1111113]);
+        // make sure the QualificationAdded event doesn't fire for test setup.
+        Event::fakeFor(function () use ($account) {
+            $account->addQualification(Qualification::code('OBS')->first());
+        });
+
+        $newQualification = Qualification::code('OBS')->first();
+
+        $ctsMember = factory(Member::class)->create([
+            'cid' => $account->id,
+        ]);
+        PracticalResult::factory()->create([
+            'student_id' => $ctsMember->id,
+            'exam' => 'OBS',
+            'result' => PracticalResult::PASSED,
+            'date' => now(),
+        ]);
+
+        $event = new QualificationAdded($account->fresh(), $newQualification);
+
+        $listener = new AddNewlyQualifiedS1ToRoster(new ExamResultRepository());
+        $listener->handle($event);
+
+        $this->assertDatabaseMissing('roster', [
+            'account_id' => $account->id,
+        ]);
+    }
+}

--- a/tests/Unit/CTS/ExamResultsRepositoryTest.php
+++ b/tests/Unit/CTS/ExamResultsRepositoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\CTS;
+
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalResult;
+use App\Models\Mship\Account;
+use App\Repositories\Cts\ExamResultRepository;
+use Tests\TestCase;
+
+class ExamResultsRepositoryTest extends TestCase
+{
+    public function test_retrieves_passed_exam_results_of_type_for_member()
+    {
+        $account = Account::factory()->create(['id' => 1111111]);
+        $member = factory(Member::class)->create([
+            'cid' => $account->id
+        ]);
+
+        $examResult = PracticalResult::factory()->create([
+            'result' => PracticalResult::PASSED,
+            'student_id' => $member->id,
+            'exam' => 'OBS'
+        ]);
+
+        # ensure failed result isn't returned
+        PracticalResult::factory()->create([
+            'result' => PracticalResult::FAILED,
+            'student_id' => $member->id,
+            'exam' => 'OBS'
+        ]);
+
+        $repository = new ExamResultRepository();
+        $result = $repository->getPassedExamResultsOfTypeForMember($account->id, "OBS");
+
+        $this->assertEquals($examResult->id, $result->id);
+    }
+}

--- a/tests/Unit/CTS/ExamResultsRepositoryTest.php
+++ b/tests/Unit/CTS/ExamResultsRepositoryTest.php
@@ -14,25 +14,45 @@ class ExamResultsRepositoryTest extends TestCase
     {
         $account = Account::factory()->create(['id' => 1111111]);
         $member = factory(Member::class)->create([
-            'cid' => $account->id
+            'cid' => $account->id,
         ]);
 
         $examResult = PracticalResult::factory()->create([
             'result' => PracticalResult::PASSED,
             'student_id' => $member->id,
-            'exam' => 'OBS'
+            'exam' => 'OBS',
         ]);
 
-        # ensure failed result isn't returned
+        // ensure failed result isn't returned
         PracticalResult::factory()->create([
             'result' => PracticalResult::FAILED,
             'student_id' => $member->id,
-            'exam' => 'OBS'
+            'exam' => 'OBS',
         ]);
 
         $repository = new ExamResultRepository();
-        $result = $repository->getPassedExamResultsOfTypeForMember($account->id, "OBS");
+        $result = $repository->getPassedExamResultsOfTypeForMember($account->id, 'OBS');
 
         $this->assertEquals($examResult->id, $result->id);
+    }
+
+    public function test_does_not_retrieve_passed_exam_of_other_type()
+    {
+        $account = Account::factory()->create(['id' => 1111111]);
+        $member = factory(Member::class)->create([
+            'cid' => $account->id,
+        ]);
+
+        // ensure failed result isn't returned
+        PracticalResult::factory()->create([
+            'result' => PracticalResult::PASSED,
+            'student_id' => $member->id,
+            'exam' => 'OBS',
+        ]);
+
+        $repository = new ExamResultRepository();
+        $result = $repository->getPassedExamResultsOfTypeForMember($account->id, 'TWR');
+
+        $this->assertNull($result);
     }
 }

--- a/tests/Unit/Roster/AccountCanControlTest.php
+++ b/tests/Unit/Roster/AccountCanControlTest.php
@@ -9,10 +9,16 @@ use App\Models\Mship\Account\Endorsement;
 use App\Models\Mship\Qualification;
 use App\Models\Mship\State;
 use App\Models\Roster;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 class AccountCanControlTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Event::fake();
+    }
+
     public function test_detects_can_control_with_rating_when_home_member()
     {
         $qualification = Qualification::code('S2')->first();

--- a/tests/Unit/Roster/AccountCanControlTest.php
+++ b/tests/Unit/Roster/AccountCanControlTest.php
@@ -16,6 +16,7 @@ class AccountCanControlTest extends TestCase
 {
     public function setUp(): void
     {
+        parent::setUp();
         Event::fake();
     }
 


### PR DESCRIPTION
This responds to the `QualificationAdded` event invokved by `addQualification` to add a member to the roster when:
- the qualification in the event is an S1
- we have a recent exam pass on record in CTS (last 30 days)

This additional check is needed for any S1s logging into Core for the first time and getting automatically added to the roster.
