### PR TITLE
Fix: Waiting lists list not listing theory exame corrects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,12 @@ php artisan migrate
 php artisan cts:migrate:fresh # Optional if you require a CTS db for tests
 ```
 
+For local dev you may need to run
+```shell
+php artisan db:seed # sets up the roles and permissions
+php artisan grant:superman <CID> # makes a test account an admin
+```
+
 ### Compiling Frontend Assets
 Install all required dependencies
 ```shell

--- a/resources/views/mship/waiting-lists/_waiting_lists_list.blade.php
+++ b/resources/views/mship/waiting-lists/_waiting_lists_list.blade.php
@@ -27,19 +27,24 @@
                             @endif
                         </td>
                         <td>{{$waitingList->pivot->created_at->format('d M Y')}}</td>
-                        <td>
-                            @if ($waitingList->isAtcList() && $waitingList->pivot->account->onRoster())
-                                {!! HTML::img("tick_mark_circle", "png", 20) !!}
-                            @elseif($waitingList->isAtcList())
-                                {!! HTML::img("cross_mark_circle", "png", 20) !!}
-                            @else
+
+                        @if($waitingList->isAtcList())
+                            <td>
+                                @if ($waitingList->pivot->account->onRoster())
+                                    {!! HTML::img("tick_mark_circle", "png", 20) !!}
+                                @else
+                                    {!! HTML::img("cross_mark_circle", "png", 20) !!}
+                                @endif
+                            </td>
+                        @else
+                            <td>
                                 N/A
-                            @endif
-                        </td>
+                            </td>
+                        @endif
                         <td>
-                            @if (($record->waitingList->feature_toggles['check_cts_theory_exam'] ?? false) && $waitingList->pivot->theory_exam_passed)
+                            @if (($waitingList->feature_toggles['check_cts_theory_exam'] ?? true) && $waitingList->pivot->theory_exam_passed)
                                 {!! HTML::img("tick_mark_circle", "png", 20) !!}
-                            @elseif($record->waitingList->feature_toggles['check_cts_theory_exam'] ?? false)
+                            @elseif($waitingList->feature_toggles['check_cts_theory_exam'] ?? true)
                                 {!! HTML::img("cross_mark_circle", "png", 20) !!}
                             @else
                                 N/A


### PR DESCRIPTION
Due to a lil snafu this has been broken for a while, should restore properly showing if you have passed the CTS exam for atc & pilot lists