### PR TITLE
Fixes #4179 - Tier endorsements list in the admin panel should be sorted by name

### DIFF
--- a/app/Filament/Resources/PositionGroupResource.php
+++ b/app/Filament/Resources/PositionGroupResource.php
@@ -34,7 +34,8 @@ class PositionGroupResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('name')->label('Name'),
+                Tables\Columns\TextColumn::make('name')->label('Name')
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('membership_endorsement_count')
                     ->label('Endorsed')
                     ->counts('membershipEndorsement'),
@@ -42,7 +43,8 @@ class PositionGroupResource extends Resource
             ->defaultSort('name')
             ->actions([
                 Tables\Actions\ViewAction::make(),
-            ]);
+            ])
+            ->defaultSort('name', 'desc');
     }
 
     public static function getRelations(): array


### PR DESCRIPTION
Fixes #4179

# Summary of changes
Added the ability to sort by the ```Name``` column
Set the default sorting order to sort by ```Name``` descending

# Screenshots (if necessary)
![image](https://github.com/user-attachments/assets/730bb447-5524-43df-9bb9-b1b0125ca637)