### PR TITLE
fix: Use correct gatwick endorsement name (has changed in the past).

### DIFF
--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -15,6 +15,8 @@ class EndorsementController extends BaseController
 
     const HEATHROW_S1_HOURS_REQUIREMENT = 50;
 
+    const GATWICK_ENDORSEMENT_NAME = 'Gatwick S1 (DEL/GND)';
+
     public function getGatwickGroundIndex()
     {
         if (! $this->account->fully_defined || ! $this->account->qualification_atc->isS1) {
@@ -57,7 +59,7 @@ class EndorsementController extends BaseController
 
         $egkkEndorsement = $this->account->endorsements()->where(function (Builder $builder) {
             $builder->whereHasMorph('endorsable', [PositionGroup::class], function (Builder $builder) {
-                $builder->where('name', 'EGKK_GND');
+                $builder->where('name', self::GATWICK_ENDORSEMENT_NAME);
             });
         })->first();
 

--- a/database/migrations/2018_02_10_180736_add_kkgnd_endorsement.php
+++ b/database/migrations/2018_02_10_180736_add_kkgnd_endorsement.php
@@ -14,7 +14,7 @@ class AddKkgndEndorsement extends Migration
         DB::table('endorsements')
             ->insert([
                 [
-                    'endorsement' => 'EGKK_GND',
+                    'endorsement' => 'Gatwick S1 (DEL/GND)',
                     'required_airfields' => '["EGCC_%","EGPH_%","EGSS_%","EGGP_%"]',
                     'required_hours' => '10',
                     'hours_months' => '3',
@@ -22,7 +22,7 @@ class AddKkgndEndorsement extends Migration
                     'updated_at' => \Carbon\Carbon::now(),
                 ],
                 [
-                    'endorsement' => 'EGKK_GND',
+                    'endorsement' => 'Gatwick S1 (DEL/GND)',
                     'required_airfields' => '["EGPF_%","EGBB_%","EGGD_%","EGGW_%"]',
                     'required_hours' => '10',
                     'hours_months' => '3',
@@ -30,7 +30,7 @@ class AddKkgndEndorsement extends Migration
                     'updated_at' => \Carbon\Carbon::now(),
                 ],
                 [
-                    'endorsement' => 'EGKK_GND',
+                    'endorsement' => 'Gatwick S1 (DEL/GND)',
                     'required_airfields' => '["EGJJ_%","EGAA_%","EGNT_%","EGNX_%"]',
                     'required_hours' => '5',
                     'hours_months' => '3',

--- a/tests/Feature/Atc/HeathrowS1EndorsementTest.php
+++ b/tests/Feature/Atc/HeathrowS1EndorsementTest.php
@@ -26,7 +26,7 @@ class HeathrowS1EndorsementTest extends TestCase
         factory(Atc::class)->create([
             'account_id' => $account->id,
             'callsign' => 'EGKK_DEL',
-            'minutes_online' => 25 * 60,
+            'minutes_online' => 10 * 60,
             'facility_type' => Atc::TYPE_DEL,
         ]);
         factory(Atc::class)->create([
@@ -38,7 +38,7 @@ class HeathrowS1EndorsementTest extends TestCase
         factory(Atc::class)->create([
             'account_id' => $account->id,
             'callsign' => 'EGKK__GND',
-            'minutes_online' => 5 * 60,
+            'minutes_online' => 30 * 60,
             'facility_type' => Atc::TYPE_GND,
         ]);
 
@@ -186,7 +186,7 @@ class HeathrowS1EndorsementTest extends TestCase
 
     public function endorseForEgkk(Account $account, Carbon $from): void
     {
-        $positionGroup = PositionGroup::where('name', 'EGKK_GND')->firstOrFail();
+        $positionGroup = PositionGroup::where('name', 'Gatwick S1 (DEL/GND)')->firstOrFail();
         Account\Endorsement::create([
             'account_id' => $account->id,
             'endorsable_id' => $positionGroup->id,


### PR DESCRIPTION
Corrects migration from 2018 to use new name, this will help local work and tests, will not run in prod.

Hopefully the name is now correct, could someone with access to prod data please check?

