### PR TITLE
Support Endorsement Role Sync within Discord Manager

### DIFF
--- a/app/Models/Discord/DiscordRoleRule.php
+++ b/app/Models/Discord/DiscordRoleRule.php
@@ -119,6 +119,6 @@ class DiscordRoleRule extends Model
                     ->exists();
         }
 
-        return false;
+        return true;
     }
 }

--- a/app/Models/Discord/DiscordRoleRule.php
+++ b/app/Models/Discord/DiscordRoleRule.php
@@ -110,13 +110,13 @@ class DiscordRoleRule extends Model
         if ($this->endorsable instanceof PositionGroup) {
             return Roster::where('account_id', $account->getKey())->exists()
                 && $account
-                ->endorsements()
-                ->active()
-                ->whereHasMorph('endorsable',
-                    PositionGroup::class,
-                    fn ($query) => $query->where('id', $this->endorsable->getKey())
-                )
-                ->exists();
+                    ->endorsements()
+                    ->active()
+                    ->whereHasMorph('endorsable',
+                        PositionGroup::class,
+                        fn ($query) => $query->where('id', $this->endorsable->getKey())
+                    )
+                    ->exists();
         }
 
         return false;

--- a/app/Models/Discord/DiscordRoleRule.php
+++ b/app/Models/Discord/DiscordRoleRule.php
@@ -2,11 +2,14 @@
 
 namespace App\Models\Discord;
 
+use App\Models\Atc\Position;
+use App\Models\Atc\PositionGroup;
 use App\Models\Cts\Member;
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
 use App\Models\Mship\State;
 use App\Models\Permission;
+use App\Models\Roster;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -51,6 +54,11 @@ class DiscordRoleRule extends Model
         return $this->belongsTo(State::class);
     }
 
+    public function endorsable()
+    {
+        return $this->morphTo();
+    }
+
     /**
      * Determine if account satifies the requirements for the role.
      */
@@ -59,7 +67,8 @@ class DiscordRoleRule extends Model
         return $this->accountSatisfiesPermissionRequirement($account)
             && $this->accountSatisfiesQualificationRequirement($account)
             && $this->accountSatisfiesStateRequirement($account)
-            && $this->accountSatisfiesCTSMayControlRequirement($account);
+            && $this->accountSatisfiesCTSMayControlRequirement($account)
+            && $this->accountSatisfiesCanControlOnRosterRequirement($account);
     }
 
     protected function accountSatisfiesPermissionRequirement(Account $account): bool
@@ -89,5 +98,26 @@ class DiscordRoleRule extends Model
         }
 
         return Str::contains($ctsMember->visit_may_control, $this->cts_may_control_contains);
+    }
+
+    protected function accountSatisfiesCanControlOnRosterRequirement(Account $account): bool
+    {
+        if ($this->endorsable instanceof Position) {
+            return Roster::firstWhere('account_id', $account->getKey())
+                ?->accountCanControl($this->endorsable);
+        }
+
+        if ($this->endorsable instanceof PositionGroup) {
+            return $account
+                ->endorsements()
+                ->active()
+                ->whereHasMorph('endorsable',
+                    PositionGroup::class,
+                    fn ($query) => $query->where('id', $this->endorsable->getKey())
+                )
+                ->exists();
+        }
+
+        return false;
     }
 }

--- a/app/Models/Discord/DiscordRoleRule.php
+++ b/app/Models/Discord/DiscordRoleRule.php
@@ -108,7 +108,8 @@ class DiscordRoleRule extends Model
         }
 
         if ($this->endorsable instanceof PositionGroup) {
-            return $account
+            return Roster::where('account_id', $account->getKey())->exists()
+                && $account
                 ->endorsements()
                 ->active()
                 ->whereHasMorph('endorsable',

--- a/database/migrations/2024_06_26_185221_add_endorseable_to_discord_role_rules.php
+++ b/database/migrations/2024_06_26_185221_add_endorseable_to_discord_role_rules.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('discord_role_rules', function (Blueprint $table) {
+            $table->nullableMorphs('endorsable');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('discord_role_rules', function (Blueprint $table) {
+            $table->dropMorphs('endorsable');
+        });
+    }
+};

--- a/tests/Unit/Discord/DiscordRoleRuleTest.php
+++ b/tests/Unit/Discord/DiscordRoleRuleTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Unit\Discord;
 
+use App\Models\Atc\PositionGroup;
 use App\Models\Cts\Member;
 use App\Models\Discord\DiscordRoleRule;
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
 use App\Models\Mship\State;
+use App\Models\Roster;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Spatie\Permission\Models\Permission;
@@ -17,9 +19,11 @@ class DiscordRoleRuleTest extends TestCase
     use DatabaseTransactions;
 
     #[DataProvider('providerTestData')]
-    public function testItReportsAccountSatisfiesCorrectly($permSetup, $stateSetup, $qualSetup, $ctsControlSetup, $expected)
+    public function testItReportsAccountSatisfiesCorrectly($permSetup, $stateSetup, $qualSetup, $ctsControlSetup, $endorsableSetup, $expected)
     {
         $state = State::first();
+
+        $positionGroup = PositionGroup::factory()->create();
 
         $role = DiscordRoleRule::factory()->create(
             [
@@ -29,6 +33,10 @@ class DiscordRoleRuleTest extends TestCase
                 'cts_may_control_contains' => $ctsControlSetup[1] ? 'CTS_SEARCH_QUERY' : null,
             ]
         );
+
+        if ($endorsableSetup[1]) {
+            $role->endorsable()->associate($positionGroup);
+        }
 
         // Setup CTS may control
         $member = factory(Member::class)->create([
@@ -51,28 +59,41 @@ class DiscordRoleRuleTest extends TestCase
             $account->addQualification($role->qualification);
         }
 
+        // Add endorsement, qualification and home state
+        if ($endorsableSetup[0]) {
+            Roster::create(['account_id' => $account->getKey()]);
+            $account->endorsements()->create([
+                'endorsable_id' => $positionGroup->id,
+                'endorsable_type' => PositionGroup::class,
+            ]);
+            $account->addQualification(Qualification::factory()->atc()->create());
+            $account->addState($state);
+        }
+
         $this->assertEquals($expected, $role->accountSatisfies($account->fresh()));
     }
 
     public static function providerTestData()
     {
         return [
-            // [Has Perm, Requires Perm], [Has State, Requires State], [Has Qual, Requires Qual], [Has CTS, Requires CTS], Expected
-            [[false, false], [false, false], [false, false], [false, false], true],
-            [[false, true], [false, true], [false, true], [false, true], false],
+            // [Has Perm, Requires Perm], [Has State, Requires State], [Has Qual, Requires Qual], [Has CTS, Requires CTS], [Has Endorsement, Requires Endorsement], Expected
+            [[false, false], [false, false], [false, false], [false, false], [false, false], true],
+            [[false, true], [false, true], [false, true], [false, true], [false, true], false],
 
-            [[true, true], [false, true], [false, true], [false, true], false], // Check no one requirement ends up in truthy
-            [[false, true], [true, true], [false, true], [false, true], false],
-            [[false, true], [false, true], [true, true], [false, true], false],
-            [[false, true], [false, true], [false, true], [true, true], false],
+            [[true, true], [false, true], [false, true], [false, true], [false, true], false], // Check no one requirement ends up in truthy
+            [[false, true], [true, true], [false, true], [false, true], [false, true], false],
+            [[false, true], [false, true], [true, true], [false, true], [false, true], false],
+            [[false, true], [false, true], [false, true], [true, true], [false, true], false],
+            [[false, true], [false, true], [false, true], [false, true], [false, true], false],
 
-            [[true, true], [true, true], [true, true], [false, true], false],
-            [[true, true], [true, true], [true, true], [true, true], true],
+            [[true, true], [true, true], [true, true], [false, true], [false, true], false],
+            [[true, true], [true, true], [true, true], [true, true], [true, true], true],
 
-            [[true, true], [false, false], [false, false], [false, false], true],
-            [[false, false], [true, true], [false, false], [false, false], true],
-            [[false, false], [false, false], [true, true], [false, false], true],
-            [[false, false], [false, false], [false, false], [true, true], true],
+            [[true, true], [false, false], [false, false], [false, false], [false, false], true],
+            [[false, false], [true, true], [false, false], [false, false], [false, false], true],
+            [[false, false], [false, false], [true, true], [false, false], [false, false], true],
+            [[false, false], [false, false], [false, false], [true, true], [false, false], true],
+            [[false, false], [false, false], [false, false], [false, false], [true, true], true],
         ];
     }
 }


### PR DESCRIPTION
Allows Discord role rules to be linked to either Positions or PositionGroups.
Whilst we don't do any that are directly related to positions right now, it may be useful in future.

Fixes TECH-236.

Go live script

```
INSERT INTO `discord_role_rules` (`name`, `discord_id`, `permission_id`, `qualification_id`, `state_id`, `cts_may_control_contains`, `endorsable_type`, `endorsable_id`) VALUES
('LL APP Endorsement', 1115367609450381363, NULL, NULL, NULL, NULL, 'App\\Models\\PositionGroup', 11),
('LL GND Endorsement', 1115367317510037596, NULL, NULL, NULL, NULL, 'App\\Models\\PositionGroup', 18),
('LL TWR Endorsement', 1115367506232746086, NULL, NULL, NULL, NULL, 'App\\Models\\PositionGroup', 10),
('Shanwick Controller', 989268023091277885, NULL, NULL, NULL, NULL, 'App\\Models\\PositionGroup', 15);
```