### PR TITLE
Fixes #4163 - Replace all instances of factory(WaitingList::class)->create() with new factory format

### DIFF
--- a/tests/Feature/Account/WaitingListsTest.php
+++ b/tests/Feature/Account/WaitingListsTest.php
@@ -29,7 +29,7 @@ class WaitingListsTest extends TestCase
     #[Test]
     public function test_index_with_no_waiting_list_accounts()
     {
-        factory(WaitingList::class)->create(['name' => 'My List']);
+        WaitingList::factory()->create(['name' => 'My List']);
 
         $this->actingAs($this->user)
             ->get(route('mship.waiting-lists.index'))
@@ -40,7 +40,7 @@ class WaitingListsTest extends TestCase
     #[Test]
     public function test_index_with_a_waiting_list_accounts()
     {
-        $list = factory(WaitingList::class)->create(['name' => 'My List']);
+        $list = WaitingList::factory()->create(['name' => 'My List']);
         $list->addToWaitingList($this->user, $this->privacc);
 
         $this->actingAs($this->user)
@@ -51,7 +51,7 @@ class WaitingListsTest extends TestCase
     #[Test]
     public function test_does_not_show_on_roster_icon_when_not_configured_for_list()
     {
-        $list = factory(WaitingList::class)->create(['name' => 'My List', 'feature_toggles' => ['display_on_roster' => false]]);
+        $list = WaitingList::factory()->create(['name' => 'My List', 'feature_toggles' => ['display_on_roster' => false]]);
         $list->addToWaitingList($this->user, $this->privacc);
 
         $this->actingAs($this->user)
@@ -63,7 +63,7 @@ class WaitingListsTest extends TestCase
     public function test_can_successfully_self_enrol_when_eligible_home_member_roster()
     {
         $account = Account::factory()->create();
-        $list = factory(WaitingList::class)->create(['name' => 'My List', 'self_enrolment_enabled' => true, 'home_members_only' => true, 'requires_roster_membership' => true]);
+        $list = WaitingList::factory()->create(['name' => 'My List', 'self_enrolment_enabled' => true, 'home_members_only' => true, 'requires_roster_membership' => true]);
 
         $account->addState(State::findByCode('DIVISION'));
         Roster::create(['account_id' => $account->id]);
@@ -87,7 +87,7 @@ class WaitingListsTest extends TestCase
         $accountNotDivisionMember = Account::factory()->create();
         $accountNotDivisionMember->addState(State::findByCode('VISITING'));
         $accountNotDivisionMember->refresh();
-        $list = factory(WaitingList::class)->create(['name' => 'My List', 'self_enrolment_enabled' => true, 'home_members_only' => true]);
+        $list = WaitingList::factory()->create(['name' => 'My List', 'self_enrolment_enabled' => true, 'home_members_only' => true]);
 
         $this->actingAs($accountNotDivisionMember)
             ->get(route('mship.waiting-lists.index'))

--- a/tests/Feature/Admin/WaitingLists/Pages/ViewWaitingListPageTest.php
+++ b/tests/Feature/Admin/WaitingLists/Pages/ViewWaitingListPageTest.php
@@ -27,7 +27,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_one_relation_manager_tables_are_present()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $this->adminUser->givePermissionTo('waiting-lists.view.atc');
         $this->adminUser->givePermissionTo('waiting-lists.access');
 
@@ -37,7 +37,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_admin_user_cant_add_student_without_permission()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
 
         $this->adminUser->givePermissionTo('waiting-lists.view.atc');
         $this->adminUser->givePermissionTo('waiting-lists.access');
@@ -49,7 +49,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_home_student_can_be_added()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $accountToAdd = Account::factory()->create();
         $accountToAdd->addState(State::findByCode('DIVISION'));
 
@@ -73,7 +73,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
     {
         Livewire::actingAs($this->adminUser);
 
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $accountToAdd = Account::factory()->create();
         $accountToAdd->addState(State::findByCode('DIVISION'));
 
@@ -92,7 +92,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_non_home_student_cant_be_added()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $accountToAdd = Account::factory()->create();
         $accountToAdd->addState(State::findByCode('INTERNATIONAL'));
 
@@ -117,7 +117,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_cannot_see_join_date_field_without_permission()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $accountToAdd = Account::factory()->create();
         $accountToAdd->addState(State::findByCode('DIVISION'));
 
@@ -134,7 +134,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
     public function test_admin_can_add_student_with_join_date_if_specified()
     {
         /** @var WaitingList $waitingList */
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $accountToAdd = Account::factory()->create();
         $accountToAdd->addState(State::findByCode('DIVISION'));
 
@@ -161,7 +161,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_admin_can_add_manual_flag_to_waiting_list()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
 
         $this->adminUser->givePermissionTo('waiting-lists.view.atc');
         $this->adminUser->givePermissionTo('waiting-lists.access');
@@ -182,7 +182,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_admin_cant_add_duplicate_named_flag_in_list()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
 
         $this->adminUser->givePermissionTo('waiting-lists.view.atc');
         $this->adminUser->givePermissionTo('waiting-lists.access');
@@ -204,7 +204,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_admin_can_create_flag_with_linked_endorsement()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $positionGroup = factory(PositionGroup::class)->create();
 
         $this->adminUser->givePermissionTo('waiting-lists.view.atc');
@@ -228,7 +228,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_flag_cannot_be_added_without_permission()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
 
         $this->adminUser->givePermissionTo('waiting-lists.view.atc');
         $this->adminUser->givePermissionTo('waiting-lists.access');
@@ -243,7 +243,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
         Livewire::actingAs($this->adminUser);
 
         /** @var WaitingList $waitingList */
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
         $waitingList->addToWaitingList($account, $this->adminUser);
@@ -261,7 +261,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
         Livewire::actingAs($this->adminUser);
 
         /** @var WaitingList $waitingList */
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
         $waitingList->addToWaitingList($account, $this->adminUser);
@@ -279,7 +279,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
         Livewire::actingAs($this->adminUser);
 
         /** @var WaitingList $waitingList */
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
         $waitingList->addToWaitingList($account, $this->adminUser);
@@ -295,7 +295,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_notes_can_be_added_to_waiting_list_account()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
         $waitingList->addToWaitingList($account, $this->adminUser);
@@ -321,7 +321,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_can_modify_manual_flag_to_true()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
         $manualFlag = factory(WaitingListFlag::class)->create([
@@ -354,7 +354,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
     public function test_can_modify_manual_flag_to_false()
     {
         /** @var WaitingList $waitingList */
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
         $manualFlag = factory(WaitingListFlag::class)->create([
@@ -394,7 +394,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_account_can_be_removed()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
         $waitingList->addToWaitingList($account, $this->adminUser);
@@ -424,7 +424,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
 
     public function test_account_can_be_removed_with_other_reason()
     {
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
         $waitingList->addToWaitingList($account, $this->adminUser);
@@ -458,7 +458,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
     {
         $userWithoutPermission = Account::factory()->create();
 
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
 
         $userWithoutPermission->givePermissionTo('waiting-lists.view.atc');
         $userWithoutPermission->givePermissionTo('waiting-lists.access');
@@ -470,7 +470,7 @@ class ViewWaitingListPageTest extends BaseAdminTestCase
     public function test_can_see_edit_button_when_admin()
     {
         $userWithPermission = Account::factory()->create();
-        $waitingList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
 
         $userWithPermission->givePermissionTo('waiting-lists.view.atc');
         $userWithPermission->givePermissionTo('waiting-lists.access');

--- a/tests/Feature/Training/WaitingListEligibilityPlumbingTest.php
+++ b/tests/Feature/Training/WaitingListEligibilityPlumbingTest.php
@@ -19,7 +19,7 @@ class WaitingListEligibilityPlumbingTest extends TestCase
     public function test_checks_eligibility_when_command_run_for_user()
     {
         Event::fakeFor(function () {
-            $waitingList = factory(WaitingList::class)->create();
+            $waitingList = WaitingList::factory()->create();
             $waitingList->addToWaitingList($this->user, $this->privacc);
 
             Bus::fake();
@@ -37,10 +37,10 @@ class WaitingListEligibilityPlumbingTest extends TestCase
     public function test_checks_eligibility_for_each_member_of_list()
     {
         Event::fakeFor(function () {
-            $waitingListA = factory(WaitingList::class)->create();
+            $waitingListA = WaitingList::factory()->create();
             $waitingListA->addToWaitingList($this->user, $this->privacc);
 
-            $waitingListB = factory(WaitingList::class)->create();
+            $waitingListB = WaitingList::factory()->create();
             $waitingListB->addToWaitingList($this->user, $this->privacc);
 
             Bus::fake();
@@ -60,7 +60,7 @@ class WaitingListEligibilityPlumbingTest extends TestCase
     public function test_checks_elgibility_following_new_flag_added_to_list()
     {
         Event::fakeFor(function () {
-            $waitingList = factory(WaitingList::class)->create();
+            $waitingList = WaitingList::factory()->create();
             $waitingList->addToWaitingList($this->user, $this->privacc);
 
             Bus::fake();

--- a/tests/Feature/Training/WaitingListInactivityIntegrationTest.php
+++ b/tests/Feature/Training/WaitingListInactivityIntegrationTest.php
@@ -34,7 +34,7 @@ class WaitingListInactivityIntegrationTest extends TestCase
         $account = Account::factory()->create(['inactive' => false]);
         $account->addState(State::findByCode('DIVISION'));
 
-        $waitingList = factory(WaitingList::class)->create();
+        $waitingList = WaitingList::factory()->create();
         $waitingList->addToWaitingList($account, $this->privacc);
 
         $this->assertTrue($waitingList->accounts->contains($account));
@@ -56,7 +56,7 @@ class WaitingListInactivityIntegrationTest extends TestCase
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
 
-        $waitingList = factory(WaitingList::class)->create();
+        $waitingList = WaitingList::factory()->create();
 
         $this->assertFalse($waitingList->accounts->contains($account));
 
@@ -76,7 +76,7 @@ class WaitingListInactivityIntegrationTest extends TestCase
         $account->refresh();
 
         /** @var WaitingList $waitingList */
-        $waitingList = factory(WaitingList::class)->create();
+        $waitingList = WaitingList::factory()->create();
         $waitingList->addToWaitingList($account, $this->privacc);
 
         $this->assertTrue($waitingList->includesAccount($account));
@@ -93,7 +93,7 @@ class WaitingListInactivityIntegrationTest extends TestCase
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
 
-        $waitingList = factory(WaitingList::class)->create();
+        $waitingList = WaitingList::factory()->create();
 
         $this->assertFalse($waitingList->includesAccount($account));
 

--- a/tests/Unit/Account/Relationships/AccountWaitingListsTest.php
+++ b/tests/Unit/Account/Relationships/AccountWaitingListsTest.php
@@ -25,8 +25,8 @@ class AccountWaitingListsTest extends TestCase
         // create as division member
         $this->user->addState(State::findByCode('DIVISION'));
 
-        $this->oldWaitingList = factory(WaitingList::class)->create();
-        $this->currentWaitingList = factory(WaitingList::class)->create();
+        $this->oldWaitingList = WaitingList::factory()->create();
+        $this->currentWaitingList = WaitingList::factory()->create();
 
         $this->oldWaitingList->addToWaitingList($this->user, $this->privacc);
         $this->currentWaitingList->addToWaitingList($this->user, $this->privacc);
@@ -52,7 +52,7 @@ class AccountWaitingListsTest extends TestCase
     #[Test]
     public function it_can_handle_trashed_waiting_lists()
     {
-        $trashed = factory(WaitingList::class)->create();
+        $trashed = WaitingList::factory()->create();
         $trashed->addToWaitingList($this->user, $this->privacc);
         $trashed->delete();
         $trashed->save();

--- a/tests/Unit/Training/WaitingList/WaitingListAccountCtsTheoryTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListAccountCtsTheoryTest.php
@@ -25,7 +25,7 @@ class WaitingListAccountCtsTheoryTest extends TestCase
 
         // create the member first as for some reason the CID is not overwritten
         // when using a factory
-        $this->member = factory(Member::class)->create();
+        $this->member = WaitingList::factory()->create();
         $this->account = Account::factory()->create(['id' => $this->member->cid]);
         $this->account->addState(State::findByCode('DIVISION'));
 
@@ -34,7 +34,7 @@ class WaitingListAccountCtsTheoryTest extends TestCase
 
     private function setupWaitingList(?string $ctsLevel, ?string $department = WaitingList::ATC_DEPARTMENT): WaitingList\WaitingListAccount
     {
-        $waitingList = factory(WaitingList::class)->create(['cts_theory_exam_level' => $ctsLevel, 'department' => $department]);
+        $waitingList = WaitingList::factory()->create(['cts_theory_exam_level' => $ctsLevel, 'department' => $department]);
 
         return $waitingList->addToWaitingList($this->account->fresh(), $this->privacc);
     }

--- a/tests/Unit/Training/WaitingList/WaitingListAccountStateChangeTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListAccountStateChangeTest.php
@@ -33,8 +33,8 @@ class WaitingListAccountStateChangeTest extends TestCase
 
         Notification::fake();
 
-        $this->waitingList = factory(WaitingList::class)->create();
-        $this->nonHomeMembersOnlyWaitingList = factory(WaitingList::class)->create();
+        $this->waitingList = WaitingList::factory()->create();
+        $this->nonHomeMembersOnlyWaitingList = WaitingList::factory()->create();
         $this->nonHomeMembersOnlyWaitingList->home_members_only = 0;
         $this->nonHomeMembersOnlyWaitingList->save();
     }

--- a/tests/Unit/Training/WaitingList/WaitingListCheckFlagsServiceTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListCheckFlagsServiceTest.php
@@ -20,14 +20,14 @@ class WaitingListCheckFlagsServiceTest extends TestCase
     {
         parent::setUp();
 
-        $this->waitingList = factory(WaitingList::class)->create();
+        $this->waitingList = WaitingList::factory()->create();
 
         $this->actingAs($this->privacc);
     }
 
     public function test_passes_checks_when_manual_flag_is_true_in_all_flags_config()
     {
-        $waitingList = factory(WaitingList::class)->create();
+        $waitingList = WaitingList::factory()->create();
         $waitingListAccount = $waitingList->addToWaitingList($this->user, $this->privacc);
 
         $flag = factory(WaitingListFlag::class)->create([
@@ -45,7 +45,7 @@ class WaitingListCheckFlagsServiceTest extends TestCase
 
     public function test_fails_checks_when_manual_flag_is_false_in_all_flags_config()
     {
-        $waitingList = factory(WaitingList::class)->create();
+        $waitingList = WaitingList::factory()->create();
         $waitingList->addToWaitingList($this->user, $this->privacc);
 
         $flag = $this->createFlag('manual', $waitingList, false);
@@ -57,7 +57,7 @@ class WaitingListCheckFlagsServiceTest extends TestCase
 
     public function test_fails_check_when_endorsement_linked_flag_is_false()
     {
-        $waitingList = factory(WaitingList::class)->create();
+        $waitingList = WaitingList::factory()->create();
         $waitingList->addToWaitingList($this->user, $this->privacc);
 
         factory(Atc::class)->create(['account_id' => $this->user->id, 'callsign' => 'EGGD_APP', 'minutes_online' => 35]);
@@ -79,7 +79,7 @@ class WaitingListCheckFlagsServiceTest extends TestCase
 
     public function test_pass_check_when_endorsement_linked_flag_is_true()
     {
-        $waitingList = factory(WaitingList::class)->create();
+        $waitingList = WaitingList::factory()->create();
         $waitingList->addToWaitingList($this->user, $this->privacc);
 
         factory(Atc::class)->create(['account_id' => $this->user->id, 'callsign' => 'EGGD_APP', 'minutes_online' => 65]);
@@ -101,7 +101,7 @@ class WaitingListCheckFlagsServiceTest extends TestCase
 
     public function test_pass_check_on_all_with_all_passing_automated_flags()
     {
-        $waitingList = factory(WaitingList::class)->create();
+        $waitingList = WaitingList::factory()->create();
         $waitingList->addToWaitingList($this->user, $this->privacc);
 
         factory(Atc::class)->create(['account_id' => $this->user->id, 'callsign' => 'EGGD_APP', 'minutes_online' => 65]);

--- a/tests/Unit/Training/WaitingList/WaitingListFlagTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListFlagTest.php
@@ -31,7 +31,7 @@ class WaitingListFlagTest extends TestCase
 
         $this->actingAs($this->privacc);
 
-        $this->waitingList = factory(WaitingList::class)->create();
+        $this->waitingList = WaitingList::factory()->create();
         $this->waitingList->addFlag($this->flag);
         $this->waitingListAccount = $this->waitingList->addToWaitingList($this->privacc, $this->privacc);
 

--- a/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentServiceTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentServiceTest.php
@@ -27,7 +27,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
     public function test_returns_empty_collection_when_no_lists_marked_as_enrollable()
     {
         $account = Account::factory()->create();
-        factory(WaitingList::class)->create([
+        WaitingList::factory()->create([
             'self_enrolment_enabled' => false,
         ]);
 
@@ -37,7 +37,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
     public function test_cannot_enrol_if_already_on_list_when_enabled()
     {
         $account = Account::factory()->create();
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
         ]);
 
@@ -51,7 +51,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
         $account = Account::factory()->create();
         $account->addState(State::findByCode('DIVISION'));
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'home_members_only' => true,
             'requires_roster_membership' => false,
@@ -67,7 +67,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
 
         Roster::create(['account_id' => $account->id]);
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'home_members_only' => true,
             'requires_roster_membership' => true,
@@ -81,7 +81,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
         $account = Account::factory()->create();
         $account->addState(State::findByCode('VISITING'));
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'home_members_only' => true,
             'requires_roster_membership' => true,
@@ -95,7 +95,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
         $account = Account::factory()->create();
         $account->addState(State::findByCode('VISITING'));
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'home_members_only' => true,
         ]);
@@ -111,7 +111,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
         $qualification = Qualification::code('OBS')->first();
         $account->addQualification($qualification);
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'home_members_only' => true,
             'self_enrolment_maximum_qualification_id' => $qualification->id,
@@ -128,7 +128,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
         $qualification = Qualification::code('S2')->first();
         $account->addQualification($qualification);
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'home_members_only' => true,
             'self_enrolment_maximum_qualification_id' => Qualification::code('S1')->first()->id,
@@ -141,7 +141,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
     {
         $account = Account::factory()->create();
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'home_members_only' => false,
             'self_enrolment_maximum_qualification_id' => null,
@@ -161,7 +161,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
         $qualification = Qualification::code('S1')->first();
         $account->addQualification($qualification);
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'home_members_only' => false,
             'self_enrolment_maximum_qualification_id' => Qualification::code('OBS')->first()->id,
@@ -174,7 +174,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
     {
         $account = Account::factory()->create();
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'self_enrolment_hours_at_qualification_id' => Qualification::code('S1')->first()->id,
             'self_enrolment_hours_at_qualification_minimum_hours' => 10,
@@ -193,7 +193,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
     {
         $account = Account::factory()->create();
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'self_enrolment_hours_at_qualification_id' => Qualification::code('S1')->first()->id,
             'self_enrolment_hours_at_qualification_minimum_hours' => 10,
@@ -212,7 +212,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
     {
         $account = Account::factory()->create();
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'self_enrolment_hours_at_qualification_id' => Qualification::code('S1')->first()->id,
             'self_enrolment_hours_at_qualification_minimum_hours' => 10,
@@ -231,7 +231,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
     {
         $account = Account::factory()->create();
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'self_enrolment_enabled' => true,
             'self_enrolment_hours_at_qualification_id' => Qualification::code('S1')->first()->id,
             'self_enrolment_hours_at_qualification_minimum_hours' => 10,
@@ -251,7 +251,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
     {
         $account = Account::factory()->create();
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'department' => WaitingList::ATC_DEPARTMENT,
             'self_enrolment_enabled' => true,
             'self_enrolment_minimum_qualification_id' => Qualification::code('S1')->first()->id,
@@ -267,7 +267,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
     {
         $account = Account::factory()->create();
 
-        $waitingList = factory(WaitingList::class)->create([
+        $waitingList = WaitingList::factory()->create([
             'department' => WaitingList::ATC_DEPARTMENT,
             'self_enrolment_enabled' => true,
             'self_enrolment_minimum_qualification_id' => Qualification::code('S1')->first()->id,

--- a/tests/Unit/Training/WaitingList/WaitingListTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListTest.php
@@ -43,7 +43,7 @@ class WaitingListTest extends TestCase
     #[Test]
     public function it_detects_if_atc_list()
     {
-        $atcList = factory(WaitingList::class)->create(['department' => 'atc']);
+        $atcList = WaitingList::factory()->create(['department' => 'atc']);
 
         $this->assertTrue($atcList->isAtcList());
         $this->assertFalse($atcList->isPilotList());
@@ -52,7 +52,7 @@ class WaitingListTest extends TestCase
     #[Test]
     public function it_detects_if_pilot_list()
     {
-        $atcList = factory(WaitingList::class)->create(['department' => 'pilot']);
+        $atcList = WaitingList::factory()->create(['department' => 'pilot']);
 
         $this->assertTrue($atcList->isPilotList());
         $this->assertFalse($atcList->isAtcList());

--- a/tests/Unit/Training/WaitingList/WaitingListTestHelper.php
+++ b/tests/Unit/Training/WaitingList/WaitingListTestHelper.php
@@ -9,7 +9,7 @@ trait WaitingListTestHelper
 {
     protected function createList(array $overrides = [])
     {
-        return factory(WaitingList::class)->create($overrides);
+        return WaitingList::factory()->create($overrides);
     }
 
     protected function createPopulatedList(array $overrides = [], $accounts = 5)

--- a/tests/Unit/Training/WaitingList/WaitingListWriteEligibilityTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListWriteEligibilityTest.php
@@ -21,7 +21,7 @@ class WaitingListWriteEligibilityTest extends TestCase
     {
         parent::setUp();
 
-        $this->waitingList = factory(WaitingList::class)->create();
+        $this->waitingList = WaitingList::factory()->create();
 
         $this->actingAs($this->privacc);
     }


### PR DESCRIPTION
Fixes #4163 

# Summary of changes
Replaced all instances of ```factory(WaitingList::class)->create()``` with ```WaitingList::factory()->create()```

# Screenshots (if necessary)

