### PR TITLE
remove EGSF from AFIS S1 endorsement list

### DIFF
--- a/resources/views/site/atc/endorsements.blade.php
+++ b/resources/views/site/atc/endorsements.blade.php
@@ -192,7 +192,6 @@
                         <li>Old Warden (EGTH)</li>
                         <li>Penzance (EGHK)</li>
                         <li>Perth (EGPT)</li>
-                        <li>Peterborough/Conington (EGSF)</li>
                         <li>Portland (EGDP)</li>
                         <li>Rochester (EGTO)</li>
                         <li>Sandtoft (EGCF)</li>


### PR DESCRIPTION
This will also require removing from the endorsement that shows on the roster, if not already done