### PR TITLE
Update to state TeamSpeak 3 client required

### DIFF
--- a/resources/views/site/community/teamspeak.blade.php
+++ b/resources/views/site/community/teamspeak.blade.php
@@ -249,8 +249,8 @@
 
                 <ol>
                     <li>
-                        Go to the&nbsp;<a href="http://www.teamspeak.com/" rel="external nofollow" target="_blank">TeamSpeak
-                            website</a>&nbsp;and download the latest client appropriate for your operating system.
+                        Go to the&nbsp;<a href="https://teamspeak.com/en/downloads/#ts3client" rel="external nofollow" target="_blank">TeamSpeak
+                            website</a>&nbsp;and download the latest TeamSpeak 3 client appropriate for your operating system.
                     </li>
                 </ol>
 


### PR DESCRIPTION
# Summary of changes

Update the TeamSpeak registration page to state that TeamSpeak 3 is required for registration as TeamSpeak 6 does not have the ability to register via one time privilege key.

# Screenshots (if necessary)

Before:
<img width="415" height="177" alt="image" src="https://github.com/user-attachments/assets/5fb2bed3-6358-42cf-9c32-61e44e6e85de" />

After:
<img width="419" height="194" alt="image" src="https://github.com/user-attachments/assets/204e3989-c73c-4360-b60c-30d0bcfc8e2b" />
