### PR TITLE
Add a linting pre-commit hook

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Running pre-commit lint hook"
+
+files=$(git diff --cached --name-only --diff-filter=ACM)
+files=$(echo "$files" | grep "\.php$")
+
+composer lint $files

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,10 +1,15 @@
 #!/bin/bash
 
+# This script is a pre-commit hook that runs PHP linting on all PHP files that are about to be committed.
+
 echo "Running pre-commit lint hook"
 
 files=$(git diff --cached --name-only --diff-filter=ACM)
 files=$(echo "$files" | grep "\.php$")
 
-echo "Running lint on the following files: $files"
+if [ -z "$files" ]; then
+    echo "No PHP files to lint"
+    exit 0
+fi
 
 composer lint $files

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -5,4 +5,5 @@ echo "Running pre-commit lint hook"
 files=$(git diff --cached --name-only --diff-filter=ACM)
 files=$(echo "$files" | grep "\.php$")
 
+echo "$files" | xargs -n 1
 composer lint $files

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -5,5 +5,6 @@ echo "Running pre-commit lint hook"
 files=$(git diff --cached --name-only --diff-filter=ACM)
 files=$(echo "$files" | grep "\.php$")
 
-echo "$files" | xargs -n 1
+echo "Running lint on the following files: $files"
+
 composer lint $files

--- a/git-hooks/setup.sh
+++ b/git-hooks/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+for file in $(ls ./git-hooks | grep -v '\.sh$'); do
+    chmod +x ./git-hooks/$file
+    ln -sf ../../git-hooks/$file .git/hooks/$file
+    echo "Initialized $file hook"
+done

--- a/git-hooks/setup.sh
+++ b/git-hooks/setup.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This script will initialize all the hooks in the git-hooks directory
+# Running: chmod +x git-hooks/setup.sh && ./git-hooks/setup.sh
+
 for file in $(ls ./git-hooks | grep -v '\.sh$'); do
     chmod +x ./git-hooks/$file
     ln -sf ../../git-hooks/$file .git/hooks/$file


### PR DESCRIPTION
This PR adds a pre-commit hook which will automatically lint all `.php` files staged for the commit.

A setup script is included which when executed will create a symlink from `.git/hooks/` to `git-hooks/` for every hook defined in the directory, meaning the setup script only has to be run for the creating of the hooks, after that they can be versioned normally.