### PR TITLE
Add development-only docker compose

### DIFF
--- a/.devcontainer/docker-compose.dev.yml
+++ b/.devcontainer/docker-compose.dev.yml
@@ -1,0 +1,37 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    command: redis-server --requirepass root
+    environment:
+      - REDIS_PASSWORD=root
+
+
+  mysql:
+    image: mysql:8.0
+    volumes:
+      - db-data:/var/lib/mysql
+      - ./mysql_init:/docker-entrypoint-initdb.d
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: core
+    ports:
+      - "3306:3306"
+    expose:
+      - "3306"
+
+  pma:
+    image: phpmyadmin
+    ports:
+      - "8090:80"
+    environment:
+      - PMA_ARBITRARY=1
+      - PMA_HOST=mysql
+      - PMA_PORT=3306
+    depends_on:
+      - mysql
+
+
+volumes:
+  db-data:

--- a/.devcontainer/docker-compose.dev.yml
+++ b/.devcontainer/docker-compose.dev.yml
@@ -1,3 +1,5 @@
+# Usage: .devcontainer/load-dotenv.sh docker-compose -f .devcontainer/docker-compose.dev.yml up
+
 services:
   redis:
     image: redis:7-alpine

--- a/.devcontainer/docker-compose.dev.yml
+++ b/.devcontainer/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
       - "6379:6379"
     command: redis-server --requirepass root
     environment:
-      - REDIS_PASSWORD=root
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
 
 
   mysql:
@@ -14,10 +14,10 @@ services:
       - db-data:/var/lib/mysql
       - ./mysql_init:/docker-entrypoint-initdb.d
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: core
+      MYSQL_ROOT_PASSWORD: ${DB_MYSQL_PASS}
+      MYSQL_DATABASE: ${DB_MYSQL_NAME}
     ports:
-      - "3306:3306"
+      - ${DB_MYSQL_PORT}:3306
     expose:
       - "3306"
 
@@ -28,7 +28,7 @@ services:
     environment:
       - PMA_ARBITRARY=1
       - PMA_HOST=mysql
-      - PMA_PORT=3306
+      - PMA_PORT=${DB_MYSQL_PORT}
     depends_on:
       - mysql
 

--- a/.devcontainer/load-dotenv.sh
+++ b/.devcontainer/load-dotenv.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script will load all environment variables from the .env file and then run the command passed as an argument.
+# Example: .devcontainer/load-dotenv.sh docker-compose -f .devcontainer/docker-compose.dev.yml up
+
+# Load environment variables from ../.env
+export $(grep -v '^#' .env | xargs)
+
+# Run the command passed as an argument
+"$@"


### PR DESCRIPTION
This PR adds a development-only compose config, taken from https://github.com/VATSIM-UK/core/blob/main/.devcontainer/docker-compose.yml but excluding core itself.

Also a utility script in `.devcontainer/load-dotenv.sh` has been added which will load all env variables defined in .env and pass them onto the command executed.

For example:
```sh
.devcontainer/load-dotenv.sh docker-compose -f .devcontainer/docker-compose.dev.yml up
```