### PR TITLE
TECH-415 / TECH-397 Waiting List Removals on Roster Removal & Notes

### DIFF
--- a/app/Models/Training/WaitingList.php
+++ b/app/Models/Training/WaitingList.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Number;
 
 /**
  * @property int $id
@@ -252,10 +253,12 @@ class WaitingList extends Model
         $waitingListAccount->removal_comment = $removal->otherReason;
         $waitingListAccount->removed_by = $removal->removedBy;
 
+        $position = Number::ordinal($this->positionOf($waitingListAccount));
+
         $noteType = Type::isShortCode('training')->firstOrFail();
         $account->addNote(
             $noteType,
-            "Removed from {$this->name} Waiting List: {$removal->comment()}",
+            "Removed from list '{$this->name}' ({$removal->comment()}), original join date {$waitingListAccount->created_at->format('Y-m-d')}, was {$position}.",
             $removal->removedBy);
 
         $waitingListAccount->save();

--- a/database/seeders/WaitingListStressSeeder.php
+++ b/database/seeders/WaitingListStressSeeder.php
@@ -30,7 +30,7 @@ class WaitingListStressSeeder extends Seeder
         $admin = $this->seedS1();
 
         /** @var WaitingList $waitingList */
-        $waitingList = WaitingList::create(['name' => 'Fake TWR List', 'slug' => 'fk-twr', 'department' => 'ATC Training']);
+        $waitingList = WaitingList::create(['name' => 'Fake TWR List', 'slug' => 'fk-twr', 'department' => 'atc', 'requires_roster_membership' => true]);
         $waitingList->save();
 
         foreach (range(0, self::SIZE) as $index) {


### PR DESCRIPTION
Properly remove people from waiting lists on roster removal (going through normal removal steps). Add better notes on waiting list removal

Fixes TECH-397
Fixes TECH-415
Fixes #4283 

# Summary of changes

Accounts now go through the "normal" waiting list removal process during removals arising from roster changes. 

The note attached to the account now includes the join date and position at time of removal. This feature may cause issues when running in production due to the large amount of position calculation that takes place. 

# Screenshots (if necessary)

< Please provide screenshots if this will facilitate a faster review of these changes>