### PR TITLE
fix: Soft deleted waiting lists would crash waiting list retrieval

### DIFF
--- a/app/Models/Mship/Concerns/HasWaitingLists.php
+++ b/app/Models/Mship/Concerns/HasWaitingLists.php
@@ -45,6 +45,12 @@ trait HasWaitingLists
         $waitingLists = collect();
         foreach ($waitingListAccounts as $waitingListAccount) {
             $waitingList = $waitingListAccount->waitingList;
+
+            if (empty($waitingList)) {
+                // Waiting list has likely been soft deleted, we don't want to retrieve it here
+                continue;
+            }
+
             $waitingLists->put($waitingList->id, $waitingList);
         }
 


### PR DESCRIPTION
Whoops!

Users with places on soft deleted waiting lists could not have their waiting lists retrieved due to an accidental null object access. This broke login as waiting list eligibility is recalculated at login.