### PR TITLE
Fixes #4198 - Sort member feedback in accounts view by most recent first

### DIFF
--- a/app/Filament/Admin/Resources/AccountResource/Pages/ListAccounts.php
+++ b/app/Filament/Admin/Resources/AccountResource/Pages/ListAccounts.php
@@ -14,18 +14,4 @@ class ListAccounts extends BaseListRecordsPage
     {
         return [];
     }
-
-    public function updatedTableSearch(): void
-    {
-        $search = $this->getTableSearch();
-
-        $match = Account::query()
-            ->where('id', 'like', "%{$search}%")
-            ->limit(2)
-            ->get();
-
-        if ($match->count() === 1) {
-            $this->redirect(AccountResource::getUrl('view', ['record' => $match->first()]));
-        }
-    }
 }

--- a/app/Filament/Admin/Resources/AccountResource/Pages/ListAccounts.php
+++ b/app/Filament/Admin/Resources/AccountResource/Pages/ListAccounts.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources\AccountResource\Pages;
 
 use App\Filament\Admin\Helpers\Pages\BaseListRecordsPage;
 use App\Filament\Admin\Resources\AccountResource;
+use App\Models\Mship\Account;
 
 class ListAccounts extends BaseListRecordsPage
 {
@@ -12,5 +13,19 @@ class ListAccounts extends BaseListRecordsPage
     protected function getHeaderActions(): array
     {
         return [];
+    }
+
+    public function updatedTableSearch(): void
+    {
+        $search = $this->getTableSearch();
+
+        $match = Account::query()
+            ->where('id', 'like', "%{$search}%")
+            ->limit(2)
+            ->get();
+
+        if ($match->count() === 1) {
+            $this->redirect(AccountResource::getUrl('view', ['record' => $match->first()]));
+        }
     }
 }

--- a/app/Filament/Admin/Resources/AccountResource/Pages/ListAccounts.php
+++ b/app/Filament/Admin/Resources/AccountResource/Pages/ListAccounts.php
@@ -4,7 +4,6 @@ namespace App\Filament\Admin\Resources\AccountResource\Pages;
 
 use App\Filament\Admin\Helpers\Pages\BaseListRecordsPage;
 use App\Filament\Admin\Resources\AccountResource;
-use App\Models\Mship\Account;
 
 class ListAccounts extends BaseListRecordsPage
 {

--- a/app/Filament/Admin/Resources/AccountResource/RelationManagers/FeedbackRelationManager.php
+++ b/app/Filament/Admin/Resources/AccountResource/RelationManagers/FeedbackRelationManager.php
@@ -23,6 +23,7 @@ class FeedbackRelationManager extends RelationManager
             ])
             ->actions([
                 Tables\Actions\ViewAction::make()->resource(FeedbackResource::class),
-            ]);
+            ])
+            ->defaultSort('created_at', 'desc');
     }
 }


### PR DESCRIPTION
Fixes #4198 

# Summary of changes
Change default sorting order to descending by the date the feedback was created.

# Screenshots (if necessary)
![image](https://github.com/user-attachments/assets/4d82ff8d-33c0-41cc-aeb4-7a7a5d428923)
