### PR TITLE
Retention checks QOL

### DIFF
--- a/app/Filament/Admin/Resources/AccountResource/RelationManagers/RetentionChecksRelationManager.php
+++ b/app/Filament/Admin/Resources/AccountResource/RelationManagers/RetentionChecksRelationManager.php
@@ -27,6 +27,7 @@ class RetentionChecksRelationManager extends RelationManager
             ->modifyQueryUsing(function ($query) {
                 return $query->with(['waitingListAccount.waitingList']);
             })
+            ->defaultSort('email_sent_at', 'desc')
             ->columns([
                 Tables\Columns\TextColumn::make('waitingListAccount.waitingList.name')
                     ->label('Waiting List')

--- a/app/Filament/Admin/Resources/AccountResource/RelationManagers/RetentionChecksRelationManager.php
+++ b/app/Filament/Admin/Resources/AccountResource/RelationManagers/RetentionChecksRelationManager.php
@@ -27,20 +27,20 @@ class RetentionChecksRelationManager extends RelationManager
             ->modifyQueryUsing(function ($query) {
                 return $query->with(['waitingListAccount.waitingList']);
             })
-            ->defaultSort('email_sent_at', 'desc')
             ->columns([
                 Tables\Columns\TextColumn::make('waitingListAccount.waitingList.name')
                     ->label('Waiting List')
                     ->sortable(),
-                Tables\Columns\TextColumn::make('status')
+                Tables\Columns\TextColumn::make('status_human')
+                    ->label('Status')
                     ->badge()
-                    ->color(fn ($state) => match ($state) {
+                    ->color(fn ($state, WaitingListRetentionCheck $record) => match ($record->status) {
                         WaitingListRetentionCheck::STATUS_PENDING => 'warning',
                         WaitingListRetentionCheck::STATUS_USED => 'success',
                         WaitingListRetentionCheck::STATUS_EXPIRED => 'danger',
                         default => 'gray',
                     })
-                    ->sortable(),
+                    ->sortable('status'),
                 Tables\Columns\TextColumn::make('email_sent_at')->dateTime()->label('Email Sent')->sortable(),
                 Tables\Columns\TextColumn::make('expires_at')->dateTime()->label('Expires')->sortable(),
                 Tables\Columns\TextColumn::make('response_at')->dateTime()->label('Responded')->sortable(),

--- a/app/Http/Controllers/Mship/WaitingLists.php
+++ b/app/Http/Controllers/Mship/WaitingLists.php
@@ -70,6 +70,13 @@ class WaitingLists extends BaseController
         }
 
         // Only the scheduled command will change the status so we need to check the expires_at timestamp as well
+        if ($retentionCheck->status === WaitingListRetentionCheck::STATUS_USED ||
+            $retentionCheck->response_at !== null) {
+            return redirect()
+                ->route('mship.waiting-lists.retention.fail')
+                ->with('failReason', 'This retention check token has already been used, waiting list place has already been confirmed');
+        }
+
         if ($retentionCheck->status !== WaitingListRetentionCheck::STATUS_PENDING || $retentionCheck->expires_at < now()) {
             return redirect()
                 ->route('mship.waiting-lists.retention.fail')

--- a/app/Models/Training/WaitingList/WaitingListRetentionCheck.php
+++ b/app/Models/Training/WaitingList/WaitingListRetentionCheck.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Training\WaitingList;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -35,6 +36,20 @@ class WaitingListRetentionCheck extends Model
             'email_sent_at' => 'datetime',
             'removal_actioned_at' => 'datetime',
         ];
+    }
+
+    protected function statusHuman(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value, array $attributes) {
+                $status = $attributes['status'] ?? null;
+
+                return match ($status) {
+                    self::STATUS_USED => 'responded',
+                    default => $status,
+                };
+            }
+        );
     }
 
     public function waitingListAccount()

--- a/tests/Feature/Training/RetentionCheckTokenTest.php
+++ b/tests/Feature/Training/RetentionCheckTokenTest.php
@@ -65,6 +65,7 @@ class RetentionCheckTokenTest extends TestCase
         WaitingListRetentionCheck::factory()->create([
             'token' => 'valid-token',
             'expires_at' => now()->addDays(7),
+            'response_at' => null,
             'status' => WaitingListRetentionCheck::STATUS_PENDING,
         ]);
 


### PR DESCRIPTION
# Summary of changes

 - Status `used` is now rendered as `responded` via the `statusHuman` accessor
 - Checks are now sorted from latest by default
 - If a token has already been used and a user tries to re-use it, they will be informed of the confirmed list place instead of being given a fail message