### PR TITLE
TECH-392 Hide duration for permanent endorsements

### DIFF
--- a/app/Filament/Resources/AccountResource/RelationManagers/EndorsementsRelationManager.php
+++ b/app/Filament/Resources/AccountResource/RelationManagers/EndorsementsRelationManager.php
@@ -14,6 +14,7 @@ use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
+use Illuminate\Database\Query\Builder;
 
 class EndorsementsRelationManager extends RelationManager
 {
@@ -58,7 +59,8 @@ class EndorsementsRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('created_at')->label('Granted')->date(),
                 Tables\Columns\TextColumn::make('expires_at')->label('Expires')->date()->default(''),
                 Tables\Columns\TextColumn::make('duration')->label('Duration (Days)')
-                    ->summarize(Sum::make()->label('Days')->numeric()),
+                    ->summarize(Sum::make()->hidden(fn (\Illuminate\Database\Eloquent\Builder $query): bool => ! $query->exists())
+                    ->label('Total Duration')),
             ])
             ->headerActions([
                 // Tables\Actions\CreateAction::make()->label('Add endorsement'),

--- a/app/Filament/Resources/AccountResource/RelationManagers/EndorsementsRelationManager.php
+++ b/app/Filament/Resources/AccountResource/RelationManagers/EndorsementsRelationManager.php
@@ -14,6 +14,7 @@ use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class EndorsementsRelationManager extends RelationManager
 {
@@ -58,7 +59,7 @@ class EndorsementsRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('created_at')->label('Granted')->date(),
                 Tables\Columns\TextColumn::make('expires_at')->label('Expires')->date()->default(''),
                 Tables\Columns\TextColumn::make('duration')->label('Duration (Days)')
-                    ->summarize(Sum::make()->hidden(fn (\Illuminate\Database\Eloquent\Builder $query): bool => ! $query->exists())
+                    ->summarize(Sum::make()->hidden(fn (Builder $query): bool => ! $query->exists())
                         ->label('Total Duration')),
             ])
             ->headerActions([

--- a/app/Filament/Resources/AccountResource/RelationManagers/EndorsementsRelationManager.php
+++ b/app/Filament/Resources/AccountResource/RelationManagers/EndorsementsRelationManager.php
@@ -14,7 +14,6 @@ use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
-use Illuminate\Database\Query\Builder;
 
 class EndorsementsRelationManager extends RelationManager
 {
@@ -60,7 +59,7 @@ class EndorsementsRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('expires_at')->label('Expires')->date()->default(''),
                 Tables\Columns\TextColumn::make('duration')->label('Duration (Days)')
                     ->summarize(Sum::make()->hidden(fn (\Illuminate\Database\Eloquent\Builder $query): bool => ! $query->exists())
-                    ->label('Total Duration')),
+                        ->label('Total Duration')),
             ])
             ->headerActions([
                 // Tables\Actions\CreateAction::make()->label('Add endorsement'),


### PR DESCRIPTION
Fixes TECH-392

# Summary of changes

Permanent/unexpired endorsements now have hidden duration. Duration is only shown for endorsements with set expiry.

# Screenshots (if necessary)

![image](https://github.com/user-attachments/assets/4f19b5ee-aa0a-4292-9252-2f820aa7d2ed)