### PR TITLE
text-370 fix: allow 25, 50, or 100 per page in waiting lists, no more all crashing everything on big lists!

### DIFF
--- a/app/Filament/Resources/WaitingListResource/RelationManagers/AccountsRelationManager.php
+++ b/app/Filament/Resources/WaitingListResource/RelationManagers/AccountsRelationManager.php
@@ -147,7 +147,10 @@ class AccountsRelationManager extends RelationManager
                     ->modalCancelActionLabel('Cancel')
                     ->visible(fn ($record) => $this->can('removeAccounts', $record->waitingList)),
             ])
-            ->defaultSort('created_at', 'asc')->persistSearchInSession()->defaultPaginationPageOption(25);
+            ->defaultSort('created_at', 'asc')
+            ->persistSearchInSession()
+            ->paginated(['25', '50', '100'])
+            ->defaultPaginationPageOption(25);
     }
 
     public function isReadOnly(): bool


### PR DESCRIPTION
Fixes TECH-370

# Summary of changes

No more 'all' option on waiting lists!
# Screenshots (if necessary)

< Please provide screenshots if this will facilitate a faster review of these changes>
