### PR TITLE
Removed unnecessary separator from Pilots dropdown

### DIFF
--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -45,7 +45,6 @@
                                 <li><a href="{{ route('site.pilots.mentor') }}">Become a Mentor</a></li>
                                 <li><a href="{{ route('site.pilots.oceanic') }}">Oceanic Procedures</a></li>
                                 <li><a href="{{ route('site.pilots.tfp') }}">Flying Programme</a></li>
-                                <li class="divider"></li>
                             </ul>
                         </li>
                     </ul>


### PR DESCRIPTION
Fix #4267
# Summary of changes
Removed the unnecessary separator (divider) at the end of the Pilots dropdown in the navigation bar.

# Screenshots
<img width="303" height="240" alt="Screenshot 2025-08-20 at 2 56 20 PM" src="https://github.com/user-attachments/assets/9d3a1620-0cf4-43eb-818e-d06706a861eb" />

