### PR TITLE
fix: Tests for soft deleted waiting lists

### DIFF
--- a/app/Models/Mship/Concerns/HasWaitingLists.php
+++ b/app/Models/Mship/Concerns/HasWaitingLists.php
@@ -20,13 +20,13 @@ trait HasWaitingLists
      */
     public function waitingLists()
     {
-        return $this->waitingListAccounts()
+        // waiting list accounts soft delete so this will exclude them
+        $waitingListAccounts = $this->waitingListAccounts()
             ->withTrashed()
-            ->get()
-            ->mapWithKeys(function (WaitingListAccount $waitingListAccount) {
-                return [$waitingListAccount->waitingList->id => $waitingListAccount->waitingList];
-            })
-            ->values();
+            ->with('waitingList')
+            ->get();
+
+        return $this->extractListsFromWaitingListAccounts($waitingListAccounts);
     }
 
     /**
@@ -41,7 +41,15 @@ trait HasWaitingLists
             ->with('waitingList')
             ->get();
 
-        // @fixme maybe replace with mapWithKeys
+        return $this->extractListsFromWaitingListAccounts($waitingListAccounts);
+    }
+
+    /**
+     * @param  Collection<WaitingListAccount>  $waitingListAccounts
+     * @return Collection<WaitingList>
+     */
+    private function extractListsFromWaitingListAccounts(Collection $waitingListAccounts): Collection
+    {
         $waitingLists = collect();
         foreach ($waitingListAccounts as $waitingListAccount) {
             $waitingList = $waitingListAccount->waitingList;

--- a/tests/Unit/Account/Relationships/AccountWaitingListsTest.php
+++ b/tests/Unit/Account/Relationships/AccountWaitingListsTest.php
@@ -47,4 +47,16 @@ class AccountWaitingListsTest extends TestCase
         $this->assertCount(1, $this->user->fresh()->currentWaitingLists());
         $this->assertContains($this->currentWaitingList->id, $this->user->fresh()->currentWaitingLists()->pluck('id'));
     }
+
+    /** @test */
+    public function itCanHandleTrashedWaitingLists()
+    {
+        $trashed = factory(WaitingList::class)->create();
+        $trashed->addToWaitingList($this->user, $this->privacc);
+        $trashed->delete();
+        $trashed->save();
+
+        $this->assertCount(1, $this->user->fresh()->currentWaitingLists());
+        $this->assertCount(2, $this->user->fresh()->waitingLists());
+    }
 }


### PR DESCRIPTION
Add some tests for retrieving waiting lists when some of the lists are soft deleted (these won't appear). Fix the same behaviour for current and soft deleted waiting list positions.

See #3880 