### PR TITLE
feat: Heathrow s1 page

### DIFF
--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Redirect;
 class EndorsementController extends BaseController
 {
     const GATWICK_HOURS_REQUIREMENT = 50;
+
     const HEATHROW_S1_HOURS_REQUIREMENT = 50;
 
     public function getGatwickGroundIndex()
@@ -60,7 +61,7 @@ class EndorsementController extends BaseController
             });
         })->first();
 
-        $hasEgkkEndorsement = (bool)$egkkEndorsement;
+        $hasEgkkEndorsement = (bool) $egkkEndorsement;
 
         $minutesOnline = 0.0;
 

--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Redirect;
 class EndorsementController extends BaseController
 {
     const GATWICK_HOURS_REQUIREMENT = 50;
+    const HEATHROW_S1_HOURS_REQUIREMENT = 50;
 
     public function getGatwickGroundIndex()
     {
@@ -40,6 +41,52 @@ class EndorsementController extends BaseController
             ->with('progress', ($totalHours / self::GATWICK_HOURS_REQUIREMENT) * 100)
             ->with('hoursMet', $hoursMet)
             ->with('onRoster', $onRoster)
+            ->with('conditionsMet', $hoursMet && $onRoster);
+    }
+
+    public function getHeathrowGroundS1Index()
+    {
+        if (! $this->account->fully_defined || ! $this->account->qualification_atc->isS1) {
+            return Redirect::route('mship.manage.dashboard')
+                ->withError('Only S1 rated controllers are eligible for a Heathrow Ground (S1) endorsement.');
+        }
+
+        // active on roster
+        $onRoster = Roster::where('account_id', $this->account->id)->exists();
+
+        $egkkEndorsement = $this->account->endorsements()->where(function (Builder $builder) {
+            $builder->whereHasMorph('endorsable', [PositionGroup::class], function (Builder $builder) {
+                $builder->where('name', 'EGKK_GND');
+            });
+        })->first();
+
+        $hasEgkkEndorsement = (bool)$egkkEndorsement;
+
+        $minutesOnline = 0.0;
+
+        // 50 hours on EGKK_GND or EGKK_DEL
+        // AFTER getting an EGKK endorsement
+        if ($hasEgkkEndorsement) {
+            $minutesOnline = $this->account->networkDataAtc()
+                ->isUK()
+                ->where('callsign', 'LIKE', 'EGKK_%')
+                ->where(function (Builder $builder) {
+                    $builder->where('facility_type', Atc::TYPE_GND)
+                        ->orWhere('facility_type', Atc::TYPE_DEL);
+                })
+                ->where('connected_at', '>=', $egkkEndorsement->created_at)
+                ->sum('minutes_online');
+        }
+
+        $totalHours = $minutesOnline / 60;
+        $hoursMet = $totalHours >= self::HEATHROW_S1_HOURS_REQUIREMENT;
+
+        return $this->viewMake('controllers.endorsements.heathrow_ground_s1')
+            ->with('totalHours', $totalHours)
+            ->with('progress', ($totalHours / self::HEATHROW_S1_HOURS_REQUIREMENT) * 100)
+            ->with('hoursMet', $hoursMet)
+            ->with('onRoster', $onRoster)
+            ->with('hasEgkkEndorsement', $hasEgkkEndorsement)
             ->with('conditionsMet', $hoursMet && $onRoster);
     }
 

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -77,6 +77,7 @@
                                 <li class="divider"></li>
                                 <li class="dropdown-header">Endorsements</li>
                                 <li>{!! link_to_route("controllers.endorsements.gatwick_ground", "Gatwick Ground") !!}</li>
+                                <li>{!! link_to_route("controllers.endorsements.heathrow_ground_s1", "Heathrow Ground (S1)") !!}</li>
                                 <li>{!! link_to_route("site.atc.heathrow", "Heathrow") !!}</li>
                             </ul>
                         </li>

--- a/resources/views/controllers/endorsements/gatwick_ground.blade.php
+++ b/resources/views/controllers/endorsements/gatwick_ground.blade.php
@@ -8,16 +8,18 @@
                 <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Gatwick Endorsement (S1)</div>
                 <div class="panel-body">
                     <p>
-                        Gatwick is a Tier 1 airport and one of the busiest airports in the VATSIM Network.
+                        Gatwick is one of the busiest airports on the VATSIM Network.
                     </p>
                     <p>
                         Before controlling at Gatwick, we want to ensure you have the knowledge you need
                         to provide a good service to pilots and get the most from your controlling session.
                     </p>
+                    <p>
+                        S1 rated controllers must hold a Gatwick Endorsement in order to control EGKK_GND and EGKK_DEL.
+                    </p>
                     <h4>Step One</h4>
                     <p>
-                        In order to control Gatwick Ground as an S1, you will need to meet
-                        the following requirements:
+                        In order to begin training for your endorsement you must meet the following requirements:
                     </p>
                     <ul>
                         <li>
@@ -55,7 +57,9 @@
                     </p>
                     <p>
                         This is not a test and you will not pass or fail, rather it is an opportunity for you to practically
-                        apply the skills and knowledge which you have learned through completing the Moodle course.<br>
+                        apply the skills and knowledge which you have learned through completing the Moodle course.
+                    </p>
+                    <p>
                         You will do this until the mentor deems you ready for the Gatwick ground endorsement. Once granted
                         the endorsement, you will be able to control EGKK_GND and EGKK_DEL on the live network without
                         supervision.

--- a/resources/views/controllers/endorsements/heathrow_ground_s1.blade.php
+++ b/resources/views/controllers/endorsements/heathrow_ground_s1.blade.php
@@ -8,11 +8,14 @@
                 <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Heathrow Ground Endorsement (S1)</div>
                 <div class="panel-body">
                     <p>
-                        Heathrow is a Tier 1 airport and one of the busiest airports in the VATSIM Network.
+                        Heathrow is one of the busiest airports on the VATSIM Network.
                     </p>
                     <p>
                         Before controlling at Heathrow, we want to ensure you have the knowledge you need
                         to provide a good service to pilots and get the most from your controlling session.
+                    </p>
+                    <p>
+                        S1 rated controllers must hold a Heathrow Endorsement in order to control EGLL_GND and ELL_DEL positions.
                     </p>
                     <h4>Step One</h4>
                     <p>

--- a/resources/views/controllers/endorsements/heathrow_ground_s1.blade.php
+++ b/resources/views/controllers/endorsements/heathrow_ground_s1.blade.php
@@ -5,18 +5,18 @@
     <div class="row">
         <div class="col-md-10 col-md-offset-1">
             <div class="panel panel-ukblue">
-                <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Gatwick Endorsement (S1)</div>
+                <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Heathrow Ground Endorsement (S1)</div>
                 <div class="panel-body">
                     <p>
-                        Gatwick is a Tier 1 airport and one of the busiest airports in the VATSIM Network.
+                        Heathrow is a Tier 1 airport and one of the busiest airports in the VATSIM Network.
                     </p>
                     <p>
-                        Before controlling at Gatwick, we want to ensure you have the knowledge you need
+                        Before controlling at Heathrow, we want to ensure you have the knowledge you need
                         to provide a good service to pilots and get the most from your controlling session.
                     </p>
                     <h4>Step One</h4>
                     <p>
-                        In order to control Gatwick Ground as an S1, you will need to meet
+                        In order to control Heathrow Ground as an S1, you will need to meet
                         the following requirements:
                     </p>
                     <ul>
@@ -30,18 +30,24 @@
                             You must be active on the controller roster
                         </li>
                         <li>
-                            You must have controlled for 50 hours at other UK aerodromes after acquiring your S1 rating.
+                            You must hold a Gatwick Endorsement
+                        </li>
+                        <li>
+                            You must have controlled for 50 hours at Gatwick after acquiring your endorsement
                         </li>
                     </ul>
                     <h4>Step Two</h4>
                     <p>
-                        You will be given access to the 'Gatwick ADC | S1 Endorsement' course. This Moodle course covers
-                        Gatwick specific procedures, radiotelephony, and local flight planning restrictions.
-                        There is a quiz at the end of the course with a pass mark of 90% - you must pass this quiz to
-                        proceed.
+                        You will be added to the waiting list for Heathrow training, and be
+                        given access to the 'Heathrow (S1) GMC' course. This Moodle course covers
+                        Heathrow specific procedures, radiotelephony, and local flight planning restrictions.
                     </p>
                     <p>
-                        If you do not pass the quiz on your first attempt, there is a study period of seven days for you to
+                        Once you are close to the top of the waiting list you will be given access to to the
+                        Moodle exam.
+                    </p>
+                    <p>
+                        If you do not pass the quiz on your first attempt, there is a study period of 72 hours for you to
                         review the Moodle course and improve your knowledge before you try again.
                     </p>
                     <p>
@@ -50,15 +56,7 @@
                     </p>
                     <h4>Step Three</h4>
                     <p>
-                        One of our Gatwick mentors will take you onto the live network, on either EGKK_GND or EGKK_DEL, and
-                        offer you hints and tips as you control You will also have the chance to ask any questions that you have.
-                    </p>
-                    <p>
-                        This is not a test and you will not pass or fail, rather it is an opportunity for you to practically
-                        apply the skills and knowledge which you have learned through completing the Moodle course.<br>
-                        You will do this until the mentor deems you ready for the Gatwick ground endorsement. Once granted
-                        the endorsement, you will be able to control EGKK_GND and EGKK_DEL on the live network without
-                        supervision.
+                        Begin training toward your Heathrow Ground endorsement.
                     </p>
                 </div>
             </div>
@@ -84,13 +82,21 @@
                         <p class="text-danger">You are not active on the controller roster. If you wish to hold a
                             Gatwick endorsement you must be active on the roster.</p>
                     @endif
+
+                    @if($hasEgkkEndorsement)
+                        <p>You are endorsed to control Gatwick.</p>
+                    @else
+                        <p class="text-danger">You do not hold a Gatwick endorsement,
+                            you must <a href="{{ route('controllers.endorsements.heathrow_ground_s1') }}">complete this before</a>
+                            starting your Heathrow training.</p>
+                    @endif
                 </div>
             </div>
         </div>
 
         <div class="col-md-4">
             <div class="panel panel-ukblue">
-                <div class="panel-heading"><i class="fa fa-info"></i> 50 Hours Controlling as an S1</div>
+                <div class="panel-heading"><i class="fa fa-info"></i> 50 Hours Controlling at Gatwick</div>
                 <div class="panel-body">
                     <div class="progress" data-toggle="tooltip" title="Hours Controlling DEL and GND">
                         @if($hoursMet)
@@ -124,14 +130,10 @@
             <div class="panel panel-ukblue">
                 <div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Request Moodle Course</div>
                 <div class="panel-body">
-                    Once you have completed the requirements above, you will be able to press the button below to
-                    request access to the Moodle course and progress to Step 2.
-                    <br><br>
                     @if($conditionsMet)
-                        <a href="mailto:atc-training@vatsim.uk?Subject=Gatwick%20Endorsement%20-%20Moodle%20Request&Body=Please%20grant%20me%20access%20to%20the%20Gatwick%20Endorsement%20exam%20on%20Moodle%20as%20I%20have%20now%20met%20the%20number%20of%20hours%20required.%0A%0AFull%20Name%3A%20{{ $_account->name }}%0AVATSIM%20CID%3A%20{{ $_account->id }}"
-                           style="text-decoration: none;">
-                            <button class="btn btn-success center-block">Request Moodle Course</button>
-                        </a>
+                        <p>
+                            <a href="https://helpdesk.vatsim.uk/open.php">Open a ticket with ATC Training</a>
+                            to request access to the Moodle Course</p>
                     @else
                         <button class="btn btn-info center-block" disabled>Request Moodle Course</button>
                     @endif

--- a/resources/views/site/atc/endorsements.blade.php
+++ b/resources/views/site/atc/endorsements.blade.php
@@ -38,8 +38,9 @@
                     <h3>Background</h3>
 
                     <p>
-                        London Gatwick (EGKK) was the 2nd busiest airport on the VATSIM network in 2022 with over 84,000
-                        movements. Controlling at London Gatwick is restricted by the ATC Training Department to S2 rated
+                        London Gatwick (EGKK) is a Tier 1 aerodrome and was the 2nd busiest airport on the
+                        VATSIM network in 2022 with over 84,000 movements.
+                        Controlling at London Gatwick is restricted by the ATC Training Department to S2 rated
                         members, or S1s that hold a special endorsement. This restriction for S1s is in place to allow
                         members to gain experience in quieter environments and practice their skills before tackling
                         the workload at Gatwick.
@@ -61,6 +62,45 @@
                     <p>
                         The process for getting started with the Gatwick Ground endorsement can be found by <a
                             href="{{ route('controllers.endorsements.gatwick_ground') }}">clicking here</a>.
+                    </p>
+
+                </div>
+            </div>
+        </div>
+
+
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-ukblue">
+                <a class="panel-heading-link" role="button" data-toggle="collapse" href="#endorsement-heathrow-s1">
+                    <div class="panel-heading">
+                        <i class="fa fa-plane-departure" aria-hidden="true"></i> &thinsp; London Heathrow - GND (S1)
+                        <i class="pull-right fa fa-arrow-down" aria-hidden="true"></i>
+                    </div>
+                </a>
+                <div id="endorsement-heathrow-s1" class="panel-collapse collapse panel-body">
+                    <h3>Background</h3>
+
+                    <p>
+                        London Heathrow (EGLL) is a Tier 1 aerodrome and the busiest airport on the VATSIM network.
+
+                        Controlling at London Heathrow is restricted by the ATC Training Department to S2 rated
+                        members, or S1s that hold a special endorsement. This restriction for S1s is in place to allow
+                        members to gain experience in quieter environments and practice their skills before tackling
+                        the workload at Heathrow.
+                    </p>
+
+                    <h3>Endorsement Process</h3>
+
+                    <p>
+                        View the requirements for the Heathrow Ground (S1) endorsement by <a
+                            href="{{ route('controllers.endorsements.heathrow_ground_s1') }}">clicking here</a>.
+                    <p>
+
+                    <h3>Get Started</h3>
+
+                    <p>
+                        The process for getting started with the Heathrow Ground (S1) endorsement can be found by <a
+                            href="{{ route('controllers.endorsements.heathrow_ground_s1') }}">clicking here</a>.
                     </p>
 
                 </div>

--- a/resources/views/site/atc/endorsements.blade.php
+++ b/resources/views/site/atc/endorsements.blade.php
@@ -38,12 +38,9 @@
                     <h3>Background</h3>
 
                     <p>
-                        London Gatwick (EGKK) is a Tier 1 aerodrome and was the 2nd busiest airport on the
-                        VATSIM network in 2022 with over 84,000 movements.
-                        Controlling at London Gatwick is restricted by the ATC Training Department to S2 rated
-                        members, or S1s that hold a special endorsement. This restriction for S1s is in place to allow
-                        members to gain experience in quieter environments and practice their skills before tackling
-                        the workload at Gatwick.
+                        Controlling at London Gatwick is restricted to S2 rated members, or S1s that hold a special endorsement.
+                        This restriction for S1s is in place to allow members to gain experience in quieter environments
+                        and practice their skills before tackling the workload at Gatwick.
                     </p>
 
                     <p>
@@ -83,10 +80,12 @@
                     <p>
                         London Heathrow (EGLL) is a Tier 1 aerodrome and the busiest airport on the VATSIM network.
 
-                        Controlling at London Heathrow is restricted by the ATC Training Department to S2 rated
-                        members, or S1s that hold a special endorsement. This restriction for S1s is in place to allow
-                        members to gain experience in quieter environments and practice their skills before tackling
-                        the workload at Heathrow.
+                        Controlling at London Heathrow is restricted, members must hold a special endorsement.
+
+                        This restriction is in place to allow members to gain experience in quieter environments
+                        and practice their skills before tackling the workload at Heathrow.
+
+                        S1 rated members that hold a Gatwick Endorsement may train for a Heathrow Ground (S1) Endorsement.
                     </p>
 
                     <h3>Endorsement Process</h3>
@@ -239,7 +238,6 @@
                         <i class="fa fa-plane-departure" aria-hidden="true"></i> &thinsp; London Heathrow (S2+)
                         <i class="pull-right fa fa-arrow-down" aria-hidden="true"></i>
                     </div>
-                </a>
                 </a>
                 <div id="endorsement-heathrow" class="panel-collapse collapse panel-body">
                     View the details for the Heathrow endorsements by <a class="nav-link" href="{{ route('site.atc.heathrow') }}">clicking here</a>.

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -148,6 +148,7 @@ Route::group([
     'middleware' => 'auth_full_group',
 ], function () {
     Route::get('endorsements/gatwick')->uses('EndorsementController@getGatwickGroundIndex')->name('endorsements.gatwick_ground');
+    Route::get('endorsements/heathrow-s1')->uses('EndorsementController@getHeathrowGroundS1Index')->name('endorsements.heathrow_ground_s1');
     Route::get('hour-check/area')->uses('EndorsementController@getAreaIndex')->name('hour_check.area');
 });
 

--- a/tests/Feature/Atc/HeathrowS1EndorsementTest.php
+++ b/tests/Feature/Atc/HeathrowS1EndorsementTest.php
@@ -78,7 +78,6 @@ class HeathrowS1EndorsementTest extends TestCase
             ->assertViewHas('conditionsMet', false);
     }
 
-
     public function testItFailsFor55HoursPreEndorsementGatwick()
     {
         $account = $this->getS1Account();
@@ -89,7 +88,7 @@ class HeathrowS1EndorsementTest extends TestCase
             'callsign' => 'EGKK_T_GND',
             'minutes_online' => 55 * 60,
             'facility_type' => Atc::TYPE_DEL,
-            'connected_at' => Carbon::create(2024, 1, 1)
+            'connected_at' => Carbon::create(2024, 1, 1),
         ]);
 
         factory(Atc::class)->create([
@@ -97,7 +96,7 @@ class HeathrowS1EndorsementTest extends TestCase
             'callsign' => 'EGKK_GND',
             'minutes_online' => 55 * 60,
             'facility_type' => Atc::TYPE_DEL,
-            'connected_at' => Carbon::create(2024, 2, 1)
+            'connected_at' => Carbon::create(2024, 2, 1),
         ]);
 
         factory(Atc::class)->create([
@@ -105,7 +104,7 @@ class HeathrowS1EndorsementTest extends TestCase
             'callsign' => 'EGKK_GND',
             'minutes_online' => 25 * 60,
             'facility_type' => Atc::TYPE_GND,
-            'connected_at' => Carbon::create(2026, 1, 1)
+            'connected_at' => Carbon::create(2026, 1, 1),
         ]);
 
         $this->actingAs($account->fresh())
@@ -117,8 +116,6 @@ class HeathrowS1EndorsementTest extends TestCase
             ->assertViewHas('hasEgkkEndorsement', true)
             ->assertViewHas('conditionsMet', false);
     }
-
-
 
     public function testItDetectsNotOnRoster()
     {

--- a/tests/Feature/Atc/HeathrowS1EndorsementTest.php
+++ b/tests/Feature/Atc/HeathrowS1EndorsementTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Tests\Feature\Atc;
+
+use App\Models\Atc\PositionGroup;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use App\Models\Mship\State;
+use App\Models\NetworkData\Atc;
+use App\Models\Roster;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class HeathrowS1EndorsementTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private const ROUTE = 'controllers.endorsements.heathrow_ground_s1';
+
+    public function testItPassesFor55Hours()
+    {
+        $account = $this->getS1Account();
+        $this->endorseForEgkk($account, Carbon::create(2000, 1, 1));
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_DEL',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_DEL,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK__GND',
+            'minutes_online' => 5 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertStatus(200)
+            ->assertViewHas('hoursMet', true)
+            ->assertViewHas('hasEgkkEndorsement', true)
+            ->assertViewHas('onRoster', true)
+            ->assertViewHas('conditionsMet', true);
+    }
+
+    public function testItFailsFor55HoursNonGatwick()
+    {
+        $account = $this->getS1Account();
+        $this->endorseForEgkk($account, Carbon::create(2000, 1, 1));
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_DEL',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_DEL,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_GND',
+            'minutes_online' => 30 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertStatus(200)
+            ->assertViewHas('hoursMet', false)
+            ->assertViewHas('onRoster', true)
+            ->assertViewHas('hasEgkkEndorsement', true)
+            ->assertViewHas('conditionsMet', false);
+    }
+
+
+    public function testItFailsFor55HoursPreEndorsementGatwick()
+    {
+        $account = $this->getS1Account();
+        $this->endorseForEgkk($account, Carbon::create(2025, 1, 1));
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_T_GND',
+            'minutes_online' => 55 * 60,
+            'facility_type' => Atc::TYPE_DEL,
+            'connected_at' => Carbon::create(2024, 1, 1)
+        ]);
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 55 * 60,
+            'facility_type' => Atc::TYPE_DEL,
+            'connected_at' => Carbon::create(2024, 2, 1)
+        ]);
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_GND,
+            'connected_at' => Carbon::create(2026, 1, 1)
+        ]);
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertStatus(200)
+            ->assertViewHas('hoursMet', false)
+            ->assertViewHas('progress', 50.0)
+            ->assertViewHas('onRoster', true)
+            ->assertViewHas('hasEgkkEndorsement', true)
+            ->assertViewHas('conditionsMet', false);
+    }
+
+
+
+    public function testItDetectsNotOnRoster()
+    {
+        $account = $this->getS1AccountNotOnRoster();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_DEL',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_DEL,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_GND',
+            'minutes_online' => 25 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_GND',
+            'minutes_online' => 5 * 60,
+            'facility_type' => Atc::TYPE_GND,
+        ]);
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertStatus(200)
+            ->assertViewHas('onRoster', false)
+            ->assertViewHas('conditionsMet', false);
+    }
+
+    public function testItRedirectsForNonS1()
+    {
+        $account = Account::factory()->create();
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertRedirect(route('mship.manage.dashboard'));
+    }
+
+    public function testItRedirectsForS2()
+    {
+        $account = Account::factory()->create();
+
+        $qualification = Qualification::code('S2')->first();
+        $account->addQualification($qualification);
+        $account->save();
+
+        $this->actingAs($account->fresh())
+            ->get(route(self::ROUTE))
+            ->assertRedirect(route('mship.manage.dashboard'));
+    }
+
+    private function getS1Account(): Account
+    {
+        $account = Account::factory()->create();
+
+        $qualification = Qualification::code('S1')->first();
+        $account->addQualification($qualification);
+        $account->save();
+
+        $divisionState = State::findByCode('DIVISION')->firstOrFail();
+        $account->addState($divisionState, 'EUR', 'GBR');
+        Roster::create(['account_id' => $account->id])->save();
+
+        return $account;
+    }
+
+    public function endorseForEgkk(Account $account, Carbon $from): void
+    {
+        $positionGroup = PositionGroup::where('name', 'EGKK_GND')->firstOrFail();
+        Account\Endorsement::create([
+            'account_id' => $account->id,
+            'endorsable_id' => $positionGroup->id,
+            'endorsable_type' => PositionGroup::class,
+            'created_at' => $from,
+        ]);
+    }
+
+    private function getS1AccountNotOnRoster(): Account
+    {
+        $account = Account::factory()->create();
+
+        $qualification = Qualification::code('S1')->first();
+        $account->addQualification($qualification);
+        $account->save();
+
+        $divisionState = State::findByCode('DIVISION')->firstOrFail();
+        $account->addState($divisionState, 'EUR', 'GBR');
+
+        return $account;
+    }
+}


### PR DESCRIPTION
Add a page detailing requirements for the heathrow s1 endorsement, easy to do using the same approach as the gatwick page.

No ticket in linear for this afaik.