### PR TITLE
Fixes #4168 - Correct ```web-support email``` on login page to ```technology-support```

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -63,7 +63,7 @@
               <div class="panel-heading"><i class="fa fa-exclamation-circle"></i> Having issues?</div>
               <div class="panel-body">
                 Use your primary email address (*****<b>{{"@" . explode("@", Auth::user()->email)[1]}}</b>) to send an email to
-                <p><a href="mailto:web-support@vatsim.uk">web-support@vatsim.uk</a></p>
+                <p><a href="mailto:technology-support@vatsim.uk">technology-support@vatsim.uk</a></p>
               </div>
             </div>
         </div>

--- a/resources/views/emails/default.blade.php
+++ b/resources/views/emails/default.blade.php
@@ -223,7 +223,7 @@
                                             <td  style="border: none !important;padding: 10px 20px;background-color: white;font-family: Arial, sans-serif, 'Roboto';color: black;">
                                                 <p>
                                                     This email was automatically sent from our system at <?= gmdate('H:i:s D jS M Y') ?> GMT. @if (isset($replyAllowed) && $replyAllowed !== true)Do not reply directly to this email, as the address is not monitored.@endif<br>
-                                                    Please <a href="mailto:web-support@vatsim.uk?subject=Erroneous automatic email" data-toggle="tooltip" title="Report Error" style="color: #00b0f0;">let us know</a> if it's not been sent to the correct person, or displays incorrectly.
+                                                    Please <a href="mailto:technology-support@vatsim.uk?subject=Erroneous automatic email" data-toggle="tooltip" title="Report Error" style="color: #00b0f0;">let us know</a> if it's not been sent to the correct person, or displays incorrectly.
                                                 </p>
                                             </td>
                                         </tr>

--- a/resources/views/emails/mship/member_email.blade.php
+++ b/resources/views/emails/mship/member_email.blade.php
@@ -3,7 +3,7 @@
 @section('body')
 
     <p style="font-weight: bold;">The following message was sent by {{$sender->name}} ({{$sender->id}}). Please report
-        abuse <a href="mailto:web-support@vatsim.uk?subject=Abuse: Membership Email Functionality" data-toggle="tooltip" title="Report Abuse" style="color: #00b0f0;">here</a>.
+        abuse <a href="mailto:technology-support@vatsim.uk?subject=Abuse: Membership Email Functionality" data-toggle="tooltip" title="Report Abuse" style="color: #00b0f0;">here</a>.
 
     <p class="well">{!! nl2br(strip_tags($messageContent)) !!}</p>
 

--- a/resources/views/errors/401.blade.php
+++ b/resources/views/errors/401.blade.php
@@ -4,5 +4,5 @@
     <h1>401 - Unauthorized</h1>
     <h4>Error Detail</h4>
     <pre>{{ $exception->getMessage() }}</pre>
-    <p>If you require support with this issue, please contact <a href="mailto:web-support@vatsim.uk">web-support@vatsim.uk</a>.</p>
+    <p>If you require support with this issue, please contact <a href="mailto:technology-support@vatsim.uk">technology-support@vatsim.uk</a>.</p>
 @stop

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -4,5 +4,5 @@
     <h1>403 - Forbidden</h1>
     <h4>Error Detail</h4>
     <pre>{{ $exception->getMessage() }}</pre>
-    <p>If you require support with this issue, please contact <a href="mailto:web-support@vatsim.uk">web-support@vatsim.uk</a>.</p>
+    <p>If you require support with this issue, please contact <a href="mailto:technology-support@vatsim.uk">technology-support@vatsim.uk</a>.</p>
 @stop


### PR DESCRIPTION
Fixes #4168

# Summary of changes
Changed web support email on the login page from ```web-support@vatsim.uk``` to ```technology-support@vatsim.uk```

# Screenshots (if necessary)

There are 4 other places on the website which still use ```web-support@vatsim.uk```, should I change these in this pull request as well?