### PR TITLE
Waiting list overview widget fix

### DIFF
--- a/app/Filament/Resources/WaitingListResource/Widgets/IndividualWaitingListOverview.php
+++ b/app/Filament/Resources/WaitingListResource/Widgets/IndividualWaitingListOverview.php
@@ -2,24 +2,26 @@
 
 namespace App\Filament\Resources\WaitingListResource\Widgets;
 
+use App\Models\Training\WaitingList;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
-use Illuminate\Database\Eloquent\Model;
 
 class IndividualWaitingListOverview extends BaseWidget
 {
-    public ?Model $record = null;
+    public ?WaitingList $record = null;
 
     protected static ?string $pollingInterval = null;
 
     protected function getStats(): array
     {
-        $totalAccounts = $this->record->accounts()->count();
+        $totalAccounts = $this->record->waitingListAccounts()->count();
 
-        $averageWaitTime = $this->record->accounts->average(fn ($account) => $account->pivot->created_at->diffInDays(now()));
+        $averageWaitTime = $this->record->waitingListAccounts->average(fn ($listAccount) => $listAccount->created_at->diffInDays(now()));
+        $longestWaitTime = $this->record->waitingListAccounts->max(fn ($listAccount) => $listAccount->created_at->diffInDays(now()));
 
         return [
             Stat::make('Total accounts', $totalAccounts),
+            Stat::make('Longest wait time', $longestWaitTime ? round($longestWaitTime).'days' : 'N/A'),
             Stat::make('Average wait time', $averageWaitTime ? round($averageWaitTime).' days' : 'N/A'),
         ];
     }

--- a/tests/Feature/Account/WaitingListsTest.php
+++ b/tests/Feature/Account/WaitingListsTest.php
@@ -41,6 +41,7 @@ class WaitingListsTest extends TestCase
 
         $this->actingAs($this->user)
             ->get(route('mship.waiting-lists.index'))
-            ->assertSee('My List');
+            ->assertSee('My List')
+            ->assertSee('Total accounts');
     }
 }

--- a/tests/Feature/Account/WaitingListsTest.php
+++ b/tests/Feature/Account/WaitingListsTest.php
@@ -41,7 +41,6 @@ class WaitingListsTest extends TestCase
 
         $this->actingAs($this->user)
             ->get(route('mship.waiting-lists.index'))
-            ->assertSee('My List')
-            ->assertSee('Total accounts');
+            ->assertSee('My List');
     }
 }


### PR DESCRIPTION
Overview widget was still using WaitingListAccount as pivot, missed in big refactor