### PR TITLE
TECH-317: Scan the db for home members we have not fetched a cert for recently

### DIFF
--- a/app/Console/Commands/Members/ImportStaleMembers.php
+++ b/app/Console/Commands/Members/ImportStaleMembers.php
@@ -106,6 +106,7 @@ class ImportStaleMembers extends Command
             ->whereHas('states', function ($q) {
                 $q->where('code', 'DIVISION');
             })
+            ->whereHas('waitingListAccounts')
             ->limit(1000)
             ->select('id')
             ->get()

--- a/app/Console/Commands/Members/ImportStaleMembers.php
+++ b/app/Console/Commands/Members/ImportStaleMembers.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Console\Commands\Members;
+
+use App\Models\Mship\Account;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+class ImportStaleMembers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:stale-members';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Scans for members without a recent vatsim api check and pulls their details. For tracking division leavers.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // find members with a cert_checked_at not not within the past week
+        // run an api request for each
+        // stick through normal update procedure, this will remove from lists etc if necessary
+        $accountIds = $this->getAccountIds();
+
+        $accountCount = $accountIds->count();
+        $updatedCount = 0;
+        $skippedCount = 0;
+
+        $this->info("Found {$accountCount} stale accounts to update.");
+
+        foreach ($accountIds as $accountId) {
+            $vAccount = $this->fetchAccount($accountId);
+            if (empty($vAccount) || ! $this->validate($vAccount)) {
+                $this->info("Could not retrieve {$accountId} from .net");
+                $skippedCount++;
+
+                continue;
+            }
+
+            $this->update($accountId, $vAccount);
+            $updatedCount++;
+        }
+
+        $this->info("Updated {$updatedCount} accounts, skipped {$skippedCount}.");
+    }
+
+    private function fetchAccount(int $cid): ?array
+    {
+        $token = config('services.vatsim-net.api.key');
+
+        $response = Http::withHeaders([
+            'Authorization' => "Token {$token}",
+        ])
+            ->withUserAgent('VATSIMUK')
+            ->get(config('services.vatsim-net.api.base')."members/{$cid}");
+
+        if ($response->notFound()) {
+            return null;
+        }
+
+        if (! $response->ok()) {
+            throw new \RuntimeException('could not call vatsim net api');
+        }
+
+        return $response->json();
+    }
+
+    private function validate(array $vAccount): bool
+    {
+        $validator = \Validator::make($vAccount, [
+            'region_id' => 'required|string',
+            'division_id' => 'required|string',
+        ]);
+
+        return $validator->passes();
+    }
+
+    private function update(int $cid, array $vMember): void
+    {
+        $account = Account::findOrFail($cid);
+        $account->cert_checked_at = now();
+
+        // There's some gnarly-ness here, if we don't have before updating divison
+        // the update division log will bounce the cert_checked_at time back to its non-dirty state
+        // side effects!
+        $account->save();
+        $account->refresh();
+
+        $account->updateDivision($vMember['division_id'], $vMember['region_id']);
+    }
+
+    public static function getAccountIds(): Collection
+    {
+        return Account::where('cert_checked_at', '<', now()->addDays(-2))
+            ->whereHas('states', function ($q) {
+                $q->where('code', 'DIVISION');
+            })
+            ->limit(1000)
+            ->select('id')
+            ->get()
+            ->pluck('id');
+    }
+}

--- a/app/Console/Commands/Members/ImportStaleMembers.php
+++ b/app/Console/Commands/Members/ImportStaleMembers.php
@@ -2,14 +2,10 @@
 
 namespace App\Console\Commands\Members;
 
+use App\Jobs\Mship\ScanStaleMembers;
 use App\Models\Mship\Account;
-use App\Models\Training\WaitingList\Removal;
-use App\Models\Training\WaitingList\RemovalReason;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\RateLimiter;
-use Illuminate\Support\Sleep;
 
 class ImportStaleMembers extends Command
 {
@@ -36,89 +32,8 @@ class ImportStaleMembers extends Command
     {
         $accountIds = $this->findHomeAccountsWithStaleChecks();
 
-        $updatedCount = $skippedCount = 0;
-
-        $this->info("Found {$accountIds->count()} stale accounts to update.");
-
-        foreach ($accountIds as $accountId) {
-            $vAccount = $this->fetchDetailsRateLimit($accountId);
-
-            if ($vAccount === null || ! $this->validateAccountApiResponse($vAccount)) {
-                $this->info("Could not retrieve {$accountId} from .net, they will be removed from waiting lists");
-                $this->removeFromAllLists($accountId);
-                $skippedCount++;
-
-                continue;
-            }
-
-            $this->update($accountId, $vAccount);
-            $updatedCount++;
-        }
-
-        $this->info("Updated {$updatedCount} accounts, skipped {$skippedCount}.");
-    }
-
-    private function fetchDetailsRateLimit(int $cid, bool $alreadySlept = false): ?array
-    {
-        if (RateLimiter::tooManyAttempts(self::RATE_LIMIT_KEY, $perMinute = 5)) {
-            if ($alreadySlept) {
-                throw new \RuntimeException('could not recover from rate limiting');
-            }
-
-            $this->sleep();
-
-            return $this->fetchDetailsRateLimit($cid, true);
-        }
-
-        $member = $this->fetchDetails($cid);
-
-        RateLimiter::increment(self::RATE_LIMIT_KEY);
-
-        return $member;
-    }
-
-    private function fetchDetails(int $cid, bool $alreadySlept = false): ?array
-    {
-        $token = config('services.vatsim-net.api.key');
-
-        $response = Http::withHeaders([
-            'Authorization' => "Token {$token}",
-        ])
-            ->withUserAgent('VATSIMUK')
-            ->get(config('services.vatsim-net.api.base')."members/{$cid}");
-
-        if ($response->notFound()) {
-            return null;
-        }
-
-        // .net applies somewhat variable rate limits, so we can't rely on throttling ourselves
-        if ($response->tooManyRequests() && $alreadySlept) {
-            throw new \RuntimeException('could not recover from rate limiting');
-        }
-
-        if ($response->tooManyRequests()) {
-            $this->sleep();
-
-            return $this->fetchDetails($cid, true);
-        }
-
-        if (! $response->ok()) {
-            throw new \RuntimeException('could not call vatsim net api');
-        }
-
-        return $response->json();
-    }
-
-    private function update(int $cid, array $vMember): void
-    {
-        $account = Account::findOrFail($cid);
-        $account->cert_checked_at = now();
-
-        // Update division logic refreshes the account, so any unsaved changes before calling it will be lost!
-        $account->save();
-
-        // This will trigget e.g waiting list removals for leavers
-        $account->updateDivision($vMember['division_id'], $vMember['region_id']);
+        $this->info("Found {$accountIds->count()} accounts to check, pushing to queue");
+        ScanStaleMembers::dispatch($accountIds);
     }
 
     /**
@@ -136,32 +51,9 @@ class ImportStaleMembers extends Command
                 $q->where('code', 'DIVISION');
             })
             ->whereHas('waitingListAccounts')
-            ->limit(50) // limit to 50 accounts to allow 10 mins run time at 5 req/min
+            ->limit(100) // limit to 100 accounts to avoid massive queue jobs, we'll get the rest later / tomorrow
             ->select('id')
             ->get()
             ->pluck('id');
-    }
-
-    private function removeFromAllLists(int $accountId): void
-    {
-        $account = Account::findOrFail($accountId);
-        foreach ($account->currentWaitingLists() as $list) {
-            $list->removeFromWaitingList($account, new Removal(RemovalReason::Other, null, '[system] could not find in core api'));
-        }
-    }
-
-    private function validateAccountApiResponse(array $vAccount): bool
-    {
-        $validator = \Validator::make($vAccount, [
-            'region_id' => 'required|string',
-            'division_id' => 'required|string',
-        ]);
-
-        return $validator->passes();
-    }
-
-    public function sleep(): void
-    {
-        Sleep::for(60)->seconds();
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -73,6 +73,10 @@ class Kernel extends ConsoleKernel
             ->twiceDaily(2, 14)
             ->graceTimeInMinutes(15);
 
+        $schedule->command('import:stale-members')
+            ->daily()
+            ->graceTimeInMinutes(15);
+
         // === By Quarter === //
         $schedule->command('roster:update', [
             Carbon::now()->subMonths(3),

--- a/app/Jobs/Mship/NetRateLimitingException.php
+++ b/app/Jobs/Mship/NetRateLimitingException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Jobs\Mship;
+
+class NetRateLimitingException extends \RuntimeException {}

--- a/app/Jobs/Mship/ScanStaleMembers.php
+++ b/app/Jobs/Mship/ScanStaleMembers.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Jobs\Mship;
+
+use App\Models\Mship\Account;
+use App\Models\Training\WaitingList\Removal;
+use App\Models\Training\WaitingList\RemovalReason;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\RateLimiter;
+
+class ScanStaleMembers implements ShouldQueue
+{
+    use Queueable;
+
+    const string RATE_LIMIT_KEY = 'vatsim-api:member-details';
+
+    const int BATCH_SIZE = 5;
+
+    const int API_LIMIT_PER_MINUTE = 5;
+
+    /** @var Collection<int> */
+    public Collection $accountIds;
+
+    /**
+     * @param  Collection<int>  $accountIds
+     */
+    public function __construct(Collection $accountIds)
+    {
+        $this->accountIds = clone $accountIds;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        \Log::info('Scanning stale members', ['total_remaining' => count($this->accountIds), 'batch_size' => self::BATCH_SIZE]);
+
+        if (count($this->accountIds) === 0) {
+            $this->delete();
+
+            return;
+        }
+
+        foreach (range(0, self::BATCH_SIZE) as $i) {
+            /** @var int $accountId */
+            $accountId = $this->accountIds->pop();
+            if (is_null($accountId)) {
+                break;
+            }
+
+            try {
+                $this->scanAccount($accountId);
+            } catch (NetRateLimitingException $e) {
+                $this->rePushIncluding($accountId);
+                $this->delete();
+
+                return;
+            }
+        }
+
+        // If we've reached the end of the batch, we repush after some waiting time
+        $this->rePushIncluding(null);
+        $this->delete();
+    }
+
+    /**
+     * Repush this job with remaining accounts, including one currently being worked if we've hit a rate limit somewhere
+     */
+    private function rePushIncluding(?int $accountId): void
+    {
+        if ($accountId) {
+            $this->accountIds->push($accountId);
+        }
+
+        ScanStaleMembers::dispatch($this->accountIds)
+            ->delay(now()->addMinutes(1));
+    }
+
+    private function scanAccount(int $accountId): void
+    {
+        $vAccount = $this->fetchDetailsRateLimit($accountId);
+
+        if ($vAccount === null || ! $this->validateAccountApiResponse($vAccount)) {
+            \Log::info("Could not retrieve {$accountId} from .net, they will be removed from waiting lists");
+            $this->removeFromAllLists($accountId);
+
+            return;
+        }
+
+        \Log::info("Updating {$accountId}");
+        $this->update($accountId, $vAccount);
+    }
+
+    private function fetchDetailsRateLimit(int $cid): ?array
+    {
+        if (RateLimiter::tooManyAttempts(key: self::RATE_LIMIT_KEY, maxAttempts: self::API_LIMIT_PER_MINUTE)) {
+            throw new NetRateLimitingException("hit rate limit, repushing {$cid}");
+        }
+
+        $member = $this->fetchDetails($cid);
+
+        RateLimiter::increment(self::RATE_LIMIT_KEY);
+
+        return $member;
+    }
+
+    private function fetchDetails(int $cid): ?array
+    {
+        $token = config('services.vatsim-net.api.key');
+
+        $response = Http::withHeaders([
+            'Authorization' => "Token {$token}",
+        ])
+            ->withUserAgent('VATSIMUK')
+            ->get(config('services.vatsim-net.api.base')."members/{$cid}");
+
+        if ($response->notFound()) {
+            return null;
+        }
+
+        // .net applies somewhat variable rate limits, so we can't rely on throttling ourselves
+        if ($response->tooManyRequests()) {
+            throw new NetRateLimitingException("hit rate limit, repushing {$cid}");
+        }
+
+        if (! $response->ok()) {
+            throw new \RuntimeException('could not call vatsim net api');
+        }
+
+        return $response->json();
+    }
+
+    private function update(int $cid, array $vMember): void
+    {
+        $account = Account::findOrFail($cid);
+        $account->cert_checked_at = now();
+
+        // Update division logic refreshes the account, so any unsaved changes before calling it will be lost!
+        $account->save();
+
+        // This will trigger e.g waiting list removals for leavers
+        $account->updateDivision($vMember['division_id'], $vMember['region_id']);
+    }
+
+    private function removeFromAllLists(int $accountId): void
+    {
+        $account = Account::findOrFail($accountId);
+        foreach ($account->currentWaitingLists() as $list) {
+            $list->removeFromWaitingList($account, new Removal(RemovalReason::Other, null, '[system] could not find in core api'));
+        }
+    }
+
+    private function validateAccountApiResponse(array $vAccount): bool
+    {
+        $validator = \Validator::make($vAccount, [
+            'region_id' => 'required|string',
+            'division_id' => 'required|string',
+        ]);
+
+        return $validator->passes();
+    }
+}

--- a/tests/Feature/Account/StaleMemberTest.php
+++ b/tests/Feature/Account/StaleMemberTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature\Account;
+
+use App\Console\Commands\Members\ImportStaleMembers;
+use App\Models\Mship\Account;
+use App\Models\Mship\State;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class StaleMemberTest extends TestCase
+{
+    public function test_ok()
+    {
+        $this->artisan('import:stale-members')->assertOk();
+    }
+
+    public function test_finds_stale_members()
+    {
+        $account = Account::factory()->create([
+            'cert_checked_at' => '2000-01-01 00:00:00',
+        ]);
+        $account->addState(State::findByCode('DIVISION'));
+
+        Http::fake([
+            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
+                'region_id' => 'EUR', // @fixme our tests / seeding data seem to rely on this being EUR, it is actually EMA
+                'division_id' => 'GBR',
+            ], 200),
+        ]);
+
+        $testNow = now();
+        Carbon::setTestNow($testNow);
+        $this->artisan('import:stale-members');
+
+        $account->refresh();
+        $this->assertEquals($testNow, $account->cert_checked_at);
+        $this->assertTrue($account->hasState(State::findByCode('DIVISION')));
+    }
+
+    public function test_removes_from_division()
+    {
+        $account = Account::factory()->create([
+            'cert_checked_at' => '2000-01-01 00:00:00',
+        ]);
+        $account->addState(State::findByCode('DIVISION'));
+        $account->save();
+        $account->refresh();
+
+        // Currently a member
+        $this->assertTrue($account->hasState(State::findByCode('DIVISION')));
+
+        // API will report they've moved to germany
+        Http::fake([
+            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
+                'region_id' => 'EMEA',
+                'division_id' => 'EUD',
+            ], 200),
+        ]);
+
+        $testNow = now();
+        Carbon::setTestNow($testNow);
+        $this->artisan('import:stale-members');
+
+        $account->refresh();
+        $this->assertFalse($account->hasState(State::findByCode('DIVISION')));
+        $this->assertEquals($testNow, $account->cert_checked_at);
+    }
+
+    public function test_handles_missing_members()
+    {
+        $account = Account::factory()->create([
+            'cert_checked_at' => '2000-01-01 00:00:00',
+        ]);
+
+        Http::fake([
+            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
+                'detail' => 'not found',
+            ], 404),
+        ]);
+
+        $this->artisan('import:stale-members')->assertOk();
+    }
+
+    public function test_ignores_international_members()
+    {
+        $account = Account::factory()->create([
+            'cert_checked_at' => '2000-01-01 00:00:00',
+        ]);
+        $account->addState(State::findByCode('DIVISION'));
+
+        $internationalAccount = Account::factory()->create([
+            'cert_checked_at' => '2000-01-01 00:00:00',
+        ]);
+        $internationalAccount->addState(State::findByCode('INTERNATIONAL'));
+
+        $ids = ImportStaleMembers::getAccountIds();
+
+        $this->assertCount(1, $ids);
+        $this->assertContains($account->id, $ids);
+        $this->assertNotContains($internationalAccount->id, $ids);
+    }
+}

--- a/tests/Feature/Account/StaleMemberTest.php
+++ b/tests/Feature/Account/StaleMemberTest.php
@@ -3,12 +3,9 @@
 namespace Tests\Feature\Account;
 
 use App\Console\Commands\Members\ImportStaleMembers;
+use App\Jobs\Mship\ScanStaleMembers;
 use App\Models\Mship\Account;
 use App\Models\Mship\State;
-use Carbon\Carbon;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\RateLimiter;
-use Illuminate\Support\Sleep;
 use Tests\TestCase;
 use Tests\Unit\Training\WaitingList\WaitingListTestHelper;
 
@@ -18,11 +15,14 @@ class StaleMemberTest extends TestCase
 
     public function test_ok()
     {
+        \Queue::fake();
         $this->artisan('import:stale-members')->assertOk();
     }
 
-    public function test_finds_stale_members_and_updates_cert()
+    public function test_finds_stale_members_and_dispatches_job()
     {
+        \Queue::fake();
+
         $account = Account::factory()->create([
             'cert_checked_at' => '2000-01-01 00:00:00',
         ]);
@@ -31,126 +31,21 @@ class StaleMemberTest extends TestCase
         $waitingList->addToWaitingList($account, $this->privacc);
         $this->assertTrue($waitingList->includesAccount($account));
 
-        Http::fake([
-            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
-                'region_id' => 'EUR', // @fixme our tests / seeding data seem to rely on this being EUR, it is actually EMA
-                'division_id' => 'GBR',
-            ], 200),
-        ]);
-
-        $testNow = now();
-        Carbon::setTestNow($testNow);
-        $this->artisan('import:stale-members');
-
-        $account->refresh();
-        $this->assertEquals($testNow, $account->cert_checked_at);
-        $this->assertTrue($account->hasState(State::findByCode('DIVISION')));
-        $this->assertTrue($waitingList->includesAccount($account));
-    }
-
-    public function test_removes_from_division_and_list()
-    {
-        $account = Account::factory()->create([
-            'cert_checked_at' => '2000-01-01 00:00:00',
-        ]);
-        $account->addState(State::findByCode('DIVISION'), 'EUR', 'GBR');
-        $waitingList = $this->createList();
-        $waitingList->addToWaitingList($account, $this->privacc);
-        $this->assertTrue($waitingList->includesAccount($account));
-
-        // Currently a member
-        $this->assertTrue($account->hasState(State::findByCode('DIVISION')));
-
-        // API will report they've moved to germany
-        Http::fake([
-            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
-                'region_id' => 'EMEA',
-                'division_id' => 'EUD',
-            ], 200),
-        ]);
-
-        $testNow = now();
-        Carbon::setTestNow($testNow);
-        $this->artisan('import:stale-members');
-
-        $account->refresh();
-        $this->assertFalse($account->hasState(State::findByCode('DIVISION')));
-        $this->assertEquals($testNow, $account->cert_checked_at);
-        $this->assertFalse($waitingList->includesAccount($account));
-    }
-
-    public function test_handles_missing_members()
-    {
-        $account = Account::factory()->create([
-            'cert_checked_at' => '2000-01-01 00:00:00',
-        ]);
-        $account->addState(State::findByCode('DIVISION'), 'EUR', 'GBR');
-        $waitingList = $this->createList();
-        $waitingList->addToWaitingList($account, $this->privacc);
-
-        Http::fake([
-            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
-                'detail' => 'not found',
-            ], 404),
-        ]);
-
         $this->artisan('import:stale-members')->assertOk();
-        $this->assertFalse($waitingList->includesAccount($account));
-    }
-
-    public function test_handles_rate_limit_problems()
-    {
-        $account = Account::factory()->create([
-            'cert_checked_at' => '2000-01-01 00:00:00',
-        ]);
-        $account->addState(State::findByCode('DIVISION'), 'EUR', 'GBR');
-        $waitingList = $this->createList();
-        $waitingList->addToWaitingList($account, $this->privacc);
-
-        Http::fake([
-            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::sequence()
-                ->pushStatus(429)
-                ->push([
-                    'region_id' => 'EMEA',
-                    'division_id' => 'EUD',
-                ], 200),
-        ]);
-
-        Sleep::fake();
-        $this->artisan('import:stale-members')->assertOk();
-        Sleep::assertSequence([
-            Sleep::for(60)->seconds(),
-        ]);
-    }
-
-    public function test_rate_limits()
-    {
-        $waitingList = $this->createList();
-        $accounts = Account::factory()->count(10)->create([
-            'cert_checked_at' => '2000-01-01 00:00:00',
-        ]);
-        foreach ($accounts as $account) {
-            $account->addState(State::findByCode('DIVISION'), 'EUR', 'GBR');
-            $waitingList->addToWaitingList($account, $this->privacc);
-        }
-
-        $this->assertCount(10, ImportStaleMembers::findHomeAccountsWithStaleChecks());
-
-        Http::fake([
-            config('services.vatsim-net.api.base').'members/*' => Http::response([
-                'region_id' => 'EUR', // @fixme our tests / seeding data seem to rely on this being EUR, it is actually EMA
-                'division_id' => 'GBR',
-            ], 200),
-        ]);
-
-        Sleep::fake();
-        Sleep::whenFakingSleep(function () {
-            RateLimiter::clear(ImportStaleMembers::RATE_LIMIT_KEY);
+        \Queue::assertPushed(function (ScanStaleMembers $job) use ($account) {
+            return $job->accountIds->contains($account->id) && $job->accountIds->count() === 1;
         });
-        $this->artisan('import:stale-members')->assertOk();
-        Sleep::assertSequence([
-            Sleep::for(60)->seconds(),
+    }
+
+    public function test_ignores_accounts_no_on_list()
+    {
+        $account = Account::factory()->create([
+            'cert_checked_at' => '2000-01-01 00:00:00',
         ]);
+        $account->addState(State::findByCode('DIVISION'), 'GBR', 'EUR');
+
+        $ids = ImportStaleMembers::findHomeAccountsWithStaleChecks();
+        $this->assertCount(0, $ids);
     }
 
     public function test_ignores_international_members()
@@ -174,16 +69,5 @@ class StaleMemberTest extends TestCase
         $this->assertCount(1, $ids);
         $this->assertContains($account->id, $ids);
         $this->assertNotContains($internationalAccount->id, $ids);
-    }
-
-    public function test_ignores_accounts_no_on_list()
-    {
-        $account = Account::factory()->create([
-            'cert_checked_at' => '2000-01-01 00:00:00',
-        ]);
-        $account->addState(State::findByCode('DIVISION'), 'GBR', 'EUR');
-
-        $ids = ImportStaleMembers::findHomeAccountsWithStaleChecks();
-        $this->assertCount(0, $ids);
     }
 }

--- a/tests/Feature/Account/StaleMemberTest.php
+++ b/tests/Feature/Account/StaleMemberTest.php
@@ -134,7 +134,7 @@ class StaleMemberTest extends TestCase
             $waitingList->addToWaitingList($account, $this->privacc);
         }
 
-        $this->assertCount(10, ImportStaleMembers::getAccountIds());
+        $this->assertCount(10, ImportStaleMembers::findHomeAccountsWithStaleChecks());
 
         Http::fake([
             config('services.vatsim-net.api.base').'members/*' => Http::response([
@@ -169,7 +169,7 @@ class StaleMemberTest extends TestCase
         $waitingList->addToWaitingList($account, $this->privacc);
         $waitingList->addToWaitingList($internationalAccount, $this->privacc);
 
-        $ids = ImportStaleMembers::getAccountIds();
+        $ids = ImportStaleMembers::findHomeAccountsWithStaleChecks();
 
         $this->assertCount(1, $ids);
         $this->assertContains($account->id, $ids);
@@ -183,7 +183,7 @@ class StaleMemberTest extends TestCase
         ]);
         $account->addState(State::findByCode('DIVISION'), 'GBR', 'EUR');
 
-        $ids = ImportStaleMembers::getAccountIds();
+        $ids = ImportStaleMembers::findHomeAccountsWithStaleChecks();
         $this->assertCount(0, $ids);
     }
 }

--- a/tests/Feature/Account/StaleMemberTest.php
+++ b/tests/Feature/Account/StaleMemberTest.php
@@ -79,10 +79,10 @@ class StaleMemberTest extends TestCase
 
     public function test_handles_missing_members()
     {
-        // @fixme how to exclude from future updates? consult with Axon
         $account = Account::factory()->create([
             'cert_checked_at' => '2000-01-01 00:00:00',
         ]);
+        $account->addState(State::findByCode('DIVISION'), 'EUR', 'GBR');
         $waitingList = $this->createList();
         $waitingList->addToWaitingList($account, $this->privacc);
 
@@ -93,6 +93,7 @@ class StaleMemberTest extends TestCase
         ]);
 
         $this->artisan('import:stale-members')->assertOk();
+        $this->assertFalse($waitingList->includesAccount($account));
     }
 
     public function test_ignores_international_members()

--- a/tests/Feature/Account/StaleMemberTest.php
+++ b/tests/Feature/Account/StaleMemberTest.php
@@ -8,20 +8,26 @@ use App\Models\Mship\State;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
+use Tests\Unit\Training\WaitingList\WaitingListTestHelper;
 
 class StaleMemberTest extends TestCase
 {
+    use WaitingListTestHelper;
+
     public function test_ok()
     {
         $this->artisan('import:stale-members')->assertOk();
     }
 
-    public function test_finds_stale_members()
+    public function test_finds_stale_members_and_updates_cert()
     {
         $account = Account::factory()->create([
             'cert_checked_at' => '2000-01-01 00:00:00',
         ]);
-        $account->addState(State::findByCode('DIVISION'));
+        $account->addState(State::findByCode('DIVISION'), 'EUR', 'GBR');
+        $waitingList = $this->createList();
+        $waitingList->addToWaitingList($account, $this->privacc);
+        $this->assertTrue($waitingList->includesAccount($account));
 
         Http::fake([
             config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
@@ -37,16 +43,18 @@ class StaleMemberTest extends TestCase
         $account->refresh();
         $this->assertEquals($testNow, $account->cert_checked_at);
         $this->assertTrue($account->hasState(State::findByCode('DIVISION')));
+        $this->assertTrue($waitingList->includesAccount($account));
     }
 
-    public function test_removes_from_division()
+    public function test_removes_from_division_and_list()
     {
         $account = Account::factory()->create([
             'cert_checked_at' => '2000-01-01 00:00:00',
         ]);
-        $account->addState(State::findByCode('DIVISION'));
-        $account->save();
-        $account->refresh();
+        $account->addState(State::findByCode('DIVISION'), 'EUR', 'GBR');
+        $waitingList = $this->createList();
+        $waitingList->addToWaitingList($account, $this->privacc);
+        $this->assertTrue($waitingList->includesAccount($account));
 
         // Currently a member
         $this->assertTrue($account->hasState(State::findByCode('DIVISION')));
@@ -66,13 +74,17 @@ class StaleMemberTest extends TestCase
         $account->refresh();
         $this->assertFalse($account->hasState(State::findByCode('DIVISION')));
         $this->assertEquals($testNow, $account->cert_checked_at);
+        $this->assertFalse($waitingList->includesAccount($account));
     }
 
     public function test_handles_missing_members()
     {
+        // @fixme how to exclude from future updates? consult with Axon
         $account = Account::factory()->create([
             'cert_checked_at' => '2000-01-01 00:00:00',
         ]);
+        $waitingList = $this->createList();
+        $waitingList->addToWaitingList($account, $this->privacc);
 
         Http::fake([
             config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
@@ -88,17 +100,32 @@ class StaleMemberTest extends TestCase
         $account = Account::factory()->create([
             'cert_checked_at' => '2000-01-01 00:00:00',
         ]);
-        $account->addState(State::findByCode('DIVISION'));
+        $account->addState(State::findByCode('DIVISION'), 'GBR', 'EUR');
 
         $internationalAccount = Account::factory()->create([
             'cert_checked_at' => '2000-01-01 00:00:00',
         ]);
         $internationalAccount->addState(State::findByCode('INTERNATIONAL'));
 
+        $waitingList = $this->createList();
+        $waitingList->addToWaitingList($account, $this->privacc);
+        $waitingList->addToWaitingList($internationalAccount, $this->privacc);
+
         $ids = ImportStaleMembers::getAccountIds();
 
         $this->assertCount(1, $ids);
         $this->assertContains($account->id, $ids);
         $this->assertNotContains($internationalAccount->id, $ids);
+    }
+
+    public function test_ignores_accounts_no_on_list()
+    {
+        $account = Account::factory()->create([
+            'cert_checked_at' => '2000-01-01 00:00:00',
+        ]);
+        $account->addState(State::findByCode('DIVISION'), 'GBR', 'EUR');
+
+        $ids = ImportStaleMembers::getAccountIds();
+        $this->assertCount(0, $ids);
     }
 }

--- a/tests/Feature/Jobs/Mship/ScanStaleMembersTest.php
+++ b/tests/Feature/Jobs/Mship/ScanStaleMembersTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Feature\Jobs\Mship;
+
+use App\Jobs\Mship\ScanStaleMembers;
+use App\Models\Mship\Account;
+use App\Models\Mship\State;
+use App\Models\Training\WaitingList;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+use Tests\Unit\Training\WaitingList\WaitingListTestHelper;
+
+class ScanStaleMembersTest extends TestCase
+{
+    use WaitingListTestHelper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        RateLimiter::resetAttempts(ScanStaleMembers::RATE_LIMIT_KEY);
+    }
+
+    public function test_empty_set()
+    {
+        \Queue::fake();
+
+        $job = (new ScanStaleMembers(new Collection))->withFakeQueueInteractions();
+        $job->handle();
+        $job->assertDeleted();
+
+        \Queue::assertNothingPushed();
+    }
+
+    public function test_updates_cert_time()
+    {
+        \Queue::fake();
+
+        [$account, $waitingList] = $this->createAccountOnWaitingList();
+
+        Http::fake([
+            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
+                'region_id' => 'EUR', // @fixme our tests / seeding data seem to rely on this being EUR, it is actually EMA
+                'division_id' => 'GBR',
+            ], 200),
+        ]);
+        $testNow = now();
+        Carbon::setTestNow($testNow);
+
+        $job = (new ScanStaleMembers(new Collection([$account->id])))->withFakeQueueInteractions();
+        $job->handle();
+        $job->assertDeleted();
+
+        $account->refresh();
+        $this->assertEquals($testNow, $account->cert_checked_at);
+        $this->assertTrue($account->hasState(State::findByCode('DIVISION')));
+        $this->assertTrue($waitingList->includesAccount($account));
+    }
+
+    public function test_removes_leavers()
+    {
+        \Queue::fake();
+
+        [$account, $waitingList] = $this->createAccountOnWaitingList();
+
+        // Currently a member
+        $this->assertTrue($account->hasState(State::findByCode('DIVISION')));
+
+        // API will report they've moved to germany
+        Http::fake([
+            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
+                'region_id' => 'EMEA',
+                'division_id' => 'EUD',
+            ], 200),
+        ]);
+
+        $testNow = now();
+        Carbon::setTestNow($testNow);
+
+        $job = (new ScanStaleMembers(new Collection([$account->id])))->withFakeQueueInteractions();
+        $job->handle();
+        $job->assertDeleted();
+
+        $account->refresh();
+        $this->assertFalse($account->hasState(State::findByCode('DIVISION')));
+        $this->assertEquals($testNow, $account->cert_checked_at);
+        $this->assertFalse($waitingList->includesAccount($account));
+    }
+
+    public function test_handles_members_missing_from_api()
+    {
+        \Queue::fake();
+
+        [$account, $waitingList] = $this->createAccountOnWaitingList();
+
+        Http::fake([
+            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
+                'detail' => 'not found',
+            ], 404),
+        ]);
+
+        $job = (new ScanStaleMembers(new Collection([$account->id])))->withFakeQueueInteractions();
+        $job->handle();
+        $job->assertDeleted();
+
+        $this->assertFalse($waitingList->includesAccount($account));
+    }
+
+    /**
+     * Need to make sure that when we push more than the batch size we end up with more jobs
+     */
+    public function test_dispatches_rest_later()
+    {
+        $this->assertSame(5, ScanStaleMembers::BATCH_SIZE, 'this test needs updating if the batch size changes');
+
+        \Queue::fake();
+
+        $accountIds = new Collection;
+
+        for ($i = 0; $i < 10; $i++) {
+            [$account, $_] = $this->createAccountOnWaitingList();
+            $accountIds->push($account->id);
+        }
+
+        $this->assertCount(10, $accountIds);
+
+        // all still members
+        Http::fake([
+            config('services.vatsim-net.api.base').'members/*' => Http::response([
+                'region_id' => 'EUR', // @fixme our tests / seeding data seem to rely on this being EUR, it is actually EMA
+                'division_id' => 'GBR',
+            ], 200),
+        ]);
+
+        $testNow = now();
+        Carbon::setTestNow($testNow);
+
+        $job = (new ScanStaleMembers(clone $accountIds))->withFakeQueueInteractions();
+        $job->handle();
+        $job->assertDeleted();
+
+        // check we've seen 5 people updated (the batch size)
+        $updateCount = 0;
+        $nonUpdatedAccounts = new Collection;
+        foreach ($accountIds as $accountId) {
+            $account = Account::findOrFail($accountId);
+            $account->refresh();
+            if ($account->cert_checked_at == $testNow) {
+                $updateCount++;
+            } else {
+                $nonUpdatedAccounts->push($accountId);
+            }
+        }
+
+        $this->assertEquals(5, $updateCount, 'expected batch size (5) accounts to be updated');
+        $this->assertCount(5, $nonUpdatedAccounts, 'expected 5 accounts to not be updated');
+
+        // check the remaining users have gone into a new job
+        \Queue::assertPushed(function (ScanStaleMembers $job) use ($nonUpdatedAccounts) {
+            return
+                $job->accountIds->toArray() == $nonUpdatedAccounts->toArray() &&
+                $job->delay->getTimestamp() > 0;
+        });
+    }
+
+    public function test_redispatches_on_rate_limiting()
+    {
+        \Queue::fake();
+
+        [$account, $_] = $this->createAccountOnWaitingList();
+
+        // Currently a member
+        $this->assertTrue($account->hasState(State::findByCode('DIVISION')));
+
+        // API will report they've moved to germany
+        Http::fake([
+            config('services.vatsim-net.api.base')."members/{$account->id}" => Http::response([
+                'region_id' => 'EMEA',
+                'division_id' => 'EUD',
+            ], 429),
+        ]);
+
+        $testNow = now();
+        Carbon::setTestNow($testNow);
+
+        $job = (new ScanStaleMembers(new Collection([$account->id])))->withFakeQueueInteractions();
+        $job->handle();
+        $job->assertDeleted();
+
+        // check the users has gone into a new job
+        \Queue::assertPushed(function (ScanStaleMembers $job) use ($account) {
+            return
+                $job->accountIds->toArray() == [$account->id] &&
+                $job->delay->getTimestamp() > 0;
+        });
+    }
+
+    public function test_redispatches_on_internal_rate_limiting()
+    {
+        \Queue::fake();
+
+        [$account, $_] = $this->createAccountOnWaitingList();
+
+        // max out our requests
+        RateLimiter::increment(ScanStaleMembers::RATE_LIMIT_KEY, amount: ScanStaleMembers::API_LIMIT_PER_MINUTE);
+
+        $job = (new ScanStaleMembers(new Collection([$account->id])))->withFakeQueueInteractions();
+        $job->handle();
+        $job->assertDeleted();
+
+        // check the user has gone into a new job
+        \Queue::assertPushed(function (ScanStaleMembers $job) use ($account) {
+            return
+                $job->accountIds->toArray() == [$account->id] &&
+                $job->delay->getTimestamp() > 0;
+        });
+    }
+
+    /**
+     * @return list{Account, WaitingList}
+     */
+    private function createAccountOnWaitingList(): array
+    {
+        $account = Account::factory()->create([
+            'cert_checked_at' => '2000-01-01 00:00:00',
+        ]);
+        $account->addState(State::findByCode('DIVISION'), 'EUR', 'GBR');
+        $waitingList = $this->createList();
+        $waitingList->addToWaitingList($account, $this->privacc);
+        $this->assertTrue($waitingList->includesAccount($account));
+
+        return [$account, $waitingList];
+    }
+}

--- a/tests/Unit/Training/WaitingList/WaitingListTestHelper.php
+++ b/tests/Unit/Training/WaitingList/WaitingListTestHelper.php
@@ -7,7 +7,7 @@ use App\Models\Training\WaitingList;
 
 trait WaitingListTestHelper
 {
-    protected function createList(array $overrides = [])
+    protected function createList(array $overrides = []): WaitingList
     {
         return factory(WaitingList::class)->create($overrides);
     }


### PR DESCRIPTION
Fixes TECH-317

# Summary of changes

Checks if people not seen in the normal divison sync are still division members and updates their state.

Runs through normal division leaving procedures so they'll get booted from the list etc.

Currently set to look for people not scanned in previous 48 hours. This is gonna hammer .net though. Not sure if there's rate limits etc here?

---

1. Find up to 100 people we haven't seen for 48 hours (they are likely to have left the division)
2. Push their ids to a queue job
3. Take the first 5 ids and try to scan .net, acting as appropriate
4. Repush a job for a minute later with the next 95 people and so on
5. if we hit a rate limit from .net push the job after a minute delay
6. if an account 404s on the .net api remove from all waiting lists
