### PR TITLE
Remove docker compose version attribute

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   vatsimuk-core:
     build:


### PR DESCRIPTION
The version attribute is now deprecated and throws a warning when included