### PR TITLE
Add pre-commit hook to run composer lint

### DIFF
--- a/.development/hooks/README.md
+++ b/.development/hooks/README.md
@@ -1,0 +1,45 @@
+# Git Hooks
+
+This directory contains Git hooks that are shared across the project to ensure code quality and consistency.
+
+These hooks are stored in `.development/hooks/` to keep development-related files organized.
+
+## Available Hooks
+
+### pre-commit
+- **Purpose**: Runs code style checks before each commit
+- **Command**: `composer lint` (Laravel Pint)
+- **Behavior**: Prevents commits if code style issues are found
+
+## Installation
+
+To install the Git hooks locally, run:
+
+```bash
+composer install-hooks
+```
+
+This will:
+1. Copy the hooks from `.development/hooks/` to `.git/hooks/`
+2. Make them executable
+3. Confirm successful installation
+
+## Manual Installation
+
+If you prefer to install manually:
+
+```bash
+cp .development/hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+## For New Team Members
+
+After cloning the repository, make sure to run:
+
+```bash
+composer install
+composer install-hooks
+```
+
+This ensures you have all dependencies and the latest Git hooks configured.

--- a/.development/hooks/pre-commit
+++ b/.development/hooks/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Pre-commit hook to run composer lint
+# This will run Laravel Pint to check code style before committing
+#
+
+echo "Running composer lint..."
+
+# Run composer lint
+if ! composer lint; then
+    echo ""
+    echo "❌ Code style check failed!"
+    echo "Please fix the style issues above before committing."
+    echo "You can run 'composer lint' to see the issues."
+    echo ""
+    exit 1
+fi
+
+echo "✅ Code style check passed!"
+exit 0

--- a/composer.json
+++ b/composer.json
@@ -155,6 +155,11 @@
         ],
         "lint": [
             "./vendor/bin/pint"
+        ],
+        "install-hooks": [
+            "cp .development/hooks/pre-commit .git/hooks/pre-commit",
+            "chmod +x .git/hooks/pre-commit",
+            "echo 'Git hooks installed successfully! 🎉'"
         ]
     },
     "config": {

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,43 @@
+# Git Hooks
+
+This directory contains Git hooks that are shared across the project to ensure code quality and consistency.
+
+## Available Hooks
+
+### pre-commit
+- **Purpose**: Runs code style checks before each commit
+- **Command**: `composer lint` (Laravel Pint)
+- **Behavior**: Prevents commits if code style issues are found
+
+## Installation
+
+To install the Git hooks locally, run:
+
+```bash
+composer install-hooks
+```
+
+This will:
+1. Copy the hooks from `hooks/` to `.git/hooks/`
+2. Make them executable
+3. Confirm successful installation
+
+## Manual Installation
+
+If you prefer to install manually:
+
+```bash
+cp hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+## For New Team Members
+
+After cloning the repository, make sure to run:
+
+```bash
+composer install
+composer install-hooks
+```
+
+This ensures you have all dependencies and the latest Git hooks configured.

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,23 @@
 Core application for VATSIM UK
 [www.vatsim.uk](https://vatsim.uk)
 
+## Getting Started
+
+After cloning the repository:
+
+```bash
+composer install
+composer install-hooks  # Install Git hooks for code quality
+```
+
+## Contributing
+
 If you wish to contribute, take a look at:
 - [Our general contributing guide](https://github.com/VATSIM-UK/core/blob/master/.github/CONTRIBUTING.md)
 - [The first time contributor's guide](https://github.com/VATSIM-UK/core/blob/main/.github/FIRST%20TIME%20CONTRIBUTORS.md)
+
+### Code Quality
+
+This project uses Git hooks to maintain code quality:
+- **Pre-commit hook**: Automatically runs `composer lint` to check code style
+- All hooks are stored in `.development/hooks/` and can be installed with `composer install-hooks`


### PR DESCRIPTION
As it says on the tin. Rolling something simple for now to save our poor pipeline when I forgot to run lint.
