### PR TITLE
fix: Pull solo endorsement duration from database

### DIFF
--- a/app/Filament/Resources/SoloEndorsementResource.php
+++ b/app/Filament/Resources/SoloEndorsementResource.php
@@ -43,7 +43,7 @@ class SoloEndorsementResource extends Resource
                 Tables\Columns\TextColumn::make('account.id')->label('CID'),
                 Tables\Columns\TextColumn::make('account.name')->label('Account'),
                 Tables\Columns\TextColumn::make('endorsable.description')->label('Position'),
-                Tables\Columns\TextColumn::make('duration')->label('Duration')->suffix(' days'),//->getStateUsing(fn ($record) => $record->expires_at->diffInDays($record->created_at).' days')->label('Duration'),
+                Tables\Columns\TextColumn::make('duration')->label('Duration')->suffix(' days'),
                 Tables\Columns\TextColumn::make('created_at')->label('Started At')->isoDateTimeFormat('lll'),
                 Tables\Columns\TextColumn::make('expires_at')->label('Expires At')->isoDateTimeFormat('lll')->sortable(),
                 Tables\Columns\TextColumn::make('status')->label('Status')->badge()


### PR DESCRIPTION
Fixes #4127 

Feel free to call me stupid, but why was this being overridden? The provided code here simply pulls the duration from the database.