### PR TITLE
remove /admin from UKCP link

### DIFF
--- a/resources/views/site/pilots/stands.blade.php
+++ b/resources/views/site/pilots/stands.blade.php
@@ -57,7 +57,7 @@
                     </p>
                     <p>
                         To enable this feature, please visit
-                        the <strong><a href="https://ukcp.vatsim.uk/admin/my-preferences">UK Controller Plugin preferences page</a></strong> and select your preffered options.
+                        the <strong><a href="https://ukcp.vatsim.uk/my-preferences">UK Controller Plugin preferences page</a></strong> and select your preffered options.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Removes `/admin` from the UKCP url.
Same issue as in https://github.com/VATSIM-UK/core/pull/3655 I've just missed this second url