### PR TITLE
Add ability to add free text roster restriction for account

### DIFF
--- a/app/Filament/Resources/AccountResource/Pages/ViewAccount.php
+++ b/app/Filament/Resources/AccountResource/Pages/ViewAccount.php
@@ -125,7 +125,6 @@ class ViewAccount extends BaseViewRecordPage
 
     protected function getRosterRestrictionActions(?Roster $roster, bool $onRoster, bool $hasRosterRestriction): array
     {
-        // dd(auth()->user()->can('roster.restriction.create'), $onRoster);
         return [
             Actions\Action::make('roster_restriction')
                 ->visible(fn () => auth()->user()->can('roster.restriction.create') && $onRoster)

--- a/app/Filament/Resources/AccountResource/Pages/ViewAccount.php
+++ b/app/Filament/Resources/AccountResource/Pages/ViewAccount.php
@@ -8,6 +8,7 @@ use App\Filament\Helpers\Pages\LogPageAccess;
 use App\Filament\Resources\AccountResource;
 use App\Jobs\UpdateMember;
 use App\Models\Contact;
+use App\Models\Mship\Note\Type;
 use App\Models\Roster;
 use App\Notifications\Mship\UserImpersonated;
 use Filament\Actions;
@@ -32,7 +33,9 @@ class ViewAccount extends BaseViewRecordPage
 
     protected function getHeaderActions(): array
     {
-        $onRoster = Roster::where('account_id', $this->record->id)->exists();
+        $roster = Roster::where('account_id', $this->record->id)->first();
+        $onRoster = $roster->exists();
+        $hasRosterRestriction = (bool) $this->record->roster?->restrictionNote;
 
         return [
 
@@ -60,10 +63,52 @@ class ViewAccount extends BaseViewRecordPage
                             Roster::create(['account_id' => $this->record->id]);
                         }
 
-                        $this->refreshFormData(['roster_status']);
+                        $this->refreshFormData(['roster_status', 'notes']);
                     })
                     ->requiresConfirmation()
                     ->successNotificationTitle('Roster status updated!'),
+                Actions\Action::make('roster_restriction')
+                    ->visible(fn () => auth()->user()->can('roster.restriction.create') && $onRoster)
+                    ->color('warning')
+                    ->icon('heroicon-o-exclamation-triangle')
+                    ->name($hasRosterRestriction ? 'Edit roster restriction' : 'Add roster restriction')
+                    ->modalHeading($hasRosterRestriction ? 'Edit Roster Restriction' : 'Add Roster Restriction')
+                    ->form([
+                        Textarea::make('restriction_note')
+                            ->label('Restriction Note')
+                            ->required()
+                            ->default(fn () => $this->record->roster?->restrictionNote?->content ?? '')
+                            ->helperText('This note will be displayed on the roster and in the user\'s profile on record so please ensure it is appropriate for public display.'),
+                    ])
+                    ->action(function (array $data) use ($roster) {
+                        $note = $roster->account->addNote(Type::isShortCode('roster')->first(), $data['restriction_note'], auth()->user());
+                        $roster->restriction_note_id = $note->id;
+                        $roster->save();
+
+                        $this->dispatch('refreshNotes');
+                    })
+                    ->requiresConfirmation(),
+
+                Actions\Action::make('roster_restriction_remove')
+                    ->visible(fn () => $hasRosterRestriction && auth()->user()->can('roster.restriction.remove'))
+                    ->color('danger')
+                    ->icon('heroicon-o-trash')
+                    ->modalHeading('Remove Roster Restriction')
+                    ->form([
+                        Textarea::make('restriction_removal_note')
+                            ->label('Removal Note')
+                            ->required()
+                            ->helperText('This note will be displayed on the members profile on record.'),
+                    ])
+                    ->action(function ($data) use ($roster) {
+                        $roster->account->addNote(Type::isShortCode('roster')->first(), $data['restriction_removal_note'], auth()->user());
+                        $roster->restriction_note_id = null;
+                        $roster->save();
+
+                        $this->dispatch('refreshNotes');
+                    })
+                    ->requiresConfirmation()
+                    ->successNotificationTitle('Roster restriction removed'),
                 Actions\Action::make('remove_password')
                     ->visible(fn () => $this->record->hasPassword() && auth()->user()->can('removeSecondaryPassword', $this->record))
                     ->color('warning')

--- a/app/Filament/Resources/AccountResource/RelationManagers/NotesRelationManager.php
+++ b/app/Filament/Resources/AccountResource/RelationManagers/NotesRelationManager.php
@@ -27,6 +27,15 @@ class NotesRelationManager extends RelationManager
 
     protected static ?string $recordTitleAttribute = 'id';
 
+    /**
+     * The listeners for the relation manager.
+     * Allows actions against a resource to trigger a refresh of the relation manager.
+     *
+     * Current usages:
+     * - Roster restrictions refreshing the notes relation manager when a roster restriction is added or removed.
+     */
+    protected $listeners = ['refreshNotes' => '$refresh'];
+
     public function isReadOnly(): bool
     {
         return false;

--- a/app/Livewire/Roster/Show.php
+++ b/app/Livewire/Roster/Show.php
@@ -24,7 +24,7 @@ class Show extends Component
     public function mount(Account $account)
     {
         $this->account = $account;
-        $this->roster = Roster::where('account_id', $this->account->id)->with("restrictionNote")->first();
+        $this->roster = Roster::where('account_id', $this->account->id)->with('restrictionNote')->first();
     }
 
     public function search()

--- a/app/Livewire/Roster/Show.php
+++ b/app/Livewire/Roster/Show.php
@@ -24,7 +24,7 @@ class Show extends Component
     public function mount(Account $account)
     {
         $this->account = $account;
-        $this->roster = Roster::where('account_id', $this->account->id)->first();
+        $this->roster = Roster::where('account_id', $this->account->id)->with("restrictionNote")->first();
     }
 
     public function search()

--- a/app/Models/Roster.php
+++ b/app/Models/Roster.php
@@ -31,7 +31,7 @@ class Roster extends Model
 
     protected $table = 'roster';
 
-    protected $fillable = ['account_id'];
+    protected $fillable = ['account_id', 'restriction_note_id'];
 
     protected static function booted(): void
     {

--- a/app/Models/Roster.php
+++ b/app/Models/Roster.php
@@ -7,6 +7,7 @@ use App\Models\Atc\PositionGroup;
 use App\Models\Atc\PositionGroupPosition;
 use App\Models\Mship\Account;
 use App\Models\Mship\Account\Endorsement;
+use App\Models\Mship\Account\Note;
 use App\Models\Mship\Qualification;
 use App\Notifications\Roster\RemovedFromRoster;
 use Illuminate\Database\Eloquent\Builder;
@@ -52,6 +53,11 @@ class Roster extends Model
     public function account()
     {
         return $this->belongsTo(Account::class);
+    }
+
+    public function restrictionNote()
+    {
+        return $this->belongsTo(Note::class, 'restriction_note_id');
     }
 
     public function remove(?RosterUpdate $update = null)

--- a/database/migrations/2025_06_24_181237_add_roster_note_type.php
+++ b/database/migrations/2025_06_24_181237_add_roster_note_type.php
@@ -1,9 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2025_06_24_181237_add_roster_note_type.php
+++ b/database/migrations/2025_06_24_181237_add_roster_note_type.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('mship_note_type')->insert([
+            'name' => 'Roster',
+            'short_code' => 'roster',
+            'is_available' => true,
+            'is_system' => false,
+            'colour_code' => 'info',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('mship_note_type')->where('short_code', 'roster')->delete();
+    }
+};

--- a/database/migrations/2025_06_24_181633_add_roster_restriction_note_column.php
+++ b/database/migrations/2025_06_24_181633_add_roster_restriction_note_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('roster', function (Blueprint $table) {
+            $table->unsignedInteger('restriction_note_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('roster', function (Blueprint $table) {
+            $table->dropColumn('restriction_note_id');
+        });
+    }
+};

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -187,6 +187,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'endorsement-request.approve.*',
             'endorsement-request.reject.*',
             'roster.manage',
+            'roster.restriction.create',
         ];
 
         foreach ($permissions as $permission) {

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -188,6 +188,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'endorsement-request.reject.*',
             'roster.manage',
             'roster.restriction.create',
+            'roster.restriction.remove',
         ];
 
         foreach ($permissions as $permission) {

--- a/resources/views/livewire/roster/show.blade.php
+++ b/resources/views/livewire/roster/show.blade.php
@@ -41,28 +41,28 @@
                 </div>
             </div>
             <div class="flex flex-col space-y-4">
-                    @if($roster)
-            <hr>
-            <form wire:submit="search" class="flex flex-col mb-4 space-y-4">
-                <div>
-                    <label for="email" class="block text-sm font-medium leading-6 text-gray-900">Check
-                        Position</label>
-                    <div class="mt-2">
-                        <input wire:model="searchTerm" id="search" name="search" type="text" autocomplete="off"
-                            required
-                            placeholder="e.g. EGKK or EGKK_APP"
-                            class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
-                    </div>
-                </div>
+                @if($roster && $roster->restrictionNote == null)
+                    <hr>
+                    <form wire:submit="search" class="flex flex-col mb-4 space-y-4">
+                        <div>
+                            <label for="email" class="block text-sm font-medium leading-6 text-gray-900">Check
+                                Position</label>
+                            <div class="mt-2">
+                                <input wire:model="searchTerm" id="search" name="search" type="text" autocomplete="off"
+                                    required
+                                    placeholder="e.g. EGKK or EGKK_APP"
+                                    class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+                            </div>
+                        </div>
 
-                <div>
-                    <button
-                        type="submit"
-                        class="flex w-full justify-center rounded-md bg-brand px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-                        Search
-                    </button>
-                </div>
-            </form>
+                        <div>
+                            <button
+                                type="submit"
+                                class="flex w-full justify-center rounded-md bg-brand px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                                Search
+                            </button>
+                        </div>
+                    </form>
                 @endif
                 @if($positions)
                     @if(count($positions) == 1)
@@ -90,9 +90,11 @@
                 @if(!$roster)
                     <span>❌ {{ $account->id }} cannot control any UK positions.</span>
                 @endif
-                
+                @if($roster && $roster->restrictionNote)
+                    <span class="text-red-500">❗ {{ $roster->restrictionNote->content }}</span>
+                @endif
             </div>
-            
+
             <div>
                 <a class="text-bold text-blue-500 hover:cursor-pointer" wire:navigate
                 href="{{ route('site.roster.search') }}">Go back</a>

--- a/tests/Feature/Roster/ShowTest.php
+++ b/tests/Feature/Roster/ShowTest.php
@@ -146,4 +146,26 @@ class ShowTest extends TestCase
             ->call('search')
             ->assertSeeTextInOrder(['EGKK_TWR', '\u2705', 'EGKK_APP', '\u274c']);
     }
+
+    public function test_shows_roster_restriction_only_when_exists()
+    {
+        $account = Account::factory()->create();
+        $qualification = Qualification::code('S2')->first();
+        $account->addState(State::findByCode('DIVISION'));
+        $account->addQualification($qualification);
+        $restrictionNote = $account->addNote(
+            \App\Models\Mship\Note\Type::isShortCode('roster')->first(),
+            'Test restriction',
+            auth()->user()
+        );
+
+        Roster::create([
+            'account_id' => $account->id,
+            'restriction_note_id' => $restrictionNote->id,
+        ]);
+
+        Livewire::test(Show::class, ['account' => $account])
+            ->assertDontSee('Search')
+            ->assertSee('Test restriction');
+    }
 }


### PR DESCRIPTION
- Adds new column to roster table to link current restriction note
- Adds new note type 'roster'
- Adds facility to add, edit and remove roster restrictions on account which is on the roster
- Shows the active note on the roster page without the facility to search by position as usual.
