### PR TITLE
fix: send keep alive commands from the teamspeak daemon

### DIFF
--- a/app/Console/Commands/TeamSpeak/TeamSpeakDaemon.php
+++ b/app/Console/Commands/TeamSpeak/TeamSpeakDaemon.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands\TeamSpeak;
 
 use App\Libraries\TeamSpeak;
 use Exception;
+use PlanetTeamSpeak\TeamSpeak3Framework\Adapter\ServerQuery;
 use PlanetTeamSpeak\TeamSpeak3Framework\Adapter\ServerQuery\Event;
 use PlanetTeamSpeak\TeamSpeak3Framework\Exception\ServerQueryException;
 use PlanetTeamSpeak\TeamSpeak3Framework\Exception\TeamSpeak3Exception;
@@ -13,6 +14,8 @@ use PlanetTeamSpeak\TeamSpeak3Framework\Node\Host;
 
 class TeamSpeakDaemon extends TeamSpeakCommand
 {
+    const int KEEP_ALIVE_SECONDS = 240;
+
     protected static $connection;
 
     protected static $connectedClients = [];
@@ -92,19 +95,31 @@ class TeamSpeakDaemon extends TeamSpeakCommand
         }
     }
 
+    public function serverQueryWaitTimeout(int $time, ServerQuery $adapter): void
+    {
+        if ($adapter->getQueryLastTimestamp() < time() - self::KEEP_ALIVE_SECONDS) {
+            $this->log('TeamSpeak: serverQueryWaitTimeout/keepAlive');
+
+            // Connection keep alive
+            $adapter->request('clientupdate');
+        }
+    }
+
     protected function establishConnection($attempt = 1)
     {
         try {
+            $id = uniqid();
             // establish connection
-            $connection = TeamSpeak::run('VATSIM UK Management Daemon', true);
+            $connection = TeamSpeak::run("teaman $id", true);
 
             // register for events
             $connection->notifyRegister('server');
 
-            Signal::getInstance()
-                ->subscribe('notifyCliententerview', self::class.'::clientJoinedEvent');
-            Signal::getInstance()
-                ->subscribe('notifyClientleftview', self::class.'::clientLeftEvent');
+            // Signal is a singleton used for message passing
+            $signalInstance = Signal::getInstance();
+            $signalInstance->subscribe('notifyCliententerview', self::class.'::clientJoinedEvent');
+            $signalInstance->subscribe('notifyClientleftview', self::class.'::clientLeftEvent');
+            $signalInstance->subscribe('serverqueryWaitTimeout', self::class.'::serverQueryWaitTimeout');
 
             return $connection;
         } catch (ServerQueryException $e) {

--- a/app/Libraries/TeamSpeak.php
+++ b/app/Libraries/TeamSpeak.php
@@ -12,7 +12,6 @@ use App\Models\TeamSpeak\ServerGroup;
 use Cache;
 use Carbon\Carbon;
 use DB;
-use Illuminate\Support\Facades\Log;
 use PlanetTeamSpeak\TeamSpeak3Framework\Exception\ServerQueryException;
 use PlanetTeamSpeak\TeamSpeak3Framework\Exception\TeamSpeak3Exception;
 use PlanetTeamSpeak\TeamSpeak3Framework\Node\Client;
@@ -49,14 +48,7 @@ class TeamSpeak
         return config('services.teamspeak.host') && config('services.teamspeak.username') && config('services.teamspeak.password') && config('services.teamspeak.port') && config('services.teamspeak.query_port');
     }
 
-    /**
-     * Connect to the TeamSpeak server.
-     *
-     * @param  string  $nickname
-     * @param  bool  $nonBlocking
-     * @return Server
-     */
-    public static function run($nickname = 'VATSIM UK TeamSpeak Bot', $nonBlocking = false)
+    public static function run($nickname = 'VATSIM UK TeamSpeak Bot', $nonBlocking = false): Server
     {
         $connectionUrl = sprintf(
             'serverquery://%s:%s@%s:%s/?nickname=%s&server_port=%s%s#no_query_clients',
@@ -69,21 +61,7 @@ class TeamSpeak
             $nonBlocking ? '&blocking=0' : ''
         );
 
-        $factory = null;
-
-        try {
-            $factory = TeamSpeak3::factory($connectionUrl);
-        } catch (ServerQueryException $e) {
-            Log::error('TeamSpeak connection failed: '.$e->getMessage());
-
-            if (stripos($e->getMessage(), 'nickname is already in use')) {
-                // Try again in 3 seconds
-                sleep(3);
-                $factory = TeamSpeak3::factory($connectionUrl);
-            }
-        }
-
-        return $factory;
+        return TeamSpeak3::factory($connectionUrl);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "maatwebsite/excel": "~3.1.17",
         "malahierba-lab/public-id": "dev-main",
         "ohdearapp/ohdear-php-sdk": "^3.0",
-        "planetteamspeak/ts3-php-framework": "dev-master",
+        "planetteamspeak/ts3-php-framework": "~1.3.0",
         "predis/predis": "^2.0",
         "pusher/pusher-php-server": "~7.2",
         "sentry/sentry-laravel": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "219d87ae610b4e9fd6adcd09697f0a5a",
+    "content-hash": "f5718e05796ac577dddfdd0fd4e13368",
     "packages": [
         {
             "name": "alawrence/laravel-ipboard",
@@ -6776,16 +6776,16 @@
         },
         {
             "name": "planetteamspeak/ts3-php-framework",
-            "version": "dev-master",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/VATSIM-UK/ts3phpframework.git",
-                "reference": "85dfd50a6a38a04677fede4f503ddbb3ec2bde5b"
+                "reference": "b3629a35a5ec0eb093128ec688a10486125cf1ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/VATSIM-UK/ts3phpframework/zipball/85dfd50a6a38a04677fede4f503ddbb3ec2bde5b",
-                "reference": "85dfd50a6a38a04677fede4f503ddbb3ec2bde5b",
+                "url": "https://api.github.com/repos/VATSIM-UK/ts3phpframework/zipball/b3629a35a5ec0eb093128ec688a10486125cf1ae",
+                "reference": "b3629a35a5ec0eb093128ec688a10486125cf1ae",
                 "shasum": ""
             },
             "require": {
@@ -6805,7 +6805,6 @@
                 "squizlabs/php_codesniffer": "^3.6",
                 "symfony/yaml": "^6.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -6856,9 +6855,9 @@
                 "email": "info@planetteamspeak.com",
                 "issues": "https://github.com/planetteamspeak/ts3phpframework/issues",
                 "docs": "https://docs.planetteamspeak.com/ts3/php/framework",
-                "source": "https://github.com/VATSIM-UK/ts3phpframework/tree/master"
+                "source": "https://github.com/VATSIM-UK/ts3phpframework/tree/1.3.0"
             },
-            "time": "2025-06-02T16:39:41+00:00"
+            "time": "2024-06-01T15:08:04+00:00"
         },
         {
             "name": "predis/predis",
@@ -15050,8 +15049,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "alawrence/laravel-ipboard": 20,
-        "malahierba-lab/public-id": 20,
-        "planetteamspeak/ts3-php-framework": 20
+        "malahierba-lab/public-id": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
Fixes TECH-369

Hypothesis: daemon was getting booted off the telnet connection to server query during periods of inactivity.
This implements a planetteamspeak feature designed to prevent this by sending a message every 4 mins.

May / may not solve the problem depending on underlying role assignment logic which has not changed


