### PR TITLE
fix: Return management bot name to something friendly

### DIFF
--- a/app/Console/Commands/TeamSpeak/TeamSpeakDaemon.php
+++ b/app/Console/Commands/TeamSpeak/TeamSpeakDaemon.php
@@ -109,7 +109,7 @@ class TeamSpeakDaemon extends TeamSpeakCommand
     {
         try {
             // establish connection
-            $connection = TeamSpeak::run("vUK Management Bot", true);
+            $connection = TeamSpeak::run('vUK Management Bot', true);
 
             // register for events
             $connection->notifyRegister('server');

--- a/app/Console/Commands/TeamSpeak/TeamSpeakDaemon.php
+++ b/app/Console/Commands/TeamSpeak/TeamSpeakDaemon.php
@@ -108,9 +108,8 @@ class TeamSpeakDaemon extends TeamSpeakCommand
     protected function establishConnection($attempt = 1)
     {
         try {
-            $id = uniqid();
             // establish connection
-            $connection = TeamSpeak::run("teaman $id", true);
+            $connection = TeamSpeak::run("vUK Management Bot", true);
 
             // register for events
             $connection->notifyRegister('server');


### PR DESCRIPTION
Fixes TEXT-399

# Summary of changes

Letters and numbers are scary and we don't want to scare people
