### PR TITLE
Use success page for used retention token instead of fail

### DIFF
--- a/app/Http/Controllers/Mship/WaitingLists.php
+++ b/app/Http/Controllers/Mship/WaitingLists.php
@@ -73,8 +73,8 @@ class WaitingLists extends BaseController
         if ($retentionCheck->status === WaitingListRetentionCheck::STATUS_USED ||
             $retentionCheck->response_at !== null) {
             return redirect()
-                ->route('mship.waiting-lists.retention.fail')
-                ->with('failReason', 'This retention check token has already been used, waiting list place has already been confirmed');
+                ->route('mship.waiting-lists.retention.success')
+                ->with('extraMessage', 'This retention check token has already been used, waiting list place has already been confirmed');
         }
 
         if ($retentionCheck->status !== WaitingListRetentionCheck::STATUS_PENDING || $retentionCheck->expires_at < now()) {

--- a/resources/views/livewire/retention-checks/success.blade.php
+++ b/resources/views/livewire/retention-checks/success.blade.php
@@ -5,6 +5,9 @@
         <div class="shadow space-y-6 rounded-lg sm:px-4">
             <p class="text-green-700 text-left py-4">🎉 Success! Waiting list retention check has been completed
                 successfully.</p>
+            @if (session('extraMessage'))
+                <p class="text-green-700 text-left pb-4">{{ session('extraMessage') }}</p>
+            @endif
         </div>
     </div>
 </main>

--- a/tests/Feature/Training/RetentionCheckTokenTest.php
+++ b/tests/Feature/Training/RetentionCheckTokenTest.php
@@ -81,4 +81,21 @@ class RetentionCheckTokenTest extends TestCase
             'status' => WaitingListRetentionCheck::STATUS_USED,
         ]);
     }
+
+    #[Test]
+    public function it_redirects_to_success_with_already_used_token()
+    {
+        WaitingListRetentionCheck::factory()->create([
+            'token' => 'used-token',
+            'expires_at' => now()->addDays(7),
+            'response_at' => now(),
+            'status' => WaitingListRetentionCheck::STATUS_USED,
+        ]);
+
+        $this->actingAs($this->user)
+            ->get(route('mship.waiting-lists.retention.token', ['token' => 'used-token']))
+            ->assertStatus(302)
+            ->assertRedirect(route('mship.waiting-lists.retention.success'))
+            ->assertSessionHas('extraMessage');
+    }
 }

--- a/tests/Feature/Training/RetentionCheckTokenTest.php
+++ b/tests/Feature/Training/RetentionCheckTokenTest.php
@@ -35,6 +35,7 @@ class RetentionCheckTokenTest extends TestCase
         WaitingListRetentionCheck::factory()->create([
             'token' => 'expired-token',
             'expires_at' => now()->subDays(1),
+            'response_at' => null,
             'status' => WaitingListRetentionCheck::STATUS_EXPIRED,
         ]);
 
@@ -50,6 +51,7 @@ class RetentionCheckTokenTest extends TestCase
         WaitingListRetentionCheck::factory()->create([
             'token' => 'expired-token',
             'expires_at' => now()->subDays(1),
+            'response_at' => null,
             'status' => WaitingListRetentionCheck::STATUS_PENDING,
         ]);
 


### PR DESCRIPTION
After some thought, it's probably better to redirect to success page if a retention token has already been used.