### PR TITLE
Allow waiting list admins to self-serve waiting list advanced settings

### DIFF
--- a/app/Filament/Resources/WaitingListResource.php
+++ b/app/Filament/Resources/WaitingListResource.php
@@ -30,14 +30,14 @@ class WaitingListResource extends Resource
     {
         return $form
             ->schema([
-                TextInput::make('name')->autofocus()->required()->live(onBlur: true)
+                TextInput::make('name')->autofocus()->required()->live(onBlur: true)->disabledOn('edit')
                     ->afterStateUpdated(fn ($state, callable $set) => $set('slug', Str::slug($state))),
-                TextInput::make('slug')->required(),
+                TextInput::make('slug')->disabledOn('edit')->required(),
 
                 Select::make('department')->options([
                     'atc' => 'ATC Training',
                     'pilot' => 'Pilot Training',
-                ])->required(),
+                ])->disabledOn('edit')->required(),
 
                 Section::make('Additional Settings')
                     ->schema([
@@ -120,6 +120,7 @@ class WaitingListResource extends Resource
         return [
             'index' => Pages\ListWaitingLists::route('/'),
             'create' => Pages\CreateWaitingList::route('/create'),
+            'edit' => Pages\EditWaitingList::route('/{record}/edit'),
             'view' => Pages\ViewWaitingList::route('/{record}'),
         ];
     }

--- a/app/Filament/Resources/WaitingListResource/Pages/EditWaitingList.php
+++ b/app/Filament/Resources/WaitingListResource/Pages/EditWaitingList.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\WaitingListResource\Pages;
+
+use App\Filament\Resources\WaitingListResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditWaitingList extends EditRecord
+{
+    protected static string $resource = WaitingListResource::class;
+}

--- a/app/Filament/Resources/WaitingListResource/Pages/ViewWaitingList.php
+++ b/app/Filament/Resources/WaitingListResource/Pages/ViewWaitingList.php
@@ -97,6 +97,7 @@ class ViewWaitingList extends ViewRecord
                         ->default(false),
                 ])
                 ->visible(fn () => auth()->user()->can('addFlags', $this->record)),
+            Actions\EditAction::make()->label('Edit settings')->visible(fn () => auth()->user()->can('update', $this->record)),
         ];
     }
 }

--- a/app/Policies/Training/WaitingListPolicy.php
+++ b/app/Policies/Training/WaitingListPolicy.php
@@ -49,7 +49,7 @@ class WaitingListPolicy
 
     public function update(Account $account, WaitingList $waitingList)
     {
-        return false;
+        return $this->checkHasPermissionForList($account, $waitingList, ['waiting-lists.admin.%s']);
     }
 
     public function delete(Account $account, WaitingList $waitingList)

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -88,6 +88,9 @@ class RolesAndPermissionsSeeder extends Seeder
             'waiting-lists.add-flags.*',
             'waiting-lists.delete.*',
             'waiting-lists.create',
+            'waiting-lists.admin.*',
+            'waiting-lists.admin.atc',
+            'waiting-lists.admin.pilot',
 
             // // Feedback System Permissions
             'feedback.access',

--- a/tests/Feature/Admin/WaitingLists/Pages/ViewWaitingListPageTest.php
+++ b/tests/Feature/Admin/WaitingLists/Pages/ViewWaitingListPageTest.php
@@ -453,4 +453,30 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
             'removal_comment' => $other_reason,
         ]);
     }
+
+    public function test_cannot_see_edit_button_when_not_admin()
+    {
+        $userWithoutPermission = Account::factory()->create();
+
+        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+
+        $userWithoutPermission->givePermissionTo('waiting-lists.view.atc');
+        $userWithoutPermission->givePermissionTo('waiting-lists.access');
+
+        Livewire::actingAs($userWithoutPermission)->test(ViewWaitingList::class, ['record' => $waitingList->id])
+            ->assertDontSee('Edit settings');
+    }
+
+    public function test_can_see_edit_button_when_admin()
+    {
+        $userWithPermission = Account::factory()->create();
+        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+
+        $userWithPermission->givePermissionTo('waiting-lists.view.atc');
+        $userWithPermission->givePermissionTo('waiting-lists.access');
+        $userWithPermission->givePermissionTo('waiting-lists.admin.atc');
+
+        Livewire::actingAs($userWithPermission)->test(ViewWaitingList::class, ['record' => $waitingList->id])
+            ->assertSee('Edit settings');
+    }
 }


### PR DESCRIPTION
Builds on work done in #4097.

Adds:
- Permission for waiting list admin defined by department (will be added to existing waiting list admin roles)
- Defines the Edit page for the WaitingList resource to allow it to be modified.
