### PR TITLE
Style: Replace references to Member Services with Community

### DIFF
--- a/app/Notifications/Roster/RemovedFromRoster.php
+++ b/app/Notifications/Roster/RemovedFromRoster.php
@@ -31,7 +31,7 @@ class RemovedFromRoster extends Notification implements ShouldQueue
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->from('support@vatsim.uk', 'VATSIM UK - Member Services')
+            ->from('support@vatsim.uk', 'VATSIM UK - Community')
             ->subject('Removed from VATSIM UK Controlling Roster')
             ->view('emails.roster.removal', ['recipient' => $notifiable]);
     }

--- a/app/Notifications/Training/RemovedFromWaitingListInactiveAccount.php
+++ b/app/Notifications/Training/RemovedFromWaitingListInactiveAccount.php
@@ -41,7 +41,7 @@ class RemovedFromWaitingListInactiveAccount extends Notification implements Disc
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->from('support@vatsim.uk', 'VATSIM UK - Member Services')
+            ->from('support@vatsim.uk', 'VATSIM UK - Community')
             ->subject('UK Training Waiting List Removal')
             ->view('emails.training.waiting_list_inactive_account', ['recipient' => $notifiable]);
     }

--- a/app/Notifications/Training/RemovedFromWaitingListNonHomeMember.php
+++ b/app/Notifications/Training/RemovedFromWaitingListNonHomeMember.php
@@ -41,7 +41,7 @@ class RemovedFromWaitingListNonHomeMember extends Notification implements Discor
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->from('support@vatsim.uk', 'VATSIM UK - Member Services')
+            ->from('support@vatsim.uk', 'VATSIM UK - Community')
             ->subject('UK Training Waiting List Removal')
             ->view('emails.training.waiting_list_non_home_removal', ['recipient' => $notifiable]);
     }

--- a/resources/views/emails/mship/s1_training_opportunities.blade.php
+++ b/resources/views/emails/mship/s1_training_opportunities.blade.php
@@ -5,7 +5,7 @@
 
     <p>Although your OBS-S1 training process is now complete, there is always more to learn! Our training programmes teach you the basics you need to pass the exams and provide a good service, but they can't tell you everything. A good controller is always looking to improve the service they provide! All of the materials you've used during the programme will remain available to you and are updated regularly, so please take the time to review them and keep your skills sharp.</p>
 
-    <p>If you're interested in obtaining a Gatwick Ground endorsement, you can get started by following the process outlined <a href="https://www.vatsim.uk/controllers/endorsements/gatwick">here</a>, and if you're interested in obtaining an AFIS/AGCS endorsement, you can get started by following the process outlined <a href="https://www.vatsim.uk/atc/endorsements#endorsement-afis">here</a>. If you're interested in training for your S2 rating, you can join the waiting list by submitting a <a href="https://helpdesk.vatsim.uk">ticket</a> to the Member Services team via our helpdesk.</p>
+    <p>If you're interested in obtaining a Gatwick Ground endorsement, you can get started by following the process outlined <a href="https://www.vatsim.uk/controllers/endorsements/gatwick">here</a>, and if you're interested in obtaining an AFIS/AGCS endorsement, you can get started by following the process outlined <a href="https://www.vatsim.uk/atc/endorsements#endorsement-afis">here</a>. If you're interested in training for your S2 rating, you can join the waiting list by submitting a <a href="https://helpdesk.vatsim.uk">ticket</a> to the Community team via our helpdesk.</p>
     
     <p>Enjoy your new rating!</p>
 @stop

--- a/resources/views/emails/training/waiting_list_inactive_account.blade.php
+++ b/resources/views/emails/training/waiting_list_inactive_account.blade.php
@@ -4,6 +4,6 @@
 
 <p>Your VATSIM account was marked as inactive. You were on a waiting list for training in VATSIM United Kingdom. You have now been removed from this waiting list(s).</p>
 
-<p>If you believe this to be in error, then please get in contact with the VATSIM UK Member Services team via the helpdesk.</p>
+<p>If you believe this to be in error, then please get in contact with the VATSIM UK Community team via the helpdesk.</p>
 
 @stop

--- a/resources/views/emails/training/waiting_list_non_home_removal.blade.php
+++ b/resources/views/emails/training/waiting_list_non_home_removal.blade.php
@@ -4,6 +4,6 @@
 
 <p>As you have changed your VATSIM Division away from the UK Division you are no longer eligible to receive training in the UK. You were on one of the waiting lists for training in the UK and, as you are no longer a member of the UK Division, you have been removed from this waiting list.</p>
 
-<p>If you believe this to be in error, then please get in contact with the Member Services team via the helpdesk.</p>
+<p>If you believe this to be in error, then please get in contact with the Community team via the helpdesk.</p>
 
 @stop

--- a/resources/views/errors/banned-local.blade.php
+++ b/resources/views/errors/banned-local.blade.php
@@ -8,5 +8,5 @@
     <p>{{ $ban->period_start->toDayDateTimeString() }} ({{ $ban->period_start->diffForHumans() }}).</p>
     <h3>Expiry</h2>
     <p>Your ban is due to expire on {{ $ban->period_finish->toDayDateTimeString() }} UTC ({{ $ban->period_finish->diffForHumans() }})</p>
-    <p>If you believe this to be an error, please contact the VATSIM UK Membership Services team at <a href="https://helpdesk.vatsim.uk">https://helpdesk.vatsim.uk</a> who will be able to assist further.</p>
+    <p>If you believe this to be an error, please contact the VATSIM UK Community team at <a href="https://helpdesk.vatsim.uk">https://helpdesk.vatsim.uk</a> who will be able to assist further.</p>
 @stop

--- a/resources/views/livewire/roster/index.blade.php
+++ b/resources/views/livewire/roster/index.blade.php
@@ -43,7 +43,7 @@
                     <span>
                         You are currently <span class="font-bold">inactive</span> on the VATSIM UK roster, and cannot control any UK positions.
                         <br>
-                        Please <a class="text-blue-500 hover:cursor-pointer" href="mailto:member-services@vatsim.uk">contact Member Services</a> if you believe this is incorrect.
+                        Please <a class="text-blue-500 hover:cursor-pointer" href="mailto:community@vatsim.uk">contact Community</a> if you believe this is incorrect.
                     </span>
                 @endif
             </div>

--- a/resources/views/site/atc/landing.blade.php
+++ b/resources/views/site/atc/landing.blade.php
@@ -27,7 +27,7 @@
                     <p>
                         The ATC Training department is structured into &quot;Training Groups&quot;, each of which deal
                         with specific types of training at various facilities. The administrative aspect of Training 
-                        Groups are handled by the team of ATC Training and Member Services staff; please always use the 
+                        Groups are handled by the team of ATC Training and Community staff; please always use the 
                         <a href="https://helpdesk.vatsim.uk/">Helpdesk</a> for queries related to ATC Training. Each 
                         Training Group has a number of Training Group Instructors (TGI), who are responsible for 
                         overseeing training in their respective groups - ensuring suitable progression and maintaining 

--- a/resources/views/visit-transfer/emails/applicant/status_changed.blade.php
+++ b/resources/views/visit-transfer/emails/applicant/status_changed.blade.php
@@ -23,7 +23,7 @@
 </p>
 @elseif($application->is_accepted)
 <p>
-    Your application has been accepted by the Member Services department. It is important to note that <strong>this does not</strong> mean you
+    Your application has been accepted by the Community department. It is important to note that <strong>this does not</strong> mean you
     have completed your application, it simply means the details of your application have been checked and deemed valid.
     You will be informed when your application is <strong>completed</strong>.
 </p>


### PR DESCRIPTION
Replaces any references to Member Services across core with the rebranded Community

It was pointed out to me that it was incorrect on the roster so I thought id update them all, something I didn't want to burden you guys with...