### PR TITLE
feat: notify users upon being granted a permanent endorsement aka. PositionGroup

### DIFF
--- a/app/Events/Mship/Endorsement/TierEndorsementAdded.php
+++ b/app/Events/Mship/Endorsement/TierEndorsementAdded.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Events\Mship\Endorsement;
+
+use App\Models\Mship\Account;
+use App\Models\Mship\Account\Endorsement;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TierEndorsementAdded
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(private Endorsement $endorsement, private Account $account)
+    {
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+
+    public function getAccount()
+    {
+        return $this->account;
+    }
+
+    public function getEndorsement()
+    {
+        return $this->endorsement;
+    }
+}

--- a/app/Events/Mship/Endorsement/TierEndorsementAdded.php
+++ b/app/Events/Mship/Endorsement/TierEndorsementAdded.php
@@ -5,7 +5,6 @@ namespace App\Events\Mship\Endorsement;
 use App\Models\Mship\Account;
 use App\Models\Mship\Account\Endorsement;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -18,18 +17,6 @@ class TierEndorsementAdded
      */
     public function __construct(private Endorsement $endorsement, private Account $account)
     {
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return array<int, \Illuminate\Broadcasting\Channel>
-     */
-    public function broadcastOn(): array
-    {
-        return [
-            new PrivateChannel('channel-name'),
-        ];
     }
 
     public function getAccount()

--- a/app/Listeners/Mship/Endorsement/NotifyOfTierEndorsement.php
+++ b/app/Listeners/Mship/Endorsement/NotifyOfTierEndorsement.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Listeners\Mship\Endorsement;
+
+use App\Events\Mship\Endorsement\TierEndorsementAdded;
+use App\Notifications\Mship\Endorsement\TierEndorsementNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class NotifyOfTierEndorsement implements ShouldQueue
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(TierEndorsementAdded $event): void
+    {
+        $event->getAccount()->notify(new TierEndorsementNotification($event->getEndorsement()));
+    }
+}

--- a/app/Models/Mship/Account/Endorsement.php
+++ b/app/Models/Mship/Account/Endorsement.php
@@ -7,11 +7,14 @@ use App\Models\Atc\PositionGroup;
 use App\Models\Model;
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
+use App\Observers\EndorsementObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+#[ObservedBy([EndorsementObserver::class])]
 class Endorsement extends Model
 {
     use HasFactory, SoftDeletes;

--- a/app/Notifications/Mship/Endorsement/TierEndorsementNotification.php
+++ b/app/Notifications/Mship/Endorsement/TierEndorsementNotification.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Notifications\Mship\Endorsement;
+
+use App\Models\Mship\Account\Endorsement;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TierEndorsementNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(public Endorsement $endorsement)
+    {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $positions = $this->endorsement->load('endorsable')->endorsable->positions->map(fn ($position) => "$position->name ($position->description)");
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
+            ->subject('Tier Endorsement Granted')
+            ->view('emails.mship.endorsement.tier_endorsement_granted', ['recipient' => $notifiable, 'positions' => $positions, 'endorsement_name' => $this->endorsement->endorsable->name]);
+    }
+}

--- a/app/Observers/EndorsementObserver.php
+++ b/app/Observers/EndorsementObserver.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Observers;
+
+use App\Events\Mship\Endorsement\TierEndorsementAdded;
+use App\Models\Atc\PositionGroup;
+use App\Models\Mship\Account\Endorsement;
+
+class EndorsementObserver
+{
+    /**
+     * Handle the Endorsement "created" event.
+     */
+    public function created(Endorsement $endorsement): void
+    {
+        $endorsement->load('account');
+
+        if ($endorsement->endorsable_type == PositionGroup::class) {
+            event(new TierEndorsementAdded($endorsement, $endorsement->account));
+
+            return;
+        }
+    }
+
+    /**
+     * Handle the Endorsement "updated" event.
+     */
+    public function updated(Endorsement $endorsement): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Endorsement "deleted" event.
+     */
+    public function deleted(Endorsement $endorsement): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Endorsement "restored" event.
+     */
+    public function restored(Endorsement $endorsement): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Endorsement "force deleted" event.
+     */
+    public function forceDeleted(Endorsement $endorsement): void
+    {
+        //
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -110,6 +110,9 @@ class EventServiceProvider extends ServiceProvider
         DiscordUnlinked::class => [
             RemoveDiscordUser::class,
         ],
+        \App\Events\Mship\Endorsement\TierEndorsementAdded::class => [
+            \App\Listeners\Mship\Endorsement\NotifyOfTierEndorsement::class,
+        ],
     ];
 
     /**

--- a/resources/views/emails/mship/endorsement/tier_endorsement_granted.blade.php
+++ b/resources/views/emails/mship/endorsement/tier_endorsement_granted.blade.php
@@ -9,7 +9,7 @@
 		<li>{{ $position }}</li>
 	@endforeach
 </ul>
-<p>The listed positions are inn addition to the positions you are already entitled to control via your controller rating and other Tier or Solo endorsements.
+<p>The listed positions are in addition to the positions you are already entitled to control via your controller rating and other Tier or Solo endorsements.
 This has been reflected on your controller roster and is effective from the reciept of this email.</p>
 
 <p>Congratulations!</p>

--- a/resources/views/emails/mship/endorsement/tier_endorsement_granted.blade.php
+++ b/resources/views/emails/mship/endorsement/tier_endorsement_granted.blade.php
@@ -1,0 +1,16 @@
+@extends('emails.messages.post')
+
+@section('body')
+<p>This email is formal notification that you have been granted a 'Tier' endorsement: <strong>{{ $endorsement_name }}</strong>.</p>
+
+<p>This endorsement entitles you additional permissions to control the following positions:</p>
+<ul>
+	@foreach($positions as $position)
+		<li>{{ $position }}</li>
+	@endforeach
+</ul>
+<p>The listed positions are inn addition to the positions you are already entitled to control via your controller rating and other Tier or Solo endorsements.
+This has been reflected on your controller roster and is effective from the reciept of this email.</p>
+
+<p>Congratulations!</p>
+@endsection


### PR DESCRIPTION
This establishes a pattern for sending events from Endorsement events and adds a notification
to inform a user they have been endorsed on a PositionGroup aka. Tier 1 / 2 endorsement.

![image](https://github.com/VATSIM-UK/core/assets/6240877/d6bc6268-23e4-4136-8ca5-4edad03f37b1)

