### PR TITLE
Fixes #4193 - Instant search result navigation for account search

### DIFF
--- a/app/Filament/Admin/Resources/AccountResource/Pages/ListAccounts.php
+++ b/app/Filament/Admin/Resources/AccountResource/Pages/ListAccounts.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources\AccountResource\Pages;
 
 use App\Filament\Admin\Helpers\Pages\BaseListRecordsPage;
 use App\Filament\Admin\Resources\AccountResource;
+use App\Models\Mship\Account;
 
 class ListAccounts extends BaseListRecordsPage
 {
@@ -12,5 +13,19 @@ class ListAccounts extends BaseListRecordsPage
     protected function getHeaderActions(): array
     {
         return [];
+    }
+
+    public function updatedTableSearch(): void
+    {
+        $search = $this->getTableSearch();
+
+        $match = Account::query()
+            ->where('id', 'like', "%{$search}%")
+            ->limit(2)
+            ->get();
+
+        if ($match->count() === 1) {
+            $this->redirect(AccountResource::getUrl('view', ['record' => $match->first()]));
+        }
     }
 }


### PR DESCRIPTION
Fixes #4193

# Summary of changes
When searching with a CID on the accounts page of the admin panel, when there is one result it navigates you straight to that member.

# Screenshots (if necessary)

https://github.com/user-attachments/assets/d3be5ce9-dc2d-4d9c-b17f-ddd3643cd762

Wasn't sure how to show this as a screenshot so I figured a short video would be best.