### PR TITLE
Split ATC Examier roles per level

### DIFF
--- a/app/Console/Commands/Members/SyncCtsRoles.php
+++ b/app/Console/Commands/Members/SyncCtsRoles.php
@@ -65,7 +65,12 @@ class SyncCtsRoles extends Command
         $this->syncStudentsByRts(17, Role::findByName('ATC Students (ENR)')->id); // Enroute Students
 
         // Sync Examiners
-        $this->syncAtcExaminers(31); // ATC
+        // Split ATC Examiner roles per level
+        $this->syncObsExaminers(Role::findByName('ATC Examiner (OBS)')->id);
+        $this->syncTwrExaminers(Role::findByName('ATC Examiner (TWR)')->id);
+        $this->syncAppExaminers(Role::findByName('ATC Examiner (APP)')->id);
+        $this->syncCtrExaminers(Role::findByName('ATC Examiner (CTR)')->id);
+
         $this->syncPilotExaminers(40); // Pilot
     }
 
@@ -83,10 +88,31 @@ class SyncCtsRoles extends Command
         $this->syncRoles($hasRole, $shouldHaveRole, $roleId);
     }
 
-    private function syncAtcExaminers(int $roleId): void
+    private function syncObsExaminers(int $roleId): void
     {
         $hasRole = $this->getAccountsWithRoleId($roleId);
-        $shouldHaveRole = (new ExaminerRepository)->getAtcExaminers();
+        $shouldHaveRole = (new ExaminerRepository)->getObsExaminers();
+        $this->syncRoles($hasRole, $shouldHaveRole, $roleId);
+    }
+
+    private function syncTwrExaminers(int $roleId): void
+    {
+        $hasRole = $this->getAccountsWithRoleId($roleId);
+        $shouldHaveRole = (new ExaminerRepository)->getTwrExaminers();
+        $this->syncRoles($hasRole, $shouldHaveRole, $roleId);
+    }
+
+    private function syncAppExaminers(int $roleId): void
+    {
+        $hasRole = $this->getAccountsWithRoleId($roleId);
+        $shouldHaveRole = (new ExaminerRepository)->getAppExaminers();
+        $this->syncRoles($hasRole, $shouldHaveRole, $roleId);
+    }
+
+    private function syncCtrExaminers(int $roleId): void
+    {
+        $hasRole = $this->getAccountsWithRoleId($roleId);
+        $shouldHaveRole = (new ExaminerRepository)->getCtrExaminers();
         $this->syncRoles($hasRole, $shouldHaveRole, $roleId);
     }
 

--- a/app/Models/Cts/ExaminerSettings.php
+++ b/app/Models/Cts/ExaminerSettings.php
@@ -27,7 +27,7 @@ class ExaminerSettings extends Model
 
     public function scopeTwr($query)
     {
-    return $query->where('S1', '=', 1);
+        return $query->where('S1', '=', 1);
     }
 
     public function scopeApp($query)

--- a/app/Models/Cts/ExaminerSettings.php
+++ b/app/Models/Cts/ExaminerSettings.php
@@ -20,6 +20,26 @@ class ExaminerSettings extends Model
         return $this->belongsTo(Member::class, 'memberID', 'id');
     }
 
+    public function scopeObs($query)
+    {
+        return $query->where('OBS', '=', 1);
+    }
+
+    public function scopeTwr($query)
+    {
+    return $query->where('S1', '=', 1);
+    }
+
+    public function scopeApp($query)
+    {
+        return $query->where('S2', '=', 1);
+    }
+
+    public function scopeCtr($query)
+    {
+        return $query->where('S3', '=', 1);
+    }
+
     public function scopeAtc($query)
     {
         return $query->where('OBS', '=', 1) // OBS to S1 examiner

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -23,6 +23,12 @@ class RolesAndPermissionsSeeder extends Seeder
         $privacc = Role::firstOrCreate(['name' => 'privacc', 'guard_name' => 'web', 'default' => false]);
         $member = Role::firstOrCreate(['name' => 'member', 'guard_name' => 'web', 'default' => true]);
 
+        // Create ATC Examier Roles
+        $obsExaminer = Role::firstOrCreate(['name' => 'ATC Examiner (OBS)', 'guard_name' => 'web', 'default' => false]);
+        $twrExaminer = Role::firstOrCreate(['name' => 'ATC Examiner (TWR)', 'guard_name' => 'web', 'default' => false]);
+        $appExaminer = Role::firstOrCreate(['name' => 'ATC Examiner (APP)', 'guard_name' => 'web', 'default' => false]);
+        $ctrExaminer = Role::firstOrCreate(['name' => 'ATC Examiner (CTR)', 'guard_name' => 'web', 'default' => false]);
+
         // Add All Permissions
         $permissions = [
             app()->isProduction() ? null : '*',
@@ -198,6 +204,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'roster.manage',
             'roster.restriction.create',
             'roster.restriction.remove',
+
         ];
 
         foreach ($permissions as $permission) {


### PR DESCRIPTION
# Summary of changes

 - Added 4 new ATC examiner roles to the role seeder
 - Added atc level scopes to `ExamierSettings` to query from CTS quickly
 - Refactored `ExaminerRepository` to avoid repetition and added methods to query examiers by level
