### PR TITLE
Fixes #4245 - Puts All Policies In Dropdown Navigation In Same List

### DIFF
--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -126,8 +126,6 @@
                                 <li><a href="{{ route('site.policy.division') }}">Division Policy</a></li>
                                 <li><a href="{{ route('site.policy.atc-training') }}">ATC Training Policy</a></li>
                                 <li><a href="{{ route('site.policy.visiting-and-transferring') }}">Visiting & Transferring Policy</a></li>
-                                <li class="divider"></li>
-                                <li class="dropdown-header">Web Policy</li>
                                 <li><a href="{{ route('site.policy.terms') }}">Terms & Conditions</a></li>
                                 <li><a href="{{ route('site.policy.privacy') }}">Privacy Policy</a></li>
                                 <li><a href="{{ route('site.policy.data-protection') }}">Data Protection Policy</a></li>


### PR DESCRIPTION
Removed the two <*li> from the page, so that the policies are one flat list.

Fixes #4245 

# Summary of changes

Removes <*li> for the divider as well as the Web Policies header, so that all policies are in the same list.

# Screenshots (if necessary)

< Please provide screenshots if this will facilitate a faster review of these changes>