### PR TITLE
Start ignoring old CTS retention checks

### DIFF
--- a/app/Console/Commands/Training/WaitingListRetentionChecks.php
+++ b/app/Console/Commands/Training/WaitingListRetentionChecks.php
@@ -30,6 +30,7 @@ class WaitingListRetentionChecks extends Command
     {
         $recordsToRemove = WaitingListWaitingListRetentionChecks::query()
             ->where('expires_at', '<', now())
+            ->where('email_sent_at', '>=', now()->subMonths(6)->subDay())
             ->where('status', WaitingListWaitingListRetentionChecks::STATUS_PENDING)
             ->get();
 
@@ -39,6 +40,7 @@ class WaitingListRetentionChecks extends Command
 
         $recodsToSend = WaitingListWaitingListRetentionChecks::query()
             ->where('email_sent_at', '<', now()->subMonths(3))
+            ->where('email_sent_at', '>=', now()->subMonths(6)->subDay())
             ->get();
 
         foreach ($recodsToSend as $record) {

--- a/app/Jobs/Training/WaitingListRetentionEmail.php
+++ b/app/Jobs/Training/WaitingListRetentionEmail.php
@@ -38,6 +38,12 @@ class WaitingListRetentionEmail implements ShouldQueue
     public function handle()
     {
         $oldRecord = $this->retentionCheck;
+
+        if (! $oldRecord->waitingListAccount) {
+            \Log::warning("WaitingListAccount not found for retention check {$this->retentionCheck->id}. Cannot send retention email.");
+
+            return;
+        }
         $verifyToken = $this->generateToken();
 
         $record = WaitingListRetentionChecks::create([

--- a/app/Jobs/Training/WaitingListRetentionRemoval.php
+++ b/app/Jobs/Training/WaitingListRetentionRemoval.php
@@ -35,6 +35,12 @@ class WaitingListRetentionRemoval implements ShouldQueue
         $this->retentionCheck->removal_actioned_at = now();
         $this->retentionCheck->save();
 
+        if (! $this->retentionCheck->waitingListAccount) {
+            \Log::warning("WaitingListAccount not found for retention check {$this->retentionCheck->id}. Cannot remove from waiting list.");
+
+            return;
+        }
+
         $this->retentionCheck->waitingListAccount->account->notify(new RemovedFromWaitingListFailedRetention($this->retentionCheck));
 
         $account = $this->retentionCheck->waitingListAccount->account;


### PR DESCRIPTION
Fixes *#nil*

# Summary of changes

Now we ignore retention checks older that 6mo + those which do not have a waiting list account