### PR TITLE
Add ability to toggle self-enrolment for a minimum number of networkdata atc hours at given qualification

### DIFF
--- a/app/Services/Training/WaitingListSelfEnrolment.php
+++ b/app/Services/Training/WaitingListSelfEnrolment.php
@@ -48,10 +48,9 @@ class WaitingListSelfEnrolment
                 $waitingList->self_enrolment_hours_at_qualification_id
             );
 
-            $atcSessionsAtQualificationsHours = Atc::where('account_id',$account->id)
+            $atcSessionsAtQualificationsHours = Atc::where('account_id', $account->id)
                 ->where('qualification_id', $requiredQualification->id)
                 ->sum('minutes_online') / 60;
-
 
             if ($atcSessionsAtQualificationsHours < $waitingList->self_enrolment_hours_at_qualification_minimum_hours) {
                 return false;

--- a/app/Services/Training/WaitingListSelfEnrolment.php
+++ b/app/Services/Training/WaitingListSelfEnrolment.php
@@ -5,6 +5,7 @@ namespace App\Services\Training;
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
 use App\Models\Mship\State;
+use App\Models\NetworkData\Atc;
 use App\Models\Training\WaitingList;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -38,6 +39,21 @@ class WaitingListSelfEnrolment
             );
 
             if (! $account->hasActiveQualification($requiredQualification)) {
+                return false;
+            }
+        }
+
+        if ($waitingList->self_enrolment_hours_at_qualification_id) {
+            $requiredQualification = Qualification::find(
+                $waitingList->self_enrolment_hours_at_qualification_id
+            );
+
+            $atcSessionsAtQualificationsHours = Atc::where('account_id',$account->id)
+                ->where('qualification_id', $requiredQualification->id)
+                ->sum('minutes_online') / 60;
+
+
+            if ($atcSessionsAtQualificationsHours < $waitingList->self_enrolment_hours_at_qualification_minimum_hours) {
                 return false;
             }
         }

--- a/database/migrations/2025_04_21_130040_add_self_enrolment_hour_requirements.php
+++ b/database/migrations/2025_04_21_130040_add_self_enrolment_hour_requirements.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('training_waiting_list', function (Blueprint $table) {
+            $table->unsignedInteger('self_enrolment_hours_at_qualification_id')->nullable();
+            $table->unsignedInteger('self_enrolment_hours_at_qualification_minimum_hours')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('training_waiting_list', function (Blueprint $table) {
+            $table->dropColumn('self_enrolment_hours_at_qualification_id');
+            $table->dropColumn('self_enrolment_hours_at_qualification_minimum_hours');
+        });
+    }
+};

--- a/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentServiceTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Training\WaitingList;
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
 use App\Models\Mship\State;
+use App\Models\NetworkData\Atc;
 use App\Models\Roster;
 use App\Models\Training\WaitingList;
 use App\Services\Training\WaitingListSelfEnrolment;
@@ -164,6 +165,83 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
             'self_enrolment_enabled' => true,
             'home_members_only' => false,
             'self_enrolment_maximum_qualification_id' => Qualification::code('OBS')->first()->id,
+        ]);
+
+        $this->assertFalse(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+    }
+
+    public function test_can_enrol_when_minimum_hours_met()
+    {
+        $account = Account::factory()->create();
+
+        $waitingList = factory(WaitingList::class)->create([
+            'self_enrolment_enabled' => true,
+            'self_enrolment_hours_at_qualification_id' => Qualification::code('S1')->first()->id,
+            'self_enrolment_hours_at_qualification_minimum_hours' => 10,
+        ]);
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'qualification_id' => Qualification::code('S1')->first()->id,
+            'minutes_online' => 10 * 60,
+        ]);
+
+        $this->assertTrue(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+    }
+
+    public function test_cannot_enrol_when_minimum_hours_not_met()
+    {
+        $account = Account::factory()->create();
+
+        $waitingList = factory(WaitingList::class)->create([
+            'self_enrolment_enabled' => true,
+            'self_enrolment_hours_at_qualification_id' => Qualification::code('S1')->first()->id,
+            'self_enrolment_hours_at_qualification_minimum_hours' => 10,
+        ]);
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'qualification_id' => Qualification::code('S1')->first()->id,
+            'minutes_online' => 5 * 60,
+        ]);
+
+        $this->assertFalse(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+    }
+
+    public function test_cannot_enrol_with_no_hours_at_qualification_but_hours_at_other_qualification()
+    {
+        $account = Account::factory()->create();
+
+        $waitingList = factory(WaitingList::class)->create([
+            'self_enrolment_enabled' => true,
+            'self_enrolment_hours_at_qualification_id' => Qualification::code('S1')->first()->id,
+            'self_enrolment_hours_at_qualification_minimum_hours' => 10,
+        ]);
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'qualification_id' => Qualification::code('OBS')->first()->id,
+            'minutes_online' => 5 * 60,
+        ]);
+
+        $this->assertFalse(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+    }
+
+    public function test_cannot_enrol_when_next_qualification_with_hours()
+    {
+        $account = Account::factory()->create();
+
+        $waitingList = factory(WaitingList::class)->create([
+            'self_enrolment_enabled' => true,
+            'self_enrolment_hours_at_qualification_id' => Qualification::code('S1')->first()->id,
+            'self_enrolment_hours_at_qualification_minimum_hours' => 10,
+            'self_enrolment_maximum_qualification_id' => Qualification::code('S1')->first()->id,
+        ]);
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'qualification_id' => Qualification::code('S2')->first()->id,
+            'minutes_online' => 5 * 60,
         ]);
 
         $this->assertFalse(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));


### PR DESCRIPTION
Flirted with the idea of having an index over `account_id,qualification_id` but I don't think the volume of data is sufficient.
Equally flirted with having the 'hours' column as a 'minutes' column to avoid some floating point stuff but didn't think it added much really.
If anyon has a better idea for those column names I'm all ears...
