### PR TITLE
Update Validations API for Roster

### DIFF
--- a/app/Http/Controllers/Api/ValidationsController.php
+++ b/app/Http/Controllers/Api/ValidationsController.php
@@ -31,7 +31,7 @@ class ValidationsController
             return Roster::all()->filter(function (Roster $roster) use ($position) {
                 return $roster->accountCanControl($position);
             })->map(function (Roster $roster) {
-               return ['id' => $roster->account_id];
+                return ['id' => $roster->account_id];
             });
         });
 

--- a/app/Http/Controllers/Api/ValidationsController.php
+++ b/app/Http/Controllers/Api/ValidationsController.php
@@ -30,7 +30,9 @@ class ValidationsController
         $validatedMembers = cache()->remember("validation_members_{$position->id}", now()->addMinutes(30), function () use ($position) {
             return Roster::all()->filter(function (Roster $roster) use ($position) {
                 return $roster->accountCanControl($position);
-            })->pluck('account_id');
+            })->map(function (Roster $roster) {
+               return ['id' => $roster->account_id];
+            });
         });
 
         return response()->json([

--- a/app/Http/Controllers/Api/ValidationsController.php
+++ b/app/Http/Controllers/Api/ValidationsController.php
@@ -11,7 +11,7 @@ class ValidationsController
 {
     public function view(Request $request)
     {
-        if (!$request->get('position')) {
+        if (! $request->get('position')) {
             return response()->json([
                 'status' => '400',
                 'message' => 'No position was supplied.',

--- a/app/Http/Controllers/Api/ValidationsController.php
+++ b/app/Http/Controllers/Api/ValidationsController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Api\CTS;
+namespace App\Http\Controllers\Api;
 
 use App\Models\Atc\Position;
 use App\Models\Roster;

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-Route::get('validations')->uses('Api\CTS\ValidationsController@view')->name('api.validations');
+Route::get('validations')->uses('Api\ValidationsController@view')->name('api.validations');
 Route::get('metar/{airportIcao}')->uses('Site\MetarController@get')->name('api.metar');
 
 Route::group([

--- a/tests/Feature/API/ValidationTest.php
+++ b/tests/Feature/API/ValidationTest.php
@@ -62,7 +62,9 @@ class ValidationTest extends TestCase
                     'position' => $position->name,
                 ],
                 'validated_members' => [
-                    $endorsement->account_id,
+                    [
+                        'id' => $endorsement->account_id,
+                    ]
                 ],
             ]);
     }

--- a/tests/Feature/API/ValidationTest.php
+++ b/tests/Feature/API/ValidationTest.php
@@ -64,7 +64,7 @@ class ValidationTest extends TestCase
                 'validated_members' => [
                     [
                         'id' => $endorsement->account_id,
-                    ]
+                    ],
                 ],
             ]);
     }

--- a/tests/Feature/API/ValidationTest.php
+++ b/tests/Feature/API/ValidationTest.php
@@ -1,10 +1,13 @@
 <?php
 
-namespace Tests\Feature\CTS;
+namespace Tests\Feature\API;
 
-use App\Models\Cts\Member;
-use App\Models\Cts\Validation;
-use App\Models\Cts\ValidationPosition;
+use App\Models\Atc\Position;
+use App\Models\Mship\Account;
+use App\Models\Mship\Account\Endorsement;
+use App\Models\Mship\Qualification;
+use App\Models\Mship\State;
+use App\Models\Roster;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
@@ -35,24 +38,31 @@ class ValidationTest extends TestCase
     /** @test */
     public function itReturnsAJsonResponse()
     {
-        $member = factory(Member::class)->create();
-        $position = factory(ValidationPosition::class)->create();
-        $validation = factory(Validation::class)->create([
-            'member_id' => $member,
-            'position_id' => $position,
+        $qualification = Qualification::code('S2')->first();
+        $account = Account::factory()->create();
+        $account->addQualification($qualification);
+        $account->addState(State::findByCode('DIVISION'));
+        $position = Position::factory()->create([
+            'type' => Position::TYPE_TOWER,
+        ]);
+        Roster::create([
+            'account_id' => $account->id,
         ]);
 
-        $this->call('GET', route('api.validations'), ['position' => $position->position])
+        $endorsement = Endorsement::factory()->create([
+            'account_id' => $account,
+            'endorsable_type' => Position::class,
+            'endorsable_id' => $position,
+        ]);
+
+        $this->call('GET', route('api.validations'), ['position' => $position->callsign])
             ->assertStatus(200)
             ->assertExactJson([
                 'status' => [
-                    'position' => $position->position,
+                    'position' => $position->name,
                 ],
                 'validated_members' => [
-                    [
-                        'id' => $member->cid,
-                        'name' => $member->name,
-                    ],
+                    $endorsement->account_id,
                 ],
             ]);
     }


### PR DESCRIPTION
Update the API endpoint that originally used CTS validations to instead look at the roster.
Not the most efficient iterating through everyone on the roster but it is pretty quick with production data.

Resolves TECH-274.