### PR TITLE
Make pre-commit exit with error if changes were made by pint

### DIFF
--- a/.development/hooks/pre-commit
+++ b/.development/hooks/pre-commit
@@ -17,9 +17,6 @@ echo "Running Pint..."
 composer lint -- --quiet $staged_files || true
 
 # Check if Pint changed any of the staged files
-composer lint -- --quiet "$staged_files" || true
-
-# Check if Pint changed any of the staged files
 fixed_files=$(git diff --name-only -- "$staged_files")
 
 if [ -n "$fixed_files" ]; then

--- a/.development/hooks/pre-commit
+++ b/.development/hooks/pre-commit
@@ -14,7 +14,7 @@ staged_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.php$' |
 [ -z "$staged_files" ] && exit 0
 
 echo "Running Pint..."
-composer lint -- --quiet $staged_files || true
+composer lint -- --quiet "$staged_files" || true
 
 # Check if Pint changed any of the staged files
 fixed_files=$(git diff --name-only -- "$staged_files")

--- a/.development/hooks/pre-commit
+++ b/.development/hooks/pre-commit
@@ -17,7 +17,10 @@ echo "Running Pint..."
 composer lint -- --quiet $staged_files || true
 
 # Check if Pint changed any of the staged files
-fixed_files=$(git diff --name-only -- $staged_files)
+composer lint -- --quiet "$staged_files" || true
+
+# Check if Pint changed any of the staged files
+fixed_files=$(git diff --name-only -- "$staged_files")
 
 if [ -n "$fixed_files" ]; then
     echo

--- a/.development/hooks/pre-commit
+++ b/.development/hooks/pre-commit
@@ -1,22 +1,30 @@
-#!/bin/bash
-#
-# Pre-commit hook to run composer lint
-# This will run Laravel Pint to check code style before committing
-#
+#!/usr/bin/env bash
 
-source ~/.bashrc
+# pre-commit hook for Laravel Pint
+# Auto-fix staged files, but fail commit if anything was fixed.
 
-echo "Running composer lint..."
+if [ -f "$HOME/.bashrc" ]; then
+    . "$HOME/.bashrc"
+fi
 
-# Run composer lint
-if ! composer lint; then
-    echo ""
-    echo "❌ Code style check failed!"
-    echo "Please fix the style issues above before committing."
-    echo "You can run 'composer lint' to see the issues."
-    echo ""
+set -euo pipefail
+
+# Get staged PHP files
+staged_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.php$' || true)
+[ -z "$staged_files" ] && exit 0
+
+echo "Running Pint..."
+composer lint -- --quiet $staged_files || true
+
+# Check if Pint changed any of the staged files
+fixed_files=$(git diff --name-only -- $staged_files)
+
+if [ -n "$fixed_files" ]; then
+    echo
+    echo "⚠️  Pint fixed some files. Please re-add them and commit again:"
+    echo "$fixed_files"
     exit 1
 fi
 
-echo "✅ Code style check passed!"
+echo "✅ Pint made no changes."
 exit 0


### PR DESCRIPTION
# Summary of changes

If the pre-commit exits with `0`, the commit gets created which is unwanted if pint made changes.
Now the hook will exit with an error code and force the user to re-add and commit again if changes were made.
*Commiting  in the hook itself is considered unsafe generally*