### PR TITLE
Improve git-hooks setup

### DIFF
--- a/.development/hooks/README.md
+++ b/.development/hooks/README.md
@@ -20,18 +20,23 @@ composer install-hooks
 ```
 
 This will:
-1. Copy the hooks from `.development/hooks/` to `.git/hooks/`
+
+1. Symlink the hooks from `.development/hooks/` to `.git/hooks/`
 2. Make them executable
 3. Confirm successful installation
 
-## Manual Installation
-
-If you prefer to install manually:
+If you wish to force reinstall the hooks, you can use:
 
 ```bash
-cp .development/hooks/pre-commit .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
+composer install-hooks -- --force
 ```
+
+This will remove existing hooks and create new symlinks.
+
+## Manual Installation
+
+If you prefer to install manually, symlink the wanted hooks from `.development/hooks/` to `.git/hooks/`:
+
 
 ## For New Team Members
 

--- a/.development/hooks/install.sh
+++ b/.development/hooks/install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Install git hooks script
+# This script symlinks files in .development/hooks to the .git/hooks directory.
+
+# Check if the script is run with --force flag
+force=false
+for arg in "$@"; do
+    [[ $arg == "--force" ]] && force=true
+done
+
+if ! ln -s test.txt test.txt 2>/dev/null || ! ls -l test.txt | grep -q '^l'; then
+    echo "⚠️ Symlinks are not supported in this environment. File contents will be copied instead of symlinks."
+fi
+
+
+echo "⚙️ Installing git hooks..."
+
+# Go through each file in the hooks directory
+# and create a symlink for each file without an extension
+# in the .git/hooks directory.
+for file in .development/hooks/*; do
+    if [ -f "$file" ]; then
+        base=$(basename "$file")
+        # skip files with an extension (keep only extensionless hook scripts)
+        [[ $base == *.* ]] &&  continue;
+
+        target=".git/hooks/$base"
+
+        # If the --force flag is set, remove the existing target
+        if $force && [ -e "$target" ]; then
+            echo "Removing existing target before recreating: $target"
+            rm -f "$target"
+        fi
+
+        # Create a symlink if it doesn't already exist
+        if [ ! -e "$target" ]; then
+            echo "Creating symlink for $base"
+            ln -s "../../$file" "$target" 2>/dev/null || ln -s "$file" "$target"
+            chmod +x "$file"
+        else
+            echo "⚔️ Hook $base is already registered, skipping. Force override with --force."
+        fi
+    fi
+done

--- a/.development/hooks/pre-commit
+++ b/.development/hooks/pre-commit
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Pre-commit hook to run composer lint
 # This will run Laravel Pint to check code style before committing
 #
+
+source ~/.bashrc
 
 echo "Running composer lint..."
 

--- a/composer.json
+++ b/composer.json
@@ -157,9 +157,8 @@
             "./vendor/bin/pint"
         ],
         "install-hooks": [
-            "cp .development/hooks/pre-commit .git/hooks/pre-commit",
-            "chmod +x .git/hooks/pre-commit",
-            "echo 'Git hooks installed successfully! 🎉'"
+            "chmod +x .development/hooks/install.sh",
+            "bash .development/hooks/install.sh"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -157,8 +157,7 @@
             "./vendor/bin/pint"
         ],
         "install-hooks": [
-            "chmod +x .development/hooks/install.sh",
-            "bash .development/hooks/install.sh"
+            "chmod +x .development/hooks/install.sh && bash .development/hooks/install.sh \"$@\""
         ]
     },
     "config": {


### PR DESCRIPTION
# Summary of changes
 - Added a bash install script
 - Now symlinks are used instead of copying from source - this enables version control without the need for reinstall.
 - Hooks now use bash and source bashrc for herd aliases in git bash (this might have a better solution)
