### PR TITLE
Fixes #4181 - Add ISLAND_CTR to positions in military endorsement contents

### DIFF
--- a/resources/views/site/atc/endorsements.blade.php
+++ b/resources/views/site/atc/endorsements.blade.php
@@ -289,6 +289,7 @@
                         <li>RAF Ascension Island (FHAW)</li>
                         <li>EGVV_CTR - 133.900 - Swanwick Military - Covers military activity in both EGTT and EGPX, as well as top-down control for Military airfields</li>
                         <li>EGVV_x_CTR - Swanwick Military - Various other splits, as outlined in <a href="https://community.vatsim.uk/topic/37499-2020-12-03-swanwick-mil-sectorisation-and-frequency-change/">this procedure change post</a>.</li>
+                        <li>ISLAND_CTR - Island Radar - Provides radar services to aircraft within the Falklands Control Zone, and top-down control for EGYP.</li>
                     </ul>
 
                     <h3>Requirements</h3>


### PR DESCRIPTION
Fixes #4181 

# Summary of changes

Add ISLAND_CTR (including brief description) to the 'Airfields/Sectors Offered' subsection of the Military endorsements section.