### PR TITLE
TECH-245 Gatwick Endorsement Requirements Page

### DIFF
--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -39,6 +39,7 @@ class EndorsementController extends BaseController
             ->with('totalHours', $totalHours)
             ->with('progress', ($totalHours / self::GATWICK_HOURS_REQUIREMENT) * 100)
             ->with('hoursMet', $hoursMet)
+            ->with('onRoster', $onRoster)
             ->with('conditionsMet', $hoursMet && $onRoster);
     }
 

--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -25,7 +25,7 @@ class EndorsementController extends BaseController
 
         // 50 hours on _GND or _DEL
         $minutesOnline = $this->account->networkDataAtc()
-            ->where('callsign', 'LIKE', 'EG%')
+            ->isUK()
             ->where(function (Builder $builder) {
                 $builder->where('facility_type', Atc::TYPE_GND)
                     ->orWhere('facility_type', Atc::TYPE_DEL);

--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -4,14 +4,46 @@ namespace App\Http\Controllers\Atc;
 
 use App\Http\Controllers\BaseController;
 use App\Models\Atc\PositionGroup;
+use App\Models\NetworkData\Atc;
+use App\Models\Roster;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Redirect;
 
 class EndorsementController extends BaseController
 {
+    const GATWICK_HOURS_REQUIREMENT = 50;
+
     public function getGatwickGroundIndex()
     {
-        return Redirect::route('mship.manage.dashboard')
-            ->withError("We're making some changes to this page, please check back later.");
+        if (! $this->account->fully_defined || ! $this->account->qualification_atc->isS1) {
+            return Redirect::route('mship.manage.dashboard')
+                ->withError('Only S1 rated controllers are eligible for a Gatwick Ground endorsement.');
+        }
+
+        // active on roster
+        $onRoster = Roster::where('account_id', $this->account->id)->exists();
+
+        // 50 hours on _GND or _DEL
+        $minutesOnline = $this->account->networkDataAtc()
+            ->where('callsign', 'LIKE', 'EG%')
+            ->where(function (Builder $builder) {
+                $builder->where('facility_type', Atc::TYPE_GND)
+                    ->orWhere('facility_type', Atc::TYPE_DEL);
+            })
+            ->sum('minutes_online');
+
+        $totalHours = $minutesOnline / 60;
+        $hoursMet = $totalHours >= self::GATWICK_HOURS_REQUIREMENT;
+
+        return $this->viewMake('controllers.endorsements.gatwick_ground')
+            ->with('totalHours', $totalHours)
+            ->with('progress', ($totalHours / self::GATWICK_HOURS_REQUIREMENT) * 100)
+            ->with('hoursMet', $hoursMet)
+            ->with('conditionsMet', $hoursMet && $onRoster);
+
+        // S1
+        // active on roster
+        // 50 hours on _GND _DEL
 
         //        $endorsement = PositionGroup::with('conditions')->where('name', 'Gatwick S1 (DEL/GND)')->first();
         //

--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -40,26 +40,6 @@ class EndorsementController extends BaseController
             ->with('progress', ($totalHours / self::GATWICK_HOURS_REQUIREMENT) * 100)
             ->with('hoursMet', $hoursMet)
             ->with('conditionsMet', $hoursMet && $onRoster);
-
-        // S1
-        // active on roster
-        // 50 hours on _GND _DEL
-
-        //        $endorsement = PositionGroup::with('conditions')->where('name', 'Gatwick S1 (DEL/GND)')->first();
-        //
-        //        $hours = $endorsement->conditions->map(function ($condition) {
-        //            return $condition->progressForUser($this->account);
-        //        });
-        //
-        //        if (! $this->account->fully_defined || ! $this->account->qualificationAtc->isS1) {
-        //            return Redirect::route('mship.manage.dashboard')
-        //                ->withError('Only S1 rated controllers are eligible for a Gatwick Ground endorsement.');
-        //        }
-        //
-        //        return $this->viewMake('controllers.endorsements.gatwick_ground')
-        //            ->with('endorsment', $endorsement)
-        //            ->with('conditions', $endorsement->conditions)
-        //            ->with('hours', $hours->all());
     }
 
     public function getAreaIndex()

--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -21,6 +21,7 @@ class BaseController extends \Illuminate\Routing\Controller
     }
     use DispatchesJobs, RedirectsUsers, ValidatesRequests;
 
+    /** @var Account */
     protected $account;
 
     protected $pageTitle;

--- a/resources/views/controllers/endorsements/gatwick_ground.blade.php
+++ b/resources/views/controllers/endorsements/gatwick_ground.blade.php
@@ -14,9 +14,8 @@
                     </p>
                     <h4>Step One</h4>
                     <p>
-                        In order to control Gatwick Ground as an S1, you will need to first meet the requirements
-                        outlined
-                        on this page.
+                        In order to control Gatwick Ground as an S1, you will need to first meet
+                        the requirements outlined on this page.
                     </p>
                     <p>
                         You must be a home member of the UK, be active on the controller roster, be rated as an S1

--- a/resources/views/controllers/endorsements/gatwick_ground.blade.php
+++ b/resources/views/controllers/endorsements/gatwick_ground.blade.php
@@ -7,46 +7,91 @@
             <div class="panel panel-ukblue">
                 <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Gatwick Endorsement</div>
                 <div class="panel-body">
-                    Gatwick is one of the busiest airports on the VATSIM network. Before controlling it, we want to
-                    ensure you have the knowledge you need to provide a good service to pilots and get the most from
-                    your controlling session.<br>
-                    <br>
+                    <p>
+                        Gatwick is one of the busiest airports on the VATSIM network. Before controlling it, we want to
+                        ensure you have the knowledge you need to provide a good service to pilots and get the most from
+                        your controlling session.
+                    </p>
                     <h4>Step One</h4>
-                    In order to control Gatwick Ground as an S1, you will need to first meet the requirements outlined
-                    on this page.<br>
-                    You must be a home member of the UK, be rated as an S1 and have controlled for 50 hours on GMC or
-                    GMP positions.<br>
-                    <br>
+                    <p>
+                        In order to control Gatwick Ground as an S1, you will need to first meet the requirements
+                        outlined
+                        on this page.
+                    </p>
+                    <p>
+                        You must be a home member of the UK, be active on the controller roster, be rated as an S1
+                        and have controlled for 50 hours on UK GMC or GMP positions.
+                    </p>
                     <h4>Step Two</h4>
-                    You will be given access to the 'Gatwick ADC | S1 Endorsement' course. This Moodle course covers
-                    Gatwick specific procedures, radiotelephony, and local flight planning restrictions.
-                    There is a quiz at the end of the course with a pass mark of 90% - you must pass this quiz to
-                    proceed.
-                    If you do not pass the quiz on your first attempt, there is a study period of seven days for you to
-                    review the Moodle course and improve your knowledge before you try again.<br>
-                    When you have passed the quiz at the end of the Moodle course, you will be prompted to submit
-                    another ticket to ATC TRAINING.<br>
-                    <br>
+                    <p>
+                        You will be given access to the 'Gatwick ADC | S1 Endorsement' course. This Moodle course covers
+                        Gatwick specific procedures, radiotelephony, and local flight planning restrictions.
+                        There is a quiz at the end of the course with a pass mark of 90% - you must pass this quiz to
+                        proceed.
+                    </p>
+                    <p>
+                        If you do not pass the quiz on your first attempt, there is a study period of seven days for you to
+                        review the Moodle course and improve your knowledge before you try again.
+                    </p>
+                    <p>
+                        When you have passed the quiz at the end of the Moodle course, you will be prompted to submit
+                        another ticket to ATC TRAINING.
+                    </p>
                     <h4>Step Three</h4>
-                    One of our Gatwick mentors will take you onto the live network, on either EGKK_GND or EGKK_DEL, and
-                    offer you hints and tips as you control You will also have the chance to ask any questions that you
-                    have.<br>
-                    This is not a test and you will not pass or fail, rather it is an opportunity for you to practically
-                    apply the skills and knowledge which you have learned through completing the Moodle course.<br>
-                    You will do this until the mentor deems you ready for the Gatwick ground endorsement. Once granted
-                    the endorsement, you will be able to control EGKK_GND and EGKK_DEL on the live network without
-                    supervision.
+                    <p>
+                        One of our Gatwick mentors will take you onto the live network, on either EGKK_GND or EGKK_DEL, and
+                        offer you hints and tips as you control You will also have the chance to ask any questions that you have.
+                    </p>
+                    <p>
+                        This is not a test and you will not pass or fail, rather it is an opportunity for you to practically
+                        apply the skills and knowledge which you have learned through completing the Moodle course.<br>
+                        You will do this until the mentor deems you ready for the Gatwick ground endorsement. Once granted
+                        the endorsement, you will be able to control EGKK_GND and EGKK_DEL on the live network without
+                        supervision.
+                    </p>
                 </div>
             </div>
         </div>
     </div>
 
     <div class="row">
+        <div class="col-md-4 col-md-offset-2">
+            <div class="panel panel-ukblue">
+                <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Membership Status</div>
+                <div class="panel-body">
+                    @if($_account->primary_state?->isDivision)
+                        <p>You are a home member of the UK.</p>
+                    @else
+                        <p class="text-danger"><strong>You are not a home member of the UK Division. If you wish to hold
+                                a Gatwick endorsement, apply to transfer to the UK
+                                by {!! link_to_route("visiting.landing", "clicking here") !!}.</strong></p>
+                    @endif
+
+                    @if($onRoster)
+                        <p>You are active on the controller roster.</p>
+                    @else
+                        <p class="text-danger">You are not active on the controller roster. If you wish to hold a
+                            Gatwick endorsement you must be active on the roster.</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+
         <div class="col-md-4">
             <div class="panel panel-ukblue">
-                <div class="panel-header"><i class="fa fa-info"></i> Control 50 Hours</div>
+                <div class="panel-heading"><i class="fa fa-info"></i> 50 Hours Controlling as an S1</div>
                 <div class="panel-body">
                     <div class="progress" data-toggle="tooltip" title="Hours Controlling _DEL and _GND">
+                        @if($hoursMet)
+                            <div
+                                class="progress-bar progress-bar-success"
+                                role="progressbar"
+                                style="width: 100%"
+                                aria-valuemin="0"
+                                aria-valuemax="50">
+                                50+ Hrs
+                            </div>
+                        @endif
                         <div
                             class="progress-bar {{ $hoursMet ? 'progress-bar-success' : '' }}"
                             role="progressbar"
@@ -63,21 +108,8 @@
 
 
     <div class="row">
-        <div class="col-md-4 col-md-offset-2">
-            <div class="panel panel-ukblue">
-                <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Membership Status</div>
-                <div class="panel-body">
-                    @if($_account->primary_state?->isDivision)
-                        You are a home member of the UK and no further action is required.
-                    @else
-                        <p class="text-danger"><strong>You are not a home member of the UK Division. If you wish to hold
-                                a Gatwick endorsement, apply to transfer to the UK
-                                by {!! link_to_route("visiting.landing", "clicking here") !!}.</strong></p>
-                    @endif
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
+
+        <div class="col-md-8 col-md-offset-2">
             <div class="panel panel-ukblue">
                 <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Request Moodle Course</div>
                 <div class="panel-body">

--- a/resources/views/controllers/endorsements/gatwick_ground.blade.php
+++ b/resources/views/controllers/endorsements/gatwick_ground.blade.php
@@ -7,22 +7,35 @@
             <div class="panel panel-ukblue">
                 <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Gatwick Endorsement</div>
                 <div class="panel-body">
-                    Gatwick is one of the busiest airports on the VATSIM network. Before controlling it, we want to ensure you have the knowledge you need to provide a good service to pilots and get the most from your controlling session.<br>
+                    Gatwick is one of the busiest airports on the VATSIM network. Before controlling it, we want to
+                    ensure you have the knowledge you need to provide a good service to pilots and get the most from
+                    your controlling session.<br>
                     <br>
                     <h4>Step One</h4>
-                    In order to control Gatwick Ground as an S1, you will need to first meet the requirements outlined on this page.<br>
-                    The requirements involve you completing a number of hours on various positions around the UK, being a home member of the UK and rated as an S1.<br>
+                    In order to control Gatwick Ground as an S1, you will need to first meet the requirements outlined
+                    on this page.<br>
+                    You must be a home member of the UK, be rated as an S1 and have controlled for 50 hours on GMC or
+                    GMP positions.<br>
                     <br>
                     <h4>Step Two</h4>
-                    You will be given access to the 'Gatwick ADC | S1 Endorsement' course. This Moodle course covers Gatwick specific procedures, radiotelephony, and local flight planning restrictions.
-                    There is a quiz at the end of the course with a pass mark of 90% - you must pass this quiz to proceed.
-                    If you do not pass the quiz on your first attempt, there is a study period of seven days for you to review the Moodle course and improve your knowledge before you try again.<br>
-                    When you have passed the quiz at the end of the Moodle course, you will be prompted to submit another ticket to ATC TRAINING.<br>
+                    You will be given access to the 'Gatwick ADC | S1 Endorsement' course. This Moodle course covers
+                    Gatwick specific procedures, radiotelephony, and local flight planning restrictions.
+                    There is a quiz at the end of the course with a pass mark of 90% - you must pass this quiz to
+                    proceed.
+                    If you do not pass the quiz on your first attempt, there is a study period of seven days for you to
+                    review the Moodle course and improve your knowledge before you try again.<br>
+                    When you have passed the quiz at the end of the Moodle course, you will be prompted to submit
+                    another ticket to ATC TRAINING.<br>
                     <br>
                     <h4>Step Three</h4>
-                    One of our Gatwick mentors will take you onto the live network, on either EGKK_GND or EGKK_DEL, and offer you hints and tips as you control You will also have the chance to ask any questions that you have.<br>
-                    This is not a test and you will not pass or fail, rather it is an opportunity for you to practically apply the skills and knowledge which you have learned through completing the Moodle course.<br>
-                    You will do this until the mentor deems you ready for the Gatwick ground endorsement. Once granted the endorsement, you will be able to control EGKK_GND and EGKK_DEL on the live network without supervision.
+                    One of our Gatwick mentors will take you onto the live network, on either EGKK_GND or EGKK_DEL, and
+                    offer you hints and tips as you control You will also have the chance to ask any questions that you
+                    have.<br>
+                    This is not a test and you will not pass or fail, rather it is an opportunity for you to practically
+                    apply the skills and knowledge which you have learned through completing the Moodle course.<br>
+                    You will do this until the mentor deems you ready for the Gatwick ground endorsement. Once granted
+                    the endorsement, you will be able to control EGKK_GND and EGKK_DEL on the live network without
+                    supervision.
                 </div>
             </div>
         </div>
@@ -31,84 +44,35 @@
     <div class="row">
         <div class="col-md-4">
             <div class="panel panel-ukblue">
-                <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Group One Controlling</div>
+                <div class="panel-header"><i class="fa fa-info"></i> Control 50 Hours</div>
                 <div class="panel-body">
-                    Control a total of <strong>{{ $conditions[0]->required_hours }} hours</strong> on one of the following positions within the last <strong>{{ $conditions[0]->within_months }} months.</strong>
-                    <ul>
-                        <li>Manchester (EGCC)</li>
-                        <li>Edinburgh (EGPH)</li>
-                        <li>Stansted (EGSS)</li>
-                        <li>Liverpool (EGGP)</li>
-                    </ul>
-                    @foreach($hours[0] as $icao => $hour)
-                        <div class="progress" data-toggle="tooltip" title="{{ $icao }}">
-                            @if($conditions[0]->isMetForUser($_account))
-                                <div class="progress-bar progress-bar-success" role="progressbar" style="width: 100%" aria-valuemin="0" aria-valuemax="{{ $conditions[0]->required_hours }}">{{ round($hour,2) }} Hrs {{ '('. $icao .')' }}</div>
-                            @else
-                                <div class="progress-bar" role="progressbar" style="width: {{ ($hour/$conditions[0]->required_hours)*100 }}%" aria-valuemin="0" aria-valuemax="{{ $conditions[0]->required_hours }}">{{ ($hour > 0) ? (round($hour,2)).' Hrs ('. $icao .')' : '' }}</div>
-                            @endif
+                    <div class="progress" data-toggle="tooltip" title="Hours Controlling _DEL and _GND">
+                        <div
+                            class="progress-bar {{ $hoursMet ? 'progress-bar-success' : '' }}"
+                            role="progressbar"
+                            style="width: {{ $progress }}%"
+                            aria-valuemin="0"
+                            aria-valuemax="50">
+                            {{ (round($totalHours,2)) .' Hrs' }}
                         </div>
-                    @endforeach
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
-            <div class="panel panel-ukblue">
-                <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Group Two Controlling</div>
-                <div class="panel-body">
-                    Control a total of <strong>{{ $conditions[1]->required_hours }} hours</strong> on one of the following positions within the last <strong>{{ $conditions[1]->within_months }} months.</strong>
-                    <ul>
-                        <li>Glasgow (EGPF)</li>
-                        <li>Birmingham (EGBB)</li>
-                        <li>Bristol (EGGD)</li>
-                        <li>Luton (EGGW)</li>
-                    </ul>
-                    @foreach($hours[1] as $icao => $hour)
-                        <div class="progress" data-toggle="tooltip" title="{{ $icao }}">
-                            @if($conditions[1]->isMetForUser($_account))
-                                <div class="progress-bar progress-bar-success" role="progressbar" style="width: 100%" aria-valuemin="0" aria-valuemax="{{ $conditions[1]->required_hours }}">{{ round($hour,2) }} Hrs {{ '('. $icao .')' }}</div>
-                            @else
-                                <div class="progress-bar" role="progressbar" style="width: {{ ($hour/$conditions[1]->required_hours)*100 }}%" aria-valuemin="0" aria-valuemax="{{ $conditions[1]->required_hours }}">{{ ($hour > 0) ? (round($hour,2)).' Hrs ('. $icao .')' : '' }}</div>
-                            @endif
-                        </div>
-                    @endforeach
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
-            <div class="panel panel-ukblue">
-                <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Group Three Controlling</div>
-                <div class="panel-body">
-                    Control a total of <strong>{{ $conditions[2]->required_hours }} hours</strong> on one of the following positions within the last <strong>{{ $conditions[2]->within_months }} months.</strong>
-                    <ul>
-                        <li>Jersey (EGJJ)</li>
-                        <li>Belfast Aldergrove (EGAA)</li>
-                        <li>Newcastle (EGNT)</li>
-                        <li>East Midlands (EGNX)</li>
-                    </ul>
-                    @foreach($hours[2] as $icao => $hour)
-                        <div class="progress" data-toggle="tooltip" title="{{ $icao }}">
-                            @if($conditions[2]->isMetForUser($_account))
-                                <div class="progress-bar progress-bar-success" role="progressbar" style="width: 100%" aria-valuemin="0" aria-valuemax="{{ $conditions[2]->required_hours }}">{{ round($hour,2) }} Hrs {{ '('. $icao .')' }}</div>
-                            @else
-                                <div class="progress-bar" role="progressbar" style="width: {{ ($hour/$conditions[2]->required_hours)*100 }}%"aria-valuemin="0" aria-valuemax="{{ $conditions[2]->required_hours }}">{{ ($hour > 0) ? (round($hour,2)).' Hrs ('. $icao .')' : '' }}</div>
-                            @endif
-                        </div>
-                    @endforeach
+                    </div>
                 </div>
             </div>
         </div>
     </div>
+
 
     <div class="row">
         <div class="col-md-4 col-md-offset-2">
             <div class="panel panel-ukblue">
                 <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Membership Status</div>
                 <div class="panel-body">
-                    @if($_account->primary_state->isDivision)
+                    @if($_account->primary_state?->isDivision)
                         You are a home member of the UK and no further action is required.
                     @else
-                        <p class="text-danger"><strong>You are not a home member of the UK Division. If you wish to hold a Gatwick endorsement, apply to transfer to the UK by {!! link_to_route("visiting.landing", "clicking here") !!}.</strong></p>
+                        <p class="text-danger"><strong>You are not a home member of the UK Division. If you wish to hold
+                                a Gatwick endorsement, apply to transfer to the UK
+                                by {!! link_to_route("visiting.landing", "clicking here") !!}.</strong></p>
                     @endif
                 </div>
             </div>
@@ -117,10 +81,12 @@
             <div class="panel panel-ukblue">
                 <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Request Moodle Course</div>
                 <div class="panel-body">
-                    Once you have completed the requirements above, you will be able to press the button below to request access to the Moodle course and progress to Step 2.
+                    Once you have completed the requirements above, you will be able to press the button below to
+                    request access to the Moodle course and progress to Step 2.
                     <br><br>
-                    @if($positionGroup->conditionsMetForUser($_account))
-                        <a href="mailto:atc-training@vatsim.uk?Subject=Gatwick%20Endorsement%20-%20Moodle%20Request&Body=Please%20grant%20me%20access%20to%20the%20Gatwick%20Endorsement%20exam%20on%20Moodle%20as%20I%20have%20now%20met%20the%20number%20of%20hours%20required%20across%20the%20three%20groups.%0A%0AGroup%201%3A%20{{ round($hours[0]->max(),1) }}%20hours%20on%20{{ $hours[0]->keys()->first() }}%20within%20the%20last%20three%20months.%0AGroup%202%3A%20{{ round($hours[1]->max(),1) }}%20hours%20on%20{{ $hours[1]->keys()->first() }}%20within%20the%20last%20three%20months.%0AGroup%203%3A%20{{ round($hours[2]->max(),1) }}%20hours%20on%20{{ $hours[2]->keys()->first() }}%20within%20the%20last%20three%20months.%0A%0AFull%20Name%3A%20{{ $_account->name }}%0AVATSIM%20CID%3A%20{{ $_account->id }}" style="text-decoration: none;">
+                    @if($conditionsMet)
+                        <a href="mailto:atc-training@vatsim.uk?Subject=Gatwick%20Endorsement%20-%20Moodle%20Request&Body=Please%20grant%20me%20access%20to%20the%20Gatwick%20Endorsement%20exam%20on%20Moodle%20as%20I%20have%20now%20met%20the%20number%20of%20hours%20required.%0A%0AFull%20Name%3A%20{{ $_account->name }}%0AVATSIM%20CID%3A%20{{ $_account->id }}"
+                           style="text-decoration: none;">
                             <button class="btn btn-success center-block">Request Moodle Course</button>
                         </a>
                     @else

--- a/resources/views/controllers/endorsements/gatwick_ground.blade.php
+++ b/resources/views/controllers/endorsements/gatwick_ground.blade.php
@@ -81,7 +81,7 @@
             <div class="panel panel-ukblue">
                 <div class="panel-heading"><i class="fa fa-info"></i> 50 Hours Controlling as an S1</div>
                 <div class="panel-body">
-                    <div class="progress" data-toggle="tooltip" title="Hours Controlling _DEL and _GND">
+                    <div class="progress" data-toggle="tooltip" title="Hours Controlling DEL and GND">
                         @if($hoursMet)
                             <div
                                 class="progress-bar progress-bar-success"

--- a/tests/Feature/Atc/GatwickEndorsementTest.php
+++ b/tests/Feature/Atc/GatwickEndorsementTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature\Atc;
+
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use App\Models\NetworkData\Atc;
+use App\Models\Roster;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class GatwickEndorsementTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private const ROUTE = 'controllers.endorsements.gatwick_ground';
+
+    public function testItPassesFor55Hours()
+    {
+        $account = $this->getS1Account();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_DEL',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_DEL,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_GND',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_GND',
+            'minutes_online' => 5 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertStatus(200)
+            ->assertViewHas('hoursMet', true);
+
+    }
+
+    public function testItFailsFor30Hours()
+    {
+        $account = $this->getS1Account();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_DEL',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_DEL,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_GND',
+            'minutes_online' => 5 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertStatus(200)
+            ->assertViewHas('hoursMet', false);
+    }
+
+    public function testItFailsForHoursNonUK()
+    {
+        $account = $this->getS1Account();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_DEL',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_DEL,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_GND',
+            'minutes_online' => 10 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'LFPG_GND',
+            'minutes_online' => 500 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertStatus(200)
+            ->assertViewHas('hoursMet', false);
+    }
+
+    public function testItRedirectsForNonS1()
+    {
+        $account = Account::factory()->create();
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertRedirect(route('mship.manage.dashboard'));
+    }
+
+    public function testItRedirectsForS2()
+    {
+        $account = Account::factory()->create();
+
+        $qualification = Qualification::code('S2')->first();
+        $account->addQualification($qualification);
+        $account->save();
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertRedirect(route('mship.manage.dashboard'));
+    }
+
+    private function getS1Account(): Account
+    {
+        $account = Account::factory()->create();
+
+        $qualification = Qualification::code('S1')->first();
+        $account->addQualification($qualification);
+        $account->save();
+
+        Roster::create(['account_id' => $account->id])->save();
+
+        return $account;
+    }
+}


### PR DESCRIPTION
Re-Implement Gatwick Endorsement requirements page for the new requirements, and update some language as necessary.

Endorsement page checks for

- 50 hours as DEL or GND in the UK based on Network Atc role data
- Home division membership
- Active on Roster
- Holding an S1

All working based on tests / qa, would appreciate a review of the language in the requirement descriptions.