### PR TITLE
Add capacity limits to training waiting lists

### DIFF
--- a/app/Filament/Resources/WaitingListResource.php
+++ b/app/Filament/Resources/WaitingListResource.php
@@ -62,6 +62,12 @@ class WaitingListResource extends Resource
                             ->default(false)
                             ->live(),
 
+                        TextInput::make('max_capacity')
+                            ->label('Maximum Capacity')
+                            ->helperText('Leave empty for unlimited capacity. Set a number to limit how many users can be on this waiting list.')
+                            ->integer()
+                            ->minValue(1),
+
                     ])
                     ->collapsible()
                     ->collapsed(),

--- a/app/Filament/Resources/WaitingListResource/RelationManagers/AccountsRelationManager.php
+++ b/app/Filament/Resources/WaitingListResource/RelationManagers/AccountsRelationManager.php
@@ -174,6 +174,11 @@ class AccountsRelationManager extends RelationManager
         return $this->can('updateAccounts', $this->getOwnerRecord());
     }
 
+    protected function canAttach(): bool
+    {
+        return $this->can('addAccounts', $this->getOwnerRecord());
+    }
+
     protected function canDetach(Model $record): bool
     {
         return $this->can('removeAccount', $this->getOwnerRecord());

--- a/app/Filament/Resources/WaitingListResource/Widgets/IndividualWaitingListOverview.php
+++ b/app/Filament/Resources/WaitingListResource/Widgets/IndividualWaitingListOverview.php
@@ -15,12 +15,14 @@ class IndividualWaitingListOverview extends BaseWidget
     protected function getStats(): array
     {
         $totalAccounts = $this->record->waitingListAccounts()->count();
+        $capacityLimit = $this->record->max_capacity;
 
         $averageWaitTime = $this->record->waitingListAccounts->average(fn ($listAccount) => $listAccount->created_at->diffInDays(now()));
         $longestWaitTime = $this->record->waitingListAccounts->max(fn ($listAccount) => $listAccount->created_at->diffInDays(now()));
 
         return [
             Stat::make('Total accounts', $totalAccounts),
+            Stat::make('Capacity limit', $capacityLimit ?? 'N/A'),
             Stat::make('Longest wait time', $longestWaitTime ? round($longestWaitTime).' days' : 'N/A'),
             Stat::make('Average wait time', $averageWaitTime ? round($averageWaitTime).' days' : 'N/A'),
         ];

--- a/app/Models/Training/WaitingList.php
+++ b/app/Models/Training/WaitingList.php
@@ -324,7 +324,7 @@ class WaitingList extends Model
 
     public function isAtCapacity(): bool
     {
-        if (!$this->hasCapacityLimit()) {
+        if (! $this->hasCapacityLimit()) {
             return false;
         }
 
@@ -333,12 +333,12 @@ class WaitingList extends Model
 
     public function hasSpaceAvailable(): bool
     {
-        return !$this->isAtCapacity();
+        return ! $this->isAtCapacity();
     }
 
     public function getRemainingCapacity(): ?int
     {
-        if (!$this->hasCapacityLimit()) {
+        if (! $this->hasCapacityLimit()) {
             return null;
         }
 

--- a/app/Models/Training/WaitingList.php
+++ b/app/Models/Training/WaitingList.php
@@ -89,7 +89,7 @@ class WaitingList extends Model
 
     public $table = 'training_waiting_list';
 
-    protected $fillable = ['name', 'slug', 'department', 'feature_toggles', 'requires_roster_membership', 'self_enrolment_enabled', 'self_enrolment_minimum_qualification_id', 'self_enrolment_maximum_qualification_id', 'self_enrolment_hours_at_qualification_id', 'self_enrolment_hours_at_qualification_minimum_hours'];
+    protected $fillable = ['name', 'slug', 'department', 'feature_toggles', 'requires_roster_membership', 'self_enrolment_enabled', 'self_enrolment_minimum_qualification_id', 'self_enrolment_maximum_qualification_id', 'self_enrolment_hours_at_qualification_id', 'self_enrolment_hours_at_qualification_minimum_hours', 'max_capacity'];
 
     const ATC_DEPARTMENT = 'atc';
 
@@ -109,6 +109,7 @@ class WaitingList extends Model
         'self_enrolment_maximum_qualification_id' => 'integer',
         'self_enrolment_hours_at_qualification_id' => 'integer',
         'self_enrolment_hours_at_qualification_minimum_hours' => 'integer',
+        'max_capacity' => 'integer',
     ];
 
     /**
@@ -192,6 +193,11 @@ class WaitingList extends Model
      */
     public function addToWaitingList(Account $account, Account $staffAccount, ?Carbon $createdAt = null): WaitingListAccount
     {
+        // Check if the waiting list is at capacity
+        if ($this->isAtCapacity()) {
+            throw new \InvalidArgumentException("Cannot add account to waiting list '{$this->name}' as it has reached its maximum capacity of {$this->max_capacity} users.");
+        }
+
         $timestamp = $createdAt != null ? $createdAt : Carbon::now();
 
         $waitingListAccount = new WaitingListAccount;
@@ -304,6 +310,39 @@ class WaitingList extends Model
     public function hoursAtQualification()
     {
         return $this->belongsTo(\App\Models\Mship\Qualification::class, 'self_enrolment_hours_at_qualification_id');
+    }
+
+    public function hasCapacityLimit(): bool
+    {
+        return $this->max_capacity !== null;
+    }
+
+    public function getCurrentCapacity(): int
+    {
+        return $this->waitingListAccounts()->count();
+    }
+
+    public function isAtCapacity(): bool
+    {
+        if (!$this->hasCapacityLimit()) {
+            return false;
+        }
+
+        return $this->getCurrentCapacity() >= $this->max_capacity;
+    }
+
+    public function hasSpaceAvailable(): bool
+    {
+        return !$this->isAtCapacity();
+    }
+
+    public function getRemainingCapacity(): ?int
+    {
+        if (!$this->hasCapacityLimit()) {
+            return null;
+        }
+
+        return max(0, $this->max_capacity - $this->getCurrentCapacity());
     }
 
     public function __toString()

--- a/app/Policies/Training/WaitingListPolicy.php
+++ b/app/Policies/Training/WaitingListPolicy.php
@@ -24,7 +24,8 @@ class WaitingListPolicy
 
     public function addAccounts(Account $account, WaitingList $waitingList)
     {
-        return $this->checkHasPermissionForList($account, $waitingList, ['waiting-lists.add-accounts.%s']);
+        return ! $waitingList->isAtCapacity() &&
+            $this->checkHasPermissionForList($account, $waitingList, ['waiting-lists.add-accounts.%s']);
     }
 
     public function addAccountsAdmin(Account $account, WaitingList $waitingList)

--- a/app/Services/Training/WaitingListSelfEnrolment.php
+++ b/app/Services/Training/WaitingListSelfEnrolment.php
@@ -29,6 +29,11 @@ class WaitingListSelfEnrolment
             return false;
         }
 
+        // Check if the waiting list is at capacity
+        if ($waitingList->isAtCapacity()) {
+            return false;
+        }
+
         if ($waitingList->requires_roster_membership && ! $account->onRoster()) {
             return false;
         }

--- a/database/migrations/2025_06_29_194053_add_max_capacity_to_training_waiting_list_table.php
+++ b/database/migrations/2025_06_29_194053_add_max_capacity_to_training_waiting_list_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('training_waiting_list', function (Blueprint $table) {
+            $table->unsignedInteger('max_capacity')->nullable()->after('self_enrolment_hours_at_qualification_minimum_hours');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('training_waiting_list', function (Blueprint $table) {
+            $table->dropColumn('max_capacity');
+        });
+    }
+};

--- a/tests/Feature/Account/WaitingListCapacityFeatureTest.php
+++ b/tests/Feature/Account/WaitingListCapacityFeatureTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Feature\Account;
+
+use App\Models\Mship\Account;
+use App\Models\Mship\State;
+use App\Models\Training\WaitingList;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class WaitingListCapacityFeatureTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_shows_success_message_when_self_enrolling_with_space_available()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 5,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        $this->actingAs($account)
+            ->post(route('mship.waiting-lists.self-enrol', $waitingList))
+            ->assertRedirect(route('mship.waiting-lists.index'))
+            ->assertSessionHas('success', 'You have been added to the waiting list.');
+
+        // Verify user was actually added
+        $this->assertTrue($waitingList->includesAccount($account));
+    }
+
+    #[Test]
+    public function it_shows_error_message_when_self_enrolling_at_capacity()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 2,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Fill the waiting list to capacity
+        $account1 = Account::factory()->create();
+        $account2 = Account::factory()->create();
+        $waitingList->addToWaitingList($account1, $this->privacc);
+        $waitingList->addToWaitingList($account2, $this->privacc);
+
+        // When the list is at capacity, the policy should prevent access (403)
+        // This is the correct behavior - capacity limits are enforced at the authorization level
+        $this->actingAs($account)
+            ->post(route('mship.waiting-lists.self-enrol', $waitingList))
+            ->assertStatus(403);
+
+        // Verify user was not added
+        $this->assertFalse($waitingList->includesAccount($account));
+    }
+
+    #[Test]
+    public function it_allows_self_enrollment_when_no_capacity_limit_is_set()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => null, // No limit
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Add many users to test unlimited capacity
+        for ($i = 0; $i < 100; $i++) {
+            $user = Account::factory()->create();
+            $waitingList->addToWaitingList($user, $this->privacc);
+        }
+
+        $this->actingAs($account)
+            ->post(route('mship.waiting-lists.self-enrol', $waitingList))
+            ->assertRedirect(route('mship.waiting-lists.index'))
+            ->assertSessionHas('success', 'You have been added to the waiting list.');
+
+        $this->assertTrue($waitingList->includesAccount($account));
+    }
+
+    #[Test]
+    public function it_displays_capacity_limited_lists_correctly_on_index_page()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        // Create a list with available space
+        $availableList = WaitingList::factory()->create([
+            'name' => 'Available List',
+            'department' => 'atc',
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 5,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Create a list at capacity
+        $fullList = WaitingList::factory()->create([
+            'name' => 'Full List',
+            'department' => 'atc',
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 2,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Fill the second list to capacity
+        $user1 = Account::factory()->create();
+        $user2 = Account::factory()->create();
+        $fullList->addToWaitingList($user1, $this->privacc);
+        $fullList->addToWaitingList($user2, $this->privacc);
+
+        $response = $this->actingAs($account)
+            ->get(route('mship.waiting-lists.index'));
+
+        $response->assertStatus(200);
+
+        // The available list should be shown as enrollable (only lists with space)
+        $atcSelfEnrolmentLists = $response->viewData('atcSelfEnrolmentLists');
+
+        // Filter to only lists that have space available
+        $availableLists = $atcSelfEnrolmentLists->filter(function ($list) {
+            return $list->hasSpaceAvailable();
+        });
+
+        $this->assertGreaterThanOrEqual(1, $availableLists->count());
+        $this->assertTrue($availableLists->contains('id', $availableList->id));
+        $this->assertFalse($availableLists->contains('id', $fullList->id));
+    }
+
+    #[Test]
+    public function it_prevents_enrollment_when_capacity_is_reached_between_page_load_and_submission()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 2,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Add one user initially
+        $account1 = Account::factory()->create();
+        $waitingList->addToWaitingList($account1, $this->privacc);
+
+        // Simulate another user filling the last spot while the first user is on the page
+        $account2 = Account::factory()->create();
+        $waitingList->addToWaitingList($account2, $this->privacc);
+
+        // Now the original user tries to enroll (should be denied by policy - 403)
+        $this->actingAs($account)
+            ->post(route('mship.waiting-lists.self-enrol', $waitingList))
+            ->assertStatus(403);
+
+        $this->assertFalse($waitingList->includesAccount($account));
+    }
+
+    #[Test]
+    public function it_handles_concurrent_enrollment_attempts_gracefully()
+    {
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 1,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        $account1 = Account::factory()->create();
+        $account1->addState(State::findByCode('DIVISION'));
+
+        $account2 = Account::factory()->create();
+        $account2->addState(State::findByCode('DIVISION'));
+
+        // First user enrolls successfully
+        $this->actingAs($account1)
+            ->post(route('mship.waiting-lists.self-enrol', $waitingList))
+            ->assertRedirect(route('mship.waiting-lists.index'))
+            ->assertSessionHas('success');
+
+        // Second user tries to enroll (should be denied by policy due to capacity - 403)
+        $this->actingAs($account2)
+            ->post(route('mship.waiting-lists.self-enrol', $waitingList))
+            ->assertStatus(403);
+
+        // Verify only the first user is on the list
+        $this->assertTrue($waitingList->includesAccount($account1));
+        $this->assertFalse($waitingList->includesAccount($account2));
+        $this->assertEquals(1, $waitingList->getCurrentCapacity());
+    }
+}

--- a/tests/Feature/Admin/WaitingLists/WaitingListCapacityAdminTest.php
+++ b/tests/Feature/Admin/WaitingLists/WaitingListCapacityAdminTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Tests\Feature\Admin\WaitingLists;
+
+use App\Models\Mship\Account;
+use App\Models\Training\WaitingList;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class WaitingListCapacityAdminTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actingAs($this->privacc);
+    }
+
+    #[Test]
+    public function it_can_create_waiting_list_with_capacity_limit()
+    {
+        $waitingListData = [
+            'name' => 'Test Capacity List',
+            'slug' => 'test-capacity-list',
+            'department' => 'atc',
+            'max_capacity' => 10,
+            'requires_roster_membership' => true,
+            'self_enrolment_enabled' => false,
+        ];
+
+        $waitingList = WaitingList::create($waitingListData);
+
+        $this->assertDatabaseHas('training_waiting_list', [
+            'name' => 'Test Capacity List',
+            'max_capacity' => 10,
+        ]);
+
+        $this->assertTrue($waitingList->hasCapacityLimit());
+        $this->assertEquals(10, $waitingList->max_capacity);
+    }
+
+    #[Test]
+    public function it_can_create_waiting_list_without_capacity_limit()
+    {
+        $waitingListData = [
+            'name' => 'Test Unlimited List',
+            'slug' => 'test-unlimited-list',
+            'department' => 'pilot',
+            'max_capacity' => null,
+            'requires_roster_membership' => true,
+            'self_enrolment_enabled' => false,
+        ];
+
+        $waitingList = WaitingList::create($waitingListData);
+
+        $this->assertDatabaseHas('training_waiting_list', [
+            'name' => 'Test Unlimited List',
+            'max_capacity' => null,
+        ]);
+
+        $this->assertFalse($waitingList->hasCapacityLimit());
+    }
+
+    #[Test]
+    public function it_can_update_waiting_list_capacity()
+    {
+        $waitingList = WaitingList::factory()->create([
+            'max_capacity' => null,
+        ]);
+
+        // Update to add capacity limit
+        $waitingList->update(['max_capacity' => 15]);
+
+        $this->assertDatabaseHas('training_waiting_list', [
+            'id' => $waitingList->id,
+            'max_capacity' => 15,
+        ]);
+
+        $this->assertTrue($waitingList->fresh()->hasCapacityLimit());
+
+        // Update to remove capacity limit
+        $waitingList->update(['max_capacity' => null]);
+
+        $this->assertDatabaseHas('training_waiting_list', [
+            'id' => $waitingList->id,
+            'max_capacity' => null,
+        ]);
+
+        $this->assertFalse($waitingList->fresh()->hasCapacityLimit());
+    }
+
+    #[Test]
+    public function it_prevents_admin_from_adding_users_when_at_capacity()
+    {
+        $waitingList = WaitingList::factory()->create([
+            'max_capacity' => 2,
+        ]);
+
+        // Fill to capacity
+        $account1 = Account::factory()->create();
+        $account2 = Account::factory()->create();
+        $waitingList->addToWaitingList($account1, $this->privacc);
+        $waitingList->addToWaitingList($account2, $this->privacc);
+
+        // Try to add another user via admin
+        $account3 = Account::factory()->create();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maximum capacity of 2 users');
+
+        $waitingList->addToWaitingList($account3, $this->privacc);
+    }
+
+    #[Test]
+    public function it_allows_admin_to_add_users_when_below_capacity()
+    {
+        $waitingList = WaitingList::factory()->create([
+            'max_capacity' => 5,
+        ]);
+
+        // Add 3 users (below capacity)
+        for ($i = 0; $i < 3; $i++) {
+            $account = Account::factory()->create();
+            $waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        $this->assertEquals(3, $waitingList->getCurrentCapacity());
+        $this->assertFalse($waitingList->isAtCapacity());
+
+        // Should be able to add another user
+        $account = Account::factory()->create();
+        $waitingList->addToWaitingList($account, $this->privacc);
+
+        $this->assertEquals(4, $waitingList->getCurrentCapacity());
+        $this->assertTrue($waitingList->includesAccount($account));
+    }
+
+    #[Test]
+    public function it_correctly_calculates_capacity_info_for_admin_display()
+    {
+        $waitingList = WaitingList::factory()->create([
+            'max_capacity' => 10,
+        ]);
+
+        // Test empty list
+        $this->assertEquals(0, $waitingList->getCurrentCapacity());
+        $this->assertEquals(10, $waitingList->getRemainingCapacity());
+
+        // Add some users
+        for ($i = 0; $i < 7; $i++) {
+            $account = Account::factory()->create();
+            $waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        $this->assertEquals(7, $waitingList->getCurrentCapacity());
+        $this->assertEquals(3, $waitingList->getRemainingCapacity());
+        $this->assertFalse($waitingList->isAtCapacity());
+
+        // Fill to capacity
+        for ($i = 0; $i < 3; $i++) {
+            $account = Account::factory()->create();
+            $waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        $this->assertEquals(10, $waitingList->getCurrentCapacity());
+        $this->assertEquals(0, $waitingList->getRemainingCapacity());
+        $this->assertTrue($waitingList->isAtCapacity());
+    }
+
+    #[Test]
+    public function it_handles_capacity_validation_when_editing_existing_list()
+    {
+        $waitingList = WaitingList::factory()->create([
+            'max_capacity' => null, // Start unlimited
+        ]);
+
+        // Add 5 users
+        for ($i = 0; $i < 5; $i++) {
+            $account = Account::factory()->create();
+            $waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        // Update capacity to be less than current users
+        $waitingList->update(['max_capacity' => 3]);
+
+        // List should be considered at capacity
+        $this->assertTrue($waitingList->isAtCapacity());
+        $this->assertEquals(0, $waitingList->getRemainingCapacity());
+
+        // Should not be able to add more users
+        $account = Account::factory()->create();
+        $this->expectException(\InvalidArgumentException::class);
+        $waitingList->addToWaitingList($account, $this->privacc);
+    }
+
+    #[Test]
+    public function it_allows_removing_users_from_capacity_limited_list()
+    {
+        $waitingList = WaitingList::factory()->create([
+            'max_capacity' => 2,
+        ]);
+
+        // Fill to capacity
+        $account1 = Account::factory()->create();
+        $account2 = Account::factory()->create();
+        $waitingList->addToWaitingList($account1, $this->privacc);
+        $waitingList->addToWaitingList($account2, $this->privacc);
+
+        $this->assertTrue($waitingList->isAtCapacity());
+
+        // Remove one user
+        $removal = new \App\Models\Training\WaitingList\Removal(
+            \App\Models\Training\WaitingList\RemovalReason::TrainingPlace,
+            $this->privacc->id
+        );
+        $waitingList->removeFromWaitingList($account1, $removal);
+
+        // Should now have space available
+        $this->assertFalse($waitingList->isAtCapacity());
+        $this->assertEquals(1, $waitingList->getCurrentCapacity());
+        $this->assertEquals(1, $waitingList->getRemainingCapacity());
+
+        // Should be able to add another user
+        $account3 = Account::factory()->create();
+        $waitingList->addToWaitingList($account3, $this->privacc);
+
+        $this->assertTrue($waitingList->isAtCapacity());
+    }
+
+    #[Test]
+    public function it_validates_minimum_capacity_value()
+    {
+        $waitingList = WaitingList::factory()->create();
+
+        // The max_capacity field accepts null or positive integers
+        // Setting to 0 should be allowed (though not practical)
+        $waitingList->update(['max_capacity' => 0]);
+        $this->assertEquals(0, $waitingList->max_capacity);
+
+        // Setting to null should be allowed (unlimited)
+        $waitingList->update(['max_capacity' => null]);
+        $this->assertNull($waitingList->max_capacity);
+
+        // Setting to positive integer should be allowed
+        $waitingList->update(['max_capacity' => 10]);
+        $this->assertEquals(10, $waitingList->max_capacity);
+    }
+}

--- a/tests/Unit/Training/WaitingList/WaitingListCapacityTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListCapacityTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Tests\Unit\Training\WaitingList;
+
+use App\Models\Mship\Account;
+use App\Models\Training\WaitingList;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class WaitingListCapacityTest extends TestCase
+{
+    use DatabaseTransactions, WaitingListTestHelper;
+
+    private WaitingList $waitingList;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->waitingList = $this->createList();
+        $this->actingAs($this->privacc);
+    }
+
+    #[Test]
+    public function it_has_no_capacity_limit_by_default()
+    {
+        $this->assertFalse($this->waitingList->hasCapacityLimit());
+        $this->assertNull($this->waitingList->max_capacity);
+    }
+
+    #[Test]
+    public function it_can_set_a_capacity_limit()
+    {
+        $this->waitingList->update(['max_capacity' => 5]);
+
+        $this->assertTrue($this->waitingList->hasCapacityLimit());
+        $this->assertEquals(5, $this->waitingList->max_capacity);
+    }
+
+    #[Test]
+    public function it_returns_current_capacity_correctly()
+    {
+        $this->assertEquals(0, $this->waitingList->getCurrentCapacity());
+
+        // Add some users
+        $account1 = Account::factory()->create();
+        $account2 = Account::factory()->create();
+
+        $this->waitingList->addToWaitingList($account1, $this->privacc);
+        $this->assertEquals(1, $this->waitingList->getCurrentCapacity());
+
+        $this->waitingList->addToWaitingList($account2, $this->privacc);
+        $this->assertEquals(2, $this->waitingList->getCurrentCapacity());
+    }
+
+    #[Test]
+    public function it_is_not_at_capacity_when_no_limit_is_set()
+    {
+        // Add many users to a list with no capacity limit
+        for ($i = 0; $i < 10; $i++) {
+            $account = Account::factory()->create();
+            $this->waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        $this->assertFalse($this->waitingList->isAtCapacity());
+        $this->assertTrue($this->waitingList->hasSpaceAvailable());
+        $this->assertNull($this->waitingList->getRemainingCapacity());
+    }
+
+    #[Test]
+    public function it_is_not_at_capacity_when_below_limit()
+    {
+        $this->waitingList->update(['max_capacity' => 5]);
+
+        // Add 3 users
+        for ($i = 0; $i < 3; $i++) {
+            $account = Account::factory()->create();
+            $this->waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        $this->assertFalse($this->waitingList->isAtCapacity());
+        $this->assertTrue($this->waitingList->hasSpaceAvailable());
+        $this->assertEquals(2, $this->waitingList->getRemainingCapacity());
+    }
+
+    #[Test]
+    public function it_is_at_capacity_when_limit_is_reached()
+    {
+        $this->waitingList->update(['max_capacity' => 3]);
+
+        // Add exactly 3 users
+        for ($i = 0; $i < 3; $i++) {
+            $account = Account::factory()->create();
+            $this->waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        $this->assertTrue($this->waitingList->isAtCapacity());
+        $this->assertFalse($this->waitingList->hasSpaceAvailable());
+        $this->assertEquals(0, $this->waitingList->getRemainingCapacity());
+    }
+
+    #[Test]
+    public function it_throws_exception_when_trying_to_add_user_at_capacity()
+    {
+        $this->waitingList->update(['max_capacity' => 2]);
+
+        // Fill the waiting list to capacity
+        $account1 = Account::factory()->create();
+        $account2 = Account::factory()->create();
+        $this->waitingList->addToWaitingList($account1, $this->privacc);
+        $this->waitingList->addToWaitingList($account2, $this->privacc);
+
+        // Try to add one more user
+        $account3 = Account::factory()->create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Cannot add account to waiting list '{$this->waitingList->name}' as it has reached its maximum capacity of 2 users.");
+
+        $this->waitingList->addToWaitingList($account3, $this->privacc);
+    }
+
+    #[Test]
+    public function it_can_add_users_after_removing_someone_from_capacity_limited_list()
+    {
+        $this->waitingList->update(['max_capacity' => 2]);
+
+        // Fill the waiting list to capacity
+        $account1 = Account::factory()->create();
+        $account2 = Account::factory()->create();
+        $this->waitingList->addToWaitingList($account1, $this->privacc);
+        $this->waitingList->addToWaitingList($account2, $this->privacc);
+
+        $this->assertTrue($this->waitingList->isAtCapacity());
+
+        // Remove one user
+        $removal = new \App\Models\Training\WaitingList\Removal(
+            \App\Models\Training\WaitingList\RemovalReason::TrainingPlace,
+            $this->privacc->id
+        );
+        $this->waitingList->removeFromWaitingList($account1, $removal);
+
+        $this->assertFalse($this->waitingList->isAtCapacity());
+        $this->assertEquals(1, $this->waitingList->getRemainingCapacity());
+
+        // Now we can add another user
+        $account3 = Account::factory()->create();
+        $this->waitingList->addToWaitingList($account3, $this->privacc);
+
+        $this->assertTrue($this->waitingList->isAtCapacity());
+    }
+
+    #[Test]
+    public function it_handles_capacity_correctly_when_capacity_is_updated()
+    {
+        // Start with no capacity limit and add 5 users
+        for ($i = 0; $i < 5; $i++) {
+            $account = Account::factory()->create();
+            $this->waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        $this->assertEquals(5, $this->waitingList->getCurrentCapacity());
+        $this->assertFalse($this->waitingList->isAtCapacity());
+
+        // Set capacity limit to 3 (below current count)
+        $this->waitingList->update(['max_capacity' => 3]);
+
+        // List should now be over capacity
+        $this->assertTrue($this->waitingList->isAtCapacity());
+        $this->assertEquals(0, $this->waitingList->getRemainingCapacity());
+
+        // Should not be able to add more users
+        $account = Account::factory()->create();
+        $this->expectException(InvalidArgumentException::class);
+        $this->waitingList->addToWaitingList($account, $this->privacc);
+    }
+
+    #[Test]
+    public function it_returns_correct_remaining_capacity()
+    {
+        $this->waitingList->update(['max_capacity' => 10]);
+
+        $this->assertEquals(10, $this->waitingList->getRemainingCapacity());
+
+        // Add 3 users
+        for ($i = 0; $i < 3; $i++) {
+            $account = Account::factory()->create();
+            $this->waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        $this->assertEquals(7, $this->waitingList->getRemainingCapacity());
+
+        // Add 7 more users to reach capacity
+        for ($i = 0; $i < 7; $i++) {
+            $account = Account::factory()->create();
+            $this->waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        $this->assertEquals(0, $this->waitingList->getRemainingCapacity());
+    }
+
+    #[Test]
+    public function it_returns_zero_remaining_capacity_when_over_capacity()
+    {
+        // Add 5 users first
+        for ($i = 0; $i < 5; $i++) {
+            $account = Account::factory()->create();
+            $this->waitingList->addToWaitingList($account, $this->privacc);
+        }
+
+        // Then set capacity to 3 (below current count)
+        $this->waitingList->update(['max_capacity' => 3]);
+
+        // Should return 0, not negative
+        $this->assertEquals(0, $this->waitingList->getRemainingCapacity());
+    }
+}

--- a/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentCapacityTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentCapacityTest.php
@@ -123,7 +123,7 @@ class WaitingListSelfEnrolmentCapacityTest extends TestCase
 
         // Remove one user to free up space
         $removal = new \App\Models\Training\WaitingList\Removal(
-            \App\Models\Training\WaitingList\RemovalReason::TRANSFERRED_TO_TRAINING,
+            \App\Models\Training\WaitingList\RemovalReason::TrainingPlace,
             $this->privacc->id
         );
         $waitingList->removeFromWaitingList($account1, $removal);

--- a/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentCapacityTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentCapacityTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Unit\Training\WaitingList;
+
+use App\Models\Mship\Account;
+use App\Models\Mship\State;
+use App\Models\Training\WaitingList;
+use App\Services\Training\WaitingListSelfEnrolment;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class WaitingListSelfEnrolmentCapacityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_prevents_self_enrollment_when_at_capacity()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 2,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Fill the waiting list to capacity
+        $account1 = Account::factory()->create();
+        $account2 = Account::factory()->create();
+        $waitingList->addToWaitingList($account1, $this->privacc);
+        $waitingList->addToWaitingList($account2, $this->privacc);
+
+        // Account should not be able to self-enroll
+        $this->assertFalse(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+
+        // List should not appear in available lists for self-enrollment
+        $availableLists = WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($account);
+        $this->assertEmpty($availableLists);
+    }
+
+    #[Test]
+    public function it_allows_self_enrollment_when_below_capacity()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 3,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Add only 1 user (below capacity of 3)
+        $account1 = Account::factory()->create();
+        $waitingList->addToWaitingList($account1, $this->privacc);
+
+        // Account should be able to self-enroll
+        $this->assertTrue(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+
+        // List should appear in available lists for self-enrollment
+        $availableLists = WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($account);
+        $this->assertCount(1, $availableLists);
+        $this->assertEquals($waitingList->id, $availableLists->first()->id);
+    }
+
+    #[Test]
+    public function it_allows_self_enrollment_when_no_capacity_limit()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => null, // No capacity limit
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Add many users to the list
+        for ($i = 0; $i < 10; $i++) {
+            $user = Account::factory()->create();
+            $waitingList->addToWaitingList($user, $this->privacc);
+        }
+
+        // Account should still be able to self-enroll
+        $this->assertTrue(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+
+        // List should appear in available lists for self-enrollment
+        $availableLists = WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($account);
+        $this->assertCount(1, $availableLists);
+    }
+
+    #[Test]
+    public function it_dynamically_updates_available_lists_as_capacity_changes()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 2,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Initially, list should be available
+        $availableLists = WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($account);
+        $this->assertCount(1, $availableLists);
+
+        // Fill to capacity
+        $account1 = Account::factory()->create();
+        $account2 = Account::factory()->create();
+        $waitingList->addToWaitingList($account1, $this->privacc);
+        $waitingList->addToWaitingList($account2, $this->privacc);
+
+        // Now list should not be available
+        $availableLists = WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($account);
+        $this->assertEmpty($availableLists);
+
+        // Remove one user to free up space
+        $removal = new \App\Models\Training\WaitingList\Removal(
+            \App\Models\Training\WaitingList\RemovalReason::TRANSFERRED_TO_TRAINING,
+            $this->privacc->id
+        );
+        $waitingList->removeFromWaitingList($account1, $removal);
+
+        // List should be available again
+        $availableLists = WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($account);
+        $this->assertCount(1, $availableLists);
+    }
+
+    #[Test]
+    public function it_filters_capacity_limited_lists_correctly_with_multiple_lists()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        // Create multiple waiting lists with different capacity situations
+        $fullList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 1,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        $availableList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => 3,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        $unlimitedList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'max_capacity' => null,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+
+        // Fill the first list to capacity
+        $user1 = Account::factory()->create();
+        $fullList->addToWaitingList($user1, $this->privacc);
+
+        // Add one user to the available list (still has space)
+        $user2 = Account::factory()->create();
+        $availableList->addToWaitingList($user2, $this->privacc);
+
+        // Account should only see the available and unlimited lists
+        $availableLists = WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($account);
+        $this->assertCount(2, $availableLists);
+
+        $listIds = $availableLists->pluck('id')->toArray();
+        $this->assertContains($availableList->id, $listIds);
+        $this->assertContains($unlimitedList->id, $listIds);
+        $this->assertNotContains($fullList->id, $listIds);
+    }
+}


### PR DESCRIPTION
Introduces a max_capacity field to training waiting lists, including migration, model logic, admin UI, and enforcement in self-enrolment and manual addition. Adds comprehensive feature and unit tests to verify capacity enforcement, admin management, and self-enrolment behavior.

Fixes TECH-379.