### PR TITLE
Fixes #4186 - Add ability to copy email from account in admin panel

### DIFF
--- a/app/Filament/Resources/AccountResource.php
+++ b/app/Filament/Resources/AccountResource.php
@@ -80,16 +80,15 @@ class AccountResource extends Resource implements DefinesGatedAttributes
 
                     Forms\Components\Fieldset::make('Emails')->schema([
                         Forms\Components\TextInput::make('email')
-            ->label('Primary Email')
-            ->disabled()
-            ->suffixAction(
-                Forms\Components\Actions\Action::make('copy')
-                    ->icon('heroicon-m-clipboard')
-                    ->tooltip('Copy')
-                    ->action(fn ($record, $livewire) => 
-                        $livewire->js('navigator.clipboard.writeText("'.$record->email.'")')
-                    )
-            ),
+                            ->label('Primary Email')
+                            ->disabled()
+                            ->suffixAction(
+                                Forms\Components\Actions\Action::make('copy')
+                                    ->icon('heroicon-m-clipboard')
+                                    ->tooltip('Copy')
+                                    ->action(fn ($record, $livewire) => $livewire->js('navigator.clipboard.writeText("'.$record->email.'")')
+                                    )
+                            ),
 
                         Forms\Components\Repeater::make('secondaryEmails')
                             ->relationship()

--- a/app/Filament/Resources/AccountResource.php
+++ b/app/Filament/Resources/AccountResource.php
@@ -14,7 +14,6 @@ use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
-use Filament\Forms\Components\Actions\Action;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;

--- a/app/Filament/Resources/AccountResource.php
+++ b/app/Filament/Resources/AccountResource.php
@@ -14,6 +14,7 @@ use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Forms\Components\Actions\Action;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
@@ -79,10 +80,13 @@ class AccountResource extends Resource implements DefinesGatedAttributes
                     Forms\Components\Placeholder::make('roster_status')->label('Roster Status')->content(fn ($record) => Roster::where('account_id', $record->id)->exists() ? 'Active' : 'Inactive'),
 
                     Forms\Components\Fieldset::make('Emails')->schema([
-                        Forms\Components\TextInput::make('email')
+                        CopyablePlaceholder::make('email')
                             ->label('Primary Email')
-                            ->required()
-                            ->disabled(),
+                            ->iconOnly()
+                            ->content(fn ($record) => $record->email)
+                            ->extraAttributes([
+                                'class' => 'flex items-center space-x-2',
+                            ]),
 
                         Forms\Components\Repeater::make('secondaryEmails')
                             ->relationship()

--- a/app/Filament/Resources/AccountResource.php
+++ b/app/Filament/Resources/AccountResource.php
@@ -79,13 +79,17 @@ class AccountResource extends Resource implements DefinesGatedAttributes
                     Forms\Components\Placeholder::make('roster_status')->label('Roster Status')->content(fn ($record) => Roster::where('account_id', $record->id)->exists() ? 'Active' : 'Inactive'),
 
                     Forms\Components\Fieldset::make('Emails')->schema([
-                        CopyablePlaceholder::make('email')
-                            ->label('Primary Email')
-                            ->iconOnly()
-                            ->content(fn ($record) => $record->email)
-                            ->extraAttributes([
-                                'class' => 'flex items-center space-x-2',
-                            ]),
+                        Forms\Components\TextInput::make('email')
+            ->label('Primary Email')
+            ->disabled()
+            ->suffixAction(
+                Forms\Components\Actions\Action::make('copy')
+                    ->icon('heroicon-m-clipboard')
+                    ->tooltip('Copy')
+                    ->action(fn ($record, $livewire) => 
+                        $livewire->js('navigator.clipboard.writeText("'.$record->email.'")')
+                    )
+            ),
 
                         Forms\Components\Repeater::make('secondaryEmails')
                             ->relationship()

--- a/resources/views/site/atc/endorsements.blade.php
+++ b/resources/views/site/atc/endorsements.blade.php
@@ -289,6 +289,7 @@
                         <li>RAF Ascension Island (FHAW)</li>
                         <li>EGVV_CTR - 133.900 - Swanwick Military - Covers military activity in both EGTT and EGPX, as well as top-down control for Military airfields</li>
                         <li>EGVV_x_CTR - Swanwick Military - Various other splits, as outlined in <a href="https://community.vatsim.uk/topic/37499-2020-12-03-swanwick-mil-sectorisation-and-frequency-change/">this procedure change post</a>.</li>
+                        <li>ISLAND_CTR - Island Radar - Provides radar services to aircraft within the Falklands Control Zone, and top-down control for EGYP.</li>
                     </ul>
 
                     <h3>Requirements</h3>


### PR DESCRIPTION
Fixes #4186

# Summary of changes
Made ```Primary Email``` a ```CopyablePlaceholder```, this will mean it is no longer a ```form field```, this means it is read only. Let me know if the ```Primary Email``` has to remain as a text input specifically. I've made the formatting match the copying option from the ```CID``` field at the top of the same page for consistency.

# Screenshots (if necessary)
![image](https://github.com/user-attachments/assets/4826a46b-b748-4342-9b47-49c783a115c0)