### PR TITLE
feat: add CTS booking API

### DIFF
--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -7,6 +7,7 @@ use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\RateLimiter;
+use Carbon\Exceptions\InvalidFormatException;
 
 class CtsController
 {
@@ -39,7 +40,7 @@ class CtsController
                     ], Response::HTTP_BAD_REQUEST);
                 }
 
-            } catch (\Carbon\Exceptions\InvalidFormatException $e) {
+            } catch (InvalidFormatException $e) {
                 return response()->json([
                     'message' => 'Invalid date format. Please use YYYY-MM-DD.',
                 ], Response::HTTP_BAD_REQUEST);

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -52,7 +52,9 @@ class CtsController
         $bookings = $this->bookingRepository->getBookings($date);
 
         return response()->json([
-            'bookings' => $bookings,
+            'bookings' => $bookings->map(function ($booking) {
+                return collect($booking)->except(['member'])->toArray();
+            }),
             'date' => $date->toDateString(),
             'count' => $bookings->count(),
             'next_page_url' => $this->generateNextPageUrl($date),

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -19,7 +19,7 @@ class CtsController
 
     public function getBookings()
     {
-        $bookings = $this->bookingRepository->getBookings(15);
+        $bookings = $this->bookingRepository->getBookings();
 
         return response()->json($bookings);
     }

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -25,6 +25,7 @@ class CtsController
             return response()->json(['message' => 'No bookings found'], 404);
         }
 
+        // Not all bookings from the min/max date may be returned if the pagination limit is reached
         $fromDate = $bookings->first()->date;
         $toDate = $bookings->last()->date;
 

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -1,12 +1,9 @@
 <?php
 
-
 namespace App\Http\Controllers\Api;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Response;
-use Illuminate\Support\Facades\Session;
 use App\Repositories\Cts\BookingRepository;
+use Illuminate\Http\Request;
 
 class CtsController
 {
@@ -34,9 +31,9 @@ class CtsController
             'meta' => [
                 'dateRange' => [
                     'from' => $fromDate,
-                    'to' => $toDate
-                ]
-            ]
+                    'to' => $toDate,
+                ],
+            ],
         ]);
     }
 }

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -4,16 +4,27 @@ namespace App\Http\Controllers\Api;
 
 use App\Repositories\Cts\BookingRepository;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Http\Response;
 
 class CtsController
 {
-    private $bookingRepository;
-
     public function __construct(private BookingRepository $bookingRepository)
     {}
 
     public function getBookings(Request $request)
     {
+        if (app()->environment() !== 'development' && RateLimiter::tooManyAttempts('get-bookings:'.$request->ip(), 1)) {
+            $seconds = RateLimiter::availableIn('get-bookings:'.$request->ip());
+            return response()->json([
+            'message' => 'Too many requests. Please try again after '.$seconds.' seconds.'
+            ], Response::HTTP_TOO_MANY_REQUESTS)
+            ->header('Retry-After', $seconds)
+            ->header('X-RateLimit-Reset', now()->addSeconds($seconds)->getTimestamp());
+        }
+
+        RateLimiter::hit('get-bookings:'.$request->ip(), 300); // 5 minutes
+
         $bookings = $this->bookingRepository->getBookings(50);
 
         if ($bookings->isEmpty()) {

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -10,8 +10,6 @@ use App\Repositories\Cts\BookingRepository;
 
 class CtsController
 {
-    public static $MAX_PER_PAGE = 50;
-
     private $bookingRepository;
 
     public function __construct(BookingRepository $bookingRepository)
@@ -19,18 +17,21 @@ class CtsController
         $this->bookingRepository = $bookingRepository;
     }
 
-    public static function normalizePageResultCount($perPage)
-    {
-        return min($perPage, CtsController::$MAX_PER_PAGE);
-    }
-
-
     public function getBookings(Request $request)
     {
-        $perPage = self::normalizePageResultCount($request->query('count', 30));
+        $bookings = $this->bookingRepository->getBookings(50);
 
-        $bookings = $this->bookingRepository->getBookings($perPage);
+        $fromDate = $bookings->first()->date;
+        $toDate = $bookings->last()->date;
 
-        return response()->json($bookings);
+        return response()->json([
+            'bookings' => $bookings,
+            'meta' => [
+                'dateRange' => [
+                    'from' => $fromDate,
+                    'to' => $toDate
+                ]
+            ]
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -21,6 +21,10 @@ class CtsController
     {
         $bookings = $this->bookingRepository->getBookings(50);
 
+        if ($bookings->isEmpty()) {
+            return response()->json(['message' => 'No bookings found'], 404);
+        }
+
         $fromDate = $bookings->first()->date;
         $toDate = $bookings->last()->date;
 

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Session;
+use App\Repositories\Cts\BookingRepository;
+
+class CtsController
+{
+    private $bookingRepository;
+
+    public function __construct(BookingRepository $bookingRepository)
+    {
+        $this->bookingRepository = $bookingRepository;
+    }
+
+    public function getBookings()
+    {
+        $bookings = $this->bookingRepository->getBookings(15);
+
+        return response()->json($bookings);
+    }
+}

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -9,10 +9,8 @@ class CtsController
 {
     private $bookingRepository;
 
-    public function __construct(BookingRepository $bookingRepository)
-    {
-        $this->bookingRepository = $bookingRepository;
-    }
+    public function __construct(private BookingRepository $bookingRepository)
+    {}
 
     public function getBookings(Request $request)
     {

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -52,6 +52,7 @@ class CtsController
 
         return response()->json([
             'bookings' => $bookings->map(function ($booking) {
+                // we exclude the member object to avoid exposing personal data
                 return collect($booking)->except(['member'])->toArray();
             }),
             'date' => $date->toDateString(),

--- a/app/Http/Controllers/Api/CtsController.php
+++ b/app/Http/Controllers/Api/CtsController.php
@@ -10,6 +10,8 @@ use App\Repositories\Cts\BookingRepository;
 
 class CtsController
 {
+    public static $MAX_PER_PAGE = 50;
+
     private $bookingRepository;
 
     public function __construct(BookingRepository $bookingRepository)
@@ -17,9 +19,17 @@ class CtsController
         $this->bookingRepository = $bookingRepository;
     }
 
-    public function getBookings()
+    public static function normalizePageResultCount($perPage)
     {
-        $bookings = $this->bookingRepository->getBookings();
+        return min($perPage, CtsController::$MAX_PER_PAGE);
+    }
+
+
+    public function getBookings(Request $request)
+    {
+        $perPage = self::normalizePageResultCount($request->query('count', 30));
+
+        $bookings = $this->bookingRepository->getBookings($perPage);
 
         return response()->json($bookings);
     }

--- a/app/Repositories/Cts/BookingRepository.php
+++ b/app/Repositories/Cts/BookingRepository.php
@@ -8,6 +8,11 @@ use Illuminate\Support\Collection;
 
 class BookingRepository
 {
+    public function getBookings($perPage = 30)
+    {
+        return Booking::orderBy('date', 'desc')->paginate($perPage);
+    }
+
     public function getTodaysBookings()
     {
         $bookings = Booking::where('date', '=', Carbon::now()->toDateString())

--- a/app/Repositories/Cts/BookingRepository.php
+++ b/app/Repositories/Cts/BookingRepository.php
@@ -5,11 +5,14 @@ namespace App\Repositories\Cts;
 use App\Models\Cts\Booking;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
+use App\Http\Controllers\Api\CtsController;
 
 class BookingRepository
 {
     public function getBookings($perPage = 30)
     {
+        $perPage = CtsController::normalizePageResultCount($perPage);
+
         return Booking::orderBy('date', 'desc')->paginate($perPage);
     }
 

--- a/app/Repositories/Cts/BookingRepository.php
+++ b/app/Repositories/Cts/BookingRepository.php
@@ -8,19 +8,19 @@ use Illuminate\Support\Collection;
 
 class BookingRepository
 {
-    public function getBookings($perPage = 50)
+    public function getBookings(Carbon $date)
     {
-        return Booking::orderBy('date', 'desc')->paginate($perPage);
-    }
-
-    public function getTodaysBookings()
-    {
-        $bookings = Booking::where('date', '=', Carbon::now()->toDateString())
+        $bookings = Booking::where('date', '=', $date->toDateString())
             ->with('member')
             ->orderBy('from')
             ->get();
 
         return $this->formatBookings($bookings);
+    }
+
+    public function getTodaysBookings()
+    {
+        return $this->getBookings(Carbon::now());
     }
 
     public function getTodaysLiveAtcBookings()

--- a/app/Repositories/Cts/BookingRepository.php
+++ b/app/Repositories/Cts/BookingRepository.php
@@ -5,7 +5,6 @@ namespace App\Repositories\Cts;
 use App\Models\Cts\Booking;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
-use App\Http\Controllers\Api\CtsController;
 
 class BookingRepository
 {

--- a/app/Repositories/Cts/BookingRepository.php
+++ b/app/Repositories/Cts/BookingRepository.php
@@ -20,7 +20,12 @@ class BookingRepository
 
     public function getTodaysBookings()
     {
-        return $this->getBookings(Carbon::now());
+        $bookings = Booking::where('date', '=', Carbon::now()->toDateString())
+            ->with('member')
+            ->orderBy('from')
+            ->get();
+
+        return $this->formatBookings($bookings);
     }
 
     public function getTodaysLiveAtcBookings()

--- a/app/Repositories/Cts/BookingRepository.php
+++ b/app/Repositories/Cts/BookingRepository.php
@@ -9,10 +9,8 @@ use App\Http\Controllers\Api\CtsController;
 
 class BookingRepository
 {
-    public function getBookings($perPage = 30)
+    public function getBookings($perPage = 50)
     {
-        $perPage = CtsController::normalizePageResultCount($perPage);
-
         return Booking::orderBy('date', 'desc')->paginate($perPage);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 Route::get('validations')->uses('Api\ValidationsController@view')->name('api.validations');
 Route::get('metar/{airportIcao}')->uses('Site\MetarController@get')->name('api.metar');
+Route::get('/cts/bookings')->uses('Api\CtsController@getBookings')->name('api.cts.bookings');
 
 Route::group([
     'middleware' => 'api_auth',

--- a/tests/Unit/CTS/BookingsRepositoryTest.php
+++ b/tests/Unit/CTS/BookingsRepositoryTest.php
@@ -33,6 +33,21 @@ class BookingsRepositoryTest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_a_list_of_bookings()
+    {
+        factory(Booking::class, 30)->create();
+
+        $bookings = $this->subjectUnderTest->getBookings();
+
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $bookings);
+        $this->assertCount(30, $bookings->items());
+
+        $bookingsCollection = collect($bookings->items());
+        $this->assertInstanceOf(Collection::class, $bookingsCollection);
+        $this->assertCount(30, $bookingsCollection);
+    }
+
+    /** @test */
     public function it_can_return_a_list_of_todays_bookings_with_owner_and_type()
     {
         factory(Booking::class, 2)->create(['date' => $this->knownDate->copy()->addDays(5)->toDateString()]);

--- a/tests/Unit/CTS/BookingsRepositoryTest.php
+++ b/tests/Unit/CTS/BookingsRepositoryTest.php
@@ -28,23 +28,20 @@ class BookingsRepositoryTest extends TestCase
         parent::setUp();
 
         $this->subjectUnderTest = resolve(BookingRepository::class);
-        $this->today = $this->knownDate->toDateString();
-        $this->tomorrow = $this->knownDate->copy()->addDay()->toDateString();
+        $this->today = $this->knownDate->copy();
+        $this->tomorrow = $this->knownDate->copy()->addDay();
     }
 
     /** @test */
-    public function it_can_return_a_list_of_bookings()
+    public function it_can_return_a_list_of_bookings_for_today()
     {
-        factory(Booking::class, 30)->create();
+        factory(Booking::class, 10)->create(['date' => $this->today->toDateString()]);
 
-        $bookings = $this->subjectUnderTest->getBookings();
+        $bookings = $this->subjectUnderTest->getBookings($this->today);
 
-        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $bookings);
-        $this->assertCount(30, $bookings->items());
-
-        $bookingsCollection = collect($bookings->items());
-        $this->assertInstanceOf(Collection::class, $bookingsCollection);
-        $this->assertCount(30, $bookingsCollection);
+        $this->assertInstanceOf(Collection::class, $bookings);
+        $this->assertCount(10, $bookings);
+        $this->assertInstanceOf(Booking::class, $bookings->first());
     }
 
     /** @test */

--- a/tests/Unit/CTS/BookingsRepositoryTest.php
+++ b/tests/Unit/CTS/BookingsRepositoryTest.php
@@ -28,16 +28,16 @@ class BookingsRepositoryTest extends TestCase
         parent::setUp();
 
         $this->subjectUnderTest = resolve(BookingRepository::class);
-        $this->today = $this->knownDate->copy();
-        $this->tomorrow = $this->knownDate->copy()->addDay();
+        $this->today = $this->knownDate->toDateString();
+        $this->tomorrow = $this->knownDate->copy()->addDay()->toDateString();
     }
 
     /** @test */
     public function it_can_return_a_list_of_bookings_for_today()
     {
-        factory(Booking::class, 10)->create(['date' => $this->today->toDateString()]);
+        factory(Booking::class, 10)->create(['date' => Carbon::now()]);
 
-        $bookings = $this->subjectUnderTest->getBookings($this->today);
+        $bookings = $this->subjectUnderTest->getBookings(Carbon::parse($this->today));
 
         $this->assertInstanceOf(Collection::class, $bookings);
         $this->assertCount(10, $bookings);


### PR DESCRIPTION
This PR introduces a GET `/api/cts/bookings?date=YYY-MM-DD` route which returns  a list of CTS bookings on that date.

Minimum allowed date is `now - 30 days`
