### PR TITLE
Add missing csrf to vt-application start

### DIFF
--- a/resources/views/visit-transfer/site/application/terms.blade.php
+++ b/resources/views/visit-transfer/site/application/terms.blade.php
@@ -15,6 +15,7 @@
                     </p>
 
                 <form action="{{ route('visiting.application.start.post', [$applicationType, $trainingTeam]) }}" method="POST">
+                    @csrf
                     <div class="col-md-10 col-md-offset-1">
                         <div class="form-group">
                             <input id="terms_read" name="terms_read" type="checkbox" value="1">


### PR DESCRIPTION
Fixes *nil*

# Summary of changes

Add a missing csrf token to the form
Application now properly redirects to `visit-transfer/application/<id>/facility`