### PR TITLE
View exam report and exam history in training panel

### DIFF
--- a/app/Filament/Training/Pages/ExamHistory.php
+++ b/app/Filament/Training/Pages/ExamHistory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Training\Pages;
+
+use App\Repositories\Cts\ExamResultRepository;
+use Filament\Pages\Page;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+
+class ExamHistory extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    protected static string $view = 'filament.training.pages.exam-history';
+
+    protected static ?string $navigationGroup = 'Exams';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()->can('training.exams.access');
+    }
+
+    public function table(Table $table): Table
+    {
+        $userPermissionsTruthTable = [
+            'obs' => auth()->user()->can('training.exams.conduct.obs'),
+            'twr' => auth()->user()->can('training.exams.conduct.twr'),
+            'app' => auth()->user()->can('training.exams.conduct.app'),
+            'ctr' => auth()->user()->can('training.exams.conduct.ctr'),
+        ];
+
+        $typesToShow = collect($userPermissionsTruthTable)->filter(fn ($value) => $value)->keys();
+
+        $examResultRepository = app(ExamResultRepository::class);
+        $query = $examResultRepository->getExamHistoryQueryForLevels($typesToShow);
+
+        return $table->query($query)->columns([
+            TextColumn::make('student.account.id')->label('CID'),
+            TextColumn::make('student.account.name')->label('Name'),
+            TextColumn::make('examBooking.exam')->label('Exam'),
+            TextColumn::make('result')->getStateUsing(fn ($record) => $record->resultHuman())->badge()->color(fn ($state) => match ($state) {
+                'Passed' => 'success',
+                'Failed' => 'danger',
+                'Incomplete' => 'warning',
+                default => 'gray',
+            })->label('Result'),
+            TextColumn::make('examBooking.position_1')->label('Position'),
+            TextColumn::make('examBooking.start_date')->label('Exam date'),
+            TextColumn::make('date')->label('Report filed'),
+        ])->defaultSort('date', 'desc')
+            ->actions([
+                Action::make('view')->label('View')->url(fn ($record) => ViewExamReport::getUrl(['examId' => $record->examid])),
+            ]);
+    }
+}

--- a/app/Filament/Training/Pages/ViewExamReport.php
+++ b/app/Filament/Training/Pages/ViewExamReport.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Filament\Training\Pages;
+
+use App\Infolists\Components\PracticalExamCriteriaResult;
+use App\Models\Cts\PracticalResult;
+use Filament\Infolists\Components\RepeatableEntry;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Concerns\InteractsWithInfolists;
+use Filament\Infolists\Contracts\HasInfolists;
+use Filament\Infolists\Infolist;
+use Filament\Pages\Page;
+
+class ViewExamReport extends Page implements HasInfolists
+{
+    use InteractsWithInfolists;
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    protected static string $view = 'filament.training.pages.view-exam-report';
+
+    protected static ?string $slug = 'exams/report/{examId}';
+
+    public int $examId;
+
+    public PracticalResult $practicalResult;
+
+    public function mount(): void
+    {
+        // Check basic training exams access
+        if (! auth()->user()->can('training.exams.access')) {
+            abort(403, 'You do not have permission to access training exams.');
+        }
+
+        $this->practicalResult = PracticalResult::where('examid', $this->examId)->firstOrFail();
+
+        // Check specific conduct permission for this exam level
+        if ($this->practicalResult->examBooking) {
+            $examLevel = strtolower($this->practicalResult->examBooking->exam);
+            if (! auth()->user()->can("training.exams.conduct.{$examLevel}")) {
+                abort(403, 'You do not have permission to view this exam report.');
+            }
+        } else {
+            abort(403, 'Invalid exam booking.');
+        }
+    }
+
+    public function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist->record($this->practicalResult)->schema([
+            Section::make('')->schema([
+                Section::make('Student')->schema([
+                    TextEntry::make('student.account.name')->label('Name'),
+                    TextEntry::make('student.account.id')->label('CID'),
+                    TextEntry::make('examBooking.studentQualification.name')->label('Qualification'),
+                ])->columns(2)->columnSpan(1)->extraAttributes(['class' => 'h-full']),
+
+                Section::make('Exam')->schema([
+                    TextEntry::make('examBooking.exam')->label('Exam'),
+                    TextEntry::make('examBooking.position_1')->label('Position'),
+                    TextEntry::make('examBooking.start_date')->label('Date'),
+                    TextEntry::make('examBooking.examiners.primaryExaminer.account.name')->label('Primary Examiner'),
+                    TextEntry::make('examBooking.examiners.secondaryExaminer.account.name')->label('Secondary Examiner'),
+                    TextEntry::make('examBooking.examiners.traineeExaminer.account.name')->label('Trainee Examiner'),
+                ])->columns(2)->columnSpan(1)->extraAttributes(['class' => 'h-full']),
+            ])->columns(2)->extraAttributes(['class' => 'items-stretch']),
+
+            Section::make('Exam Result')->schema([
+                TextEntry::make('result')->label('Result')->badge()->color(fn ($state) => match ($state) {
+                    'Passed' => 'success',
+                    'Failed' => 'danger',
+                    'Incomplete' => 'warning',
+                    default => 'gray',
+                })->getStateUsing(fn ($record) => $record->resultHuman()),
+
+                TextEntry::make('notes')->html()->label('Additional Comments'),
+            ])->columns(2)->extraAttributes(['class' => 'items-stretch']),
+        ]);
+    }
+
+    public function criteriaInfoList(Infolist $infolist): Infolist
+    {
+        return $infolist->record($this->practicalResult)->schema([
+            RepeatableEntry::make('criteria')->label('')->schema([
+                TextEntry::make('examCriteria.criteria')->label(null)->columnSpan(10),
+                PracticalExamCriteriaResult::make('result')->label('Result')->columnSpan(2),
+                TextEntry::make('notes')->html()->label('Notes')->columnSpan(12),
+            ])->columns(12),
+        ]);
+    }
+}

--- a/app/Infolists/Components/PracticalExamCriteriaResult.php
+++ b/app/Infolists/Components/PracticalExamCriteriaResult.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Infolists\Components;
+
+use Filament\Infolists\Components\Entry;
+
+class PracticalExamCriteriaResult extends Entry
+{
+    protected string $view = 'infolists.components.practical-exam-criteria-result';
+
+    public function getColorForResult(): string
+    {
+        return match ($this->getState()) {
+            'P' => '#B0EEBE',
+            'M' => '#ffcc66',
+            'R' => '#ff9966',
+            'N' => '#999999',
+            'F' => '#ce484b',
+            default => '#999999',
+        };
+    }
+
+    public function getTextColorForResult(): string
+    {
+        return match ($this->getState()) {
+            'P' => '#1f2937',
+            'M' => '#1f2937',
+            'R' => '#1f2937',
+            'N' => '#ffffff',
+            'F' => '#ffffff',
+            default => '#ffffff',
+        };
+    }
+}

--- a/app/Models/Cts/ExamCriteriaAssessment.php
+++ b/app/Models/Cts/ExamCriteriaAssessment.php
@@ -2,7 +2,9 @@
 
 namespace App\Models\Cts;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ExamCriteriaAssessment extends Model
 {
@@ -33,5 +35,23 @@ class ExamCriteriaAssessment extends Model
             self::NOT_ASSESSED => 'Not Assessed',
             self::FAIL => 'Fail',
         ];
+    }
+
+    public function examCriteria(): BelongsTo
+    {
+        return $this->belongsTo(ExamCriteria::class, 'criteria_id', 'id');
+    }
+
+    protected function resultHuman(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => [
+                self::FULLY_COMPETENT => 'Fully Competent',
+                self::MOSTLY_COMPETENT => 'Mostly Competent',
+                self::PARTLY_COMPETENT => 'Partly Competent',
+                self::NOT_ASSESSED => 'Not Assessed',
+                self::FAIL => 'Fail',
+            ][$this->result],
+        );
     }
 }

--- a/app/Models/Cts/PracticalResult.php
+++ b/app/Models/Cts/PracticalResult.php
@@ -5,6 +5,7 @@ namespace App\Models\Cts;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class PracticalResult extends Model
 {
@@ -44,5 +45,10 @@ class PracticalResult extends Model
             self::INCOMPLETE => 'Incomplete',
             default => 'Unknown',
         };
+    }
+
+    public function criteria(): HasMany
+    {
+        return $this->hasMany(ExamCriteriaAssessment::class, 'examid', 'examid')->with('examCriteria');
     }
 }

--- a/app/Providers/Filament/TrainingPanelProvider.php
+++ b/app/Providers/Filament/TrainingPanelProvider.php
@@ -46,6 +46,7 @@ class TrainingPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 TrainingPanelAccessMiddleware::class,
-            ]);
+            ])
+            ->viteTheme('resources/assets/css/tailwind.css');
     }
 }

--- a/app/Repositories/Cts/ExamResultRepository.php
+++ b/app/Repositories/Cts/ExamResultRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories\Cts;
 use App\Events\Training\Exams\PracticalExamCompleted;
 use App\Models\Cts\ExamBooking;
 use App\Models\Cts\PracticalResult;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 class ExamResultRepository
@@ -39,5 +40,17 @@ class ExamResultRepository
         $examBooking->update(['finished' => ExamBooking::FINISHED_FLAG]);
 
         event(new PracticalExamCompleted($examBooking, $practicalResult));
+    }
+
+    /**
+     * Get a query for practical results filtered by exam levels
+     *
+     * @param  Collection  $examLevels  Collection of exam levels to include
+     */
+    public function getExamHistoryQueryForLevels(Collection $examLevels): Builder
+    {
+        return PracticalResult::query()
+            ->with('student', 'examBooking')
+            ->whereIn('exam', $examLevels);
     }
 }

--- a/resources/views/filament/training/pages/exam-history.blade.php
+++ b/resources/views/filament/training/pages/exam-history.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/resources/views/filament/training/pages/view-exam-report.blade.php
+++ b/resources/views/filament/training/pages/view-exam-report.blade.php
@@ -1,0 +1,7 @@
+<x-filament-panels::page>
+    {{ $this->infolist }}
+
+    <h1 class="text-xl font-bold">Grades</h1>
+
+    {{ $this->criteriaInfoList}}
+</x-filament-panels::page>

--- a/resources/views/infolists/components/practical-exam-criteria-result.blade.php
+++ b/resources/views/infolists/components/practical-exam-criteria-result.blade.php
@@ -1,0 +1,6 @@
+<x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
+    <div class="flex items-center justify-center w-full px-3 py-1.5 text-xs font-semibold rounded-md uppercase tracking-wide shadow-sm transition-all duration-200 hover:shadow-md"
+         style="background-color: {{ $getColorForResult() }}; color: {{ $getTextColorForResult() }};">
+        <span class="leading-none">{{ $getRecord()->resultHuman }}</span>
+    </div>
+</x-dynamic-component>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,15 +47,17 @@ module.exports = {
             pink: colors.pink,
             rose: colors.rose,
         }
-    }, content: {
-        files: [
-            './app/**/*.php',
-            './resources/*.php',
-            './resources/**/*.php',
-            "./resources/**/*.blade.php",
-            './vendor/filament/**/*.blade.php',
-            './storage/framework/views/*.php'
-        ]
     },
+    content: [
+        './app/**/*.php',
+        './resources/**/*.php',
+        './resources/**/*.blade.php',
+        './resources/**/*.js',
+        './app/Filament/**/*.php',
+        './app/Livewire/**/*.php',
+        './vendor/filament/**/*.blade.php',
+        './vendor/wire-elements/modal/resources/views/*.blade.php',
+        './storage/framework/views/*.php'
+    ],
     plugins: [require("@tailwindcss/forms")],
 };

--- a/tests/Feature/TrainingPanel/Exams/ExamHistoryTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamHistoryTest.php
@@ -1,0 +1,332 @@
+<?php
+
+namespace Tests\Feature\TrainingPanel\Exams;
+
+use App\Filament\Training\Pages\ExamHistory;
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalResult;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class ExamHistoryTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    protected array $examBookings = [];
+
+    protected array $practicalResults = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create exam data for all levels
+        $this->createExamData();
+    }
+
+    private function createExamData(): void
+    {
+        $examLevels = ['OBS', 'TWR', 'APP', 'CTR'];
+
+        foreach ($examLevels as $level) {
+            // Create a student account and member
+            $student = Account::factory()->create();
+            $studentMember = Member::factory()->create([
+                'id' => $student->id,
+                'cid' => $student->id,
+            ]);
+
+            // Create an exam booking
+            $examBooking = ExamBooking::factory()->create([
+                'taken' => 1,
+                'finished' => ExamBooking::FINISHED_FLAG,
+                'exam' => $level,
+                'student_id' => $studentMember->id,
+                'student_rating' => Qualification::code('S1')->first()->vatsim,
+                'position_1' => 'EGKK_'.$level,
+            ]);
+
+            // Create examiners
+            $examBooking->examiners()->create([
+                'examid' => $examBooking->id,
+                'senior' => $this->panelUser->id,
+            ]);
+
+            // Create a practical result
+            $practicalResult = PracticalResult::factory()->create([
+                'examid' => $examBooking->id,
+                'student_id' => $studentMember->id,
+                'result' => PracticalResult::PASSED,
+                'exam' => $level,
+                'date' => now()->subDays(rand(1, 30)),
+            ]);
+
+            $this->examBookings[$level] = $examBooking;
+            $this->practicalResults[$level] = $practicalResult;
+        }
+    }
+
+    #[Test]
+    public function it_loads_if_user_has_basic_access()
+    {
+        $this->panelUser->givePermissionTo('training.exams.access');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_does_not_load_if_user_lacks_basic_access()
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_shows_no_exams_when_user_has_no_conduct_permissions()
+    {
+        $this->panelUser->givePermissionTo('training.exams.access');
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should show no table data since user has no conduct permissions
+        $component->assertDontSee($this->practicalResults['OBS']->student->account->name);
+        $component->assertDontSee($this->practicalResults['TWR']->student->account->name);
+        $component->assertDontSee($this->practicalResults['APP']->student->account->name);
+        $component->assertDontSee($this->practicalResults['CTR']->student->account->name);
+    }
+
+    #[Test]
+    public function it_shows_only_obs_exams_when_user_has_obs_permission()
+    {
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.obs']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should show OBS exams
+        $component->assertSee($this->practicalResults['OBS']->student->account->name);
+        $component->assertSee('OBS');
+
+        // Should not show other exam types
+        $component->assertDontSee($this->practicalResults['TWR']->student->account->name);
+        $component->assertDontSee($this->practicalResults['APP']->student->account->name);
+        $component->assertDontSee($this->practicalResults['CTR']->student->account->name);
+    }
+
+    #[Test]
+    public function it_shows_only_twr_exams_when_user_has_twr_permission()
+    {
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should show TWR exams
+        $component->assertSee($this->practicalResults['TWR']->student->account->name);
+        $component->assertSee('TWR');
+
+        // Should not show other exam types
+        $component->assertDontSee($this->practicalResults['OBS']->student->account->name);
+        $component->assertDontSee($this->practicalResults['APP']->student->account->name);
+        $component->assertDontSee($this->practicalResults['CTR']->student->account->name);
+    }
+
+    #[Test]
+    public function it_shows_only_app_exams_when_user_has_app_permission()
+    {
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.app']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should show APP exams
+        $component->assertSee($this->practicalResults['APP']->student->account->name);
+        $component->assertSee('APP');
+
+        // Should not show other exam types
+        $component->assertDontSee($this->practicalResults['OBS']->student->account->name);
+        $component->assertDontSee($this->practicalResults['TWR']->student->account->name);
+        $component->assertDontSee($this->practicalResults['CTR']->student->account->name);
+    }
+
+    #[Test]
+    public function it_shows_only_ctr_exams_when_user_has_ctr_permission()
+    {
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.ctr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should show CTR exams
+        $component->assertSee($this->practicalResults['CTR']->student->account->name);
+        $component->assertSee('CTR');
+
+        // Should not show other exam types
+        $component->assertDontSee($this->practicalResults['OBS']->student->account->name);
+        $component->assertDontSee($this->practicalResults['TWR']->student->account->name);
+        $component->assertDontSee($this->practicalResults['APP']->student->account->name);
+    }
+
+    #[Test]
+    public function it_shows_multiple_exam_types_when_user_has_multiple_permissions()
+    {
+        $this->panelUser->givePermissionTo([
+            'training.exams.access',
+            'training.exams.conduct.obs',
+            'training.exams.conduct.twr',
+        ]);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should show OBS and TWR exams
+        $component->assertSee($this->practicalResults['OBS']->student->account->name);
+        $component->assertSee($this->practicalResults['TWR']->student->account->name);
+        $component->assertSee('OBS');
+        $component->assertSee('TWR');
+
+        // Should not show APP and CTR exams
+        $component->assertDontSee($this->practicalResults['APP']->student->account->name);
+        $component->assertDontSee($this->practicalResults['CTR']->student->account->name);
+    }
+
+    #[Test]
+    public function it_shows_all_exam_types_when_user_has_all_permissions()
+    {
+        $this->panelUser->givePermissionTo([
+            'training.exams.access',
+            'training.exams.conduct.obs',
+            'training.exams.conduct.twr',
+            'training.exams.conduct.app',
+            'training.exams.conduct.ctr',
+        ]);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should show all exam types
+        $component->assertSee($this->practicalResults['OBS']->student->account->name);
+        $component->assertSee($this->practicalResults['TWR']->student->account->name);
+        $component->assertSee($this->practicalResults['APP']->student->account->name);
+        $component->assertSee($this->practicalResults['CTR']->student->account->name);
+
+        $component->assertSee('OBS');
+        $component->assertSee('TWR');
+        $component->assertSee('APP');
+        $component->assertSee('CTR');
+    }
+
+    #[Test]
+    public function it_displays_correct_exam_result_badges()
+    {
+        // Update some results to different states
+        $this->practicalResults['OBS']->update(['result' => PracticalResult::PASSED]);
+        $this->practicalResults['TWR']->update(['result' => PracticalResult::FAILED]);
+        $this->practicalResults['APP']->update(['result' => PracticalResult::INCOMPLETE]);
+
+        $this->panelUser->givePermissionTo([
+            'training.exams.access',
+            'training.exams.conduct.obs',
+            'training.exams.conduct.twr',
+            'training.exams.conduct.app',
+        ]);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should show correct result badges
+        $component->assertSee('Passed');
+        $component->assertSee('Failed');
+        $component->assertSee('Incomplete');
+    }
+
+    #[Test]
+    public function it_displays_exam_information_correctly()
+    {
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        $twr = $this->practicalResults['TWR'];
+
+        // Should show exam information
+        $component->assertSee($twr->student->account->id); // CID
+        $component->assertSee($twr->student->account->name); // Name
+        $component->assertSee('TWR'); // Exam type
+        $component->assertSee($twr->examBooking->position_1); // Position
+    }
+
+    #[Test]
+    public function it_has_view_action_for_each_exam()
+    {
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should have view action (the URL will be tested separately)
+        $component->assertSee('View');
+    }
+
+    #[Test]
+    public function it_filters_by_exam_level_case_insensitive()
+    {
+        // Test that lowercase permissions match uppercase exam levels
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+
+        // Should show TWR exam even though permission is lowercase 'twr'
+        $component->assertSee($this->practicalResults['TWR']->student->account->name);
+        $component->assertSee('TWR');
+    }
+
+    #[Test]
+    public function it_handles_missing_exam_booking_gracefully()
+    {
+        // Create a practical result without an exam booking
+        $orphanStudent = Account::factory()->create();
+        $orphanStudentMember = Member::factory()->create([
+            'id' => $orphanStudent->id,
+            'cid' => $orphanStudent->id,
+        ]);
+
+        // Use a smaller examid that fits in the database column
+        PracticalResult::factory()->create([
+            'examid' => 9999, // Non-existent exam booking (smaller number)
+            'student_id' => $orphanStudentMember->id,
+            'result' => PracticalResult::PASSED,
+            'exam' => 'TWR',
+            'date' => now(),
+        ]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        // Should load without errors even with orphaned data
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamHistory::class)
+            ->assertSuccessful();
+    }
+}

--- a/tests/Feature/TrainingPanel/Exams/ViewExamReportTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ViewExamReportTest.php
@@ -1,0 +1,396 @@
+<?php
+
+namespace Tests\Feature\TrainingPanel\Exams;
+
+use App\Filament\Training\Pages\ViewExamReport;
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\ExamCriteria;
+use App\Models\Cts\ExamCriteriaAssessment;
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalResult;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class ViewExamReportTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    protected Account $student;
+
+    protected Member $studentMember;
+
+    protected ExamBooking $examBooking;
+
+    protected PracticalResult $practicalResult;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a student account and member
+        $this->student = Account::factory()->create();
+        $this->studentMember = Member::factory()->create([
+            'id' => $this->student->id,
+            'cid' => $this->student->id,
+        ]);
+
+        // Create an exam booking
+        $this->examBooking = ExamBooking::factory()->create([
+            'taken' => 1,
+            'finished' => ExamBooking::FINISHED_FLAG,
+            'exam' => 'TWR',
+            'student_id' => $this->studentMember->id,
+            'student_rating' => Qualification::code('S1')->first()->vatsim,
+            'position_1' => 'EGKK_TWR',
+        ]);
+
+        // Create examiners
+        $this->examBooking->examiners()->create([
+            'examid' => $this->examBooking->id,
+            'senior' => $this->panelUser->id,
+        ]);
+
+        // Create a practical result
+        $this->practicalResult = PracticalResult::factory()->create([
+            'examid' => $this->examBooking->id,
+            'student_id' => $this->studentMember->id,
+            'result' => PracticalResult::PASSED,
+            'notes' => 'Excellent performance throughout the exam.',
+            'exam' => 'TWR',
+        ]);
+    }
+
+    #[Test]
+    public function it_loads_if_authorised()
+    {
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_does_not_load_if_unauthorised()
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_does_not_load_if_missing_basic_access_permission()
+    {
+        // Only give conduct permission but not basic access
+        $this->panelUser->givePermissionTo('training.exams.conduct.twr');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_does_not_load_if_missing_conduct_permission_for_exam_level()
+    {
+        // Give basic access but wrong conduct permission (OBS instead of TWR)
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.obs']);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function it_loads_with_correct_conduct_permission_for_different_exam_levels()
+    {
+        // Test APP exam
+        $this->examBooking->update(['exam' => 'APP']);
+        $this->practicalResult->update(['exam' => 'APP']);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.app']);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function test_unauthorized_when_exam_doesnt_exist()
+    {
+        $examId = 9999; // Assuming this ID does not exist
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $examId]);
+    }
+
+    #[Test]
+    public function test_unauthorized_when_practical_result_doesnt_exist()
+    {
+        // Create an exam without a practical result
+        $examWithoutResult = ExamBooking::factory()->create([
+            'taken' => 1,
+            'finished' => ExamBooking::FINISHED_FLAG,
+            'exam' => 'TWR',
+            'student_id' => $this->studentMember->id,
+        ]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $examWithoutResult->id]);
+    }
+
+    #[Test]
+    public function test_displays_student_information_correctly()
+    {
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Check that student information is displayed
+        $component->assertSee($this->student->name)
+            ->assertSee($this->student->id)
+            ->assertSee($this->examBooking->studentQualification->name ?? 'S1');
+    }
+
+    #[Test]
+    public function test_displays_exam_information_correctly()
+    {
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Check that exam information is displayed
+        $component->assertSee($this->examBooking->exam)
+            ->assertSee($this->examBooking->position_1);
+    }
+
+    #[Test]
+    public function test_displays_exam_result_badge_correctly_for_passed()
+    {
+        $this->practicalResult->update(['result' => PracticalResult::PASSED]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Check that the passed result is displayed
+        $component->assertSee('Passed');
+    }
+
+    #[Test]
+    public function test_displays_exam_result_badge_correctly_for_failed()
+    {
+        $this->practicalResult->update(['result' => PracticalResult::FAILED]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Check that the failed result is displayed
+        $component->assertSee('Failed');
+    }
+
+    #[Test]
+    public function test_displays_exam_result_badge_correctly_for_incomplete()
+    {
+        $this->practicalResult->update(['result' => PracticalResult::INCOMPLETE]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Check that the incomplete result is displayed
+        $component->assertSee('Incomplete');
+    }
+
+    #[Test]
+    public function test_displays_additional_comments()
+    {
+        $this->practicalResult->update(['notes' => 'Additional comments about the exam performance.']);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Check that additional comments are displayed
+        $component->assertSee('Additional comments about the exam performance.');
+    }
+
+    #[Test]
+    public function test_displays_criteria_assessments_correctly()
+    {
+        // Create exam criteria
+        $criteria1 = ExamCriteria::create([
+            'exam' => 'TWR',
+            'criteria' => 'Radio Communication',
+            'deleted' => 0,
+        ]);
+
+        $criteria2 = ExamCriteria::create([
+            'exam' => 'TWR',
+            'criteria' => 'Traffic Management',
+            'deleted' => 0,
+        ]);
+
+        // Create criteria assessments
+        ExamCriteriaAssessment::create([
+            'examid' => $this->examBooking->id,
+            'criteria_id' => $criteria1->id,
+            'result' => ExamCriteriaAssessment::FULLY_COMPETENT,
+            'notes' => 'Excellent radio work',
+        ]);
+
+        ExamCriteriaAssessment::create([
+            'examid' => $this->examBooking->id,
+            'criteria_id' => $criteria2->id,
+            'result' => ExamCriteriaAssessment::MOSTLY_COMPETENT,
+            'notes' => 'Good traffic management with minor issues',
+        ]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Check that criteria and assessments are displayed
+        $component->assertSee('Radio Communication')
+            ->assertSee('Traffic Management')
+            ->assertSee('Excellent radio work')
+            ->assertSee('Good traffic management with minor issues')
+            ->assertSee('Fully Competent')
+            ->assertSee('Mostly Competent');
+    }
+
+    #[Test]
+    public function test_displays_examiner_information()
+    {
+        // Create secondary and trainee examiners
+        $secondaryExaminer = Account::factory()->create();
+        $traineeExaminer = Account::factory()->create();
+
+        Member::factory()->create(['id' => $secondaryExaminer->id, 'cid' => $secondaryExaminer->id]);
+        Member::factory()->create(['id' => $traineeExaminer->id, 'cid' => $traineeExaminer->id]);
+
+        $this->examBooking->examiners()->update([
+            'other' => $secondaryExaminer->id,
+            'trainee' => $traineeExaminer->id,
+        ]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Check that examiner information is displayed
+        $component->assertSee($this->panelUser->name) // Primary examiner
+            ->assertSee($secondaryExaminer->name) // Secondary examiner
+            ->assertSee($traineeExaminer->name); // Trainee examiner
+    }
+
+    #[Test]
+    public function test_handles_missing_examiner_information_gracefully()
+    {
+        // Update exam to have no secondary or trainee examiners
+        $this->examBooking->examiners()->update([
+            'other' => null,
+            'trainee' => null,
+        ]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Should load without errors even with missing examiner data
+    }
+
+    #[Test]
+    public function test_displays_exam_date_correctly()
+    {
+        $examDate = now()->subDays(5);
+        $this->examBooking->update([
+            'taken_date' => $examDate->format('Y-m-d'),
+            'taken_from' => $examDate->format('H:i'),
+        ]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Check that the exam date is displayed (uses startDate accessor)
+        $component->assertSee($examDate->format('Y-m-d'));
+    }
+
+    #[Test]
+    public function test_criteria_infolist_loads_correctly()
+    {
+        // Create some criteria and assessments
+        $criteria = ExamCriteria::create([
+            'exam' => 'TWR',
+            'criteria' => 'Test Criteria',
+            'deleted' => 0,
+        ]);
+
+        ExamCriteriaAssessment::create([
+            'examid' => $this->examBooking->id,
+            'criteria_id' => $criteria->id,
+            'result' => ExamCriteriaAssessment::FULLY_COMPETENT,
+            'notes' => 'Test notes',
+        ]);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful();
+
+        // Ensure the criteria infolist method exists and returns an Infolist
+        $this->assertTrue(method_exists($component->instance(), 'criteriaInfoList'));
+
+        $infolist = new \Filament\Infolists\Infolist($component->instance());
+        $result = $component->instance()->criteriaInfoList($infolist);
+        $this->assertInstanceOf(\Filament\Infolists\Infolist::class, $result);
+    }
+
+    #[Test]
+    public function test_page_handles_different_exam_types()
+    {
+        // Test with APP exam type
+        $this->examBooking->update(['exam' => 'APP']);
+        $this->practicalResult->update(['exam' => 'APP']);
+
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.app']);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ViewExamReport::class, ['examId' => $this->examBooking->id])
+            ->assertSuccessful()
+            ->assertSee('APP');
+    }
+}

--- a/tests/Unit/Repositories/Cts/ExamResultRepositoryTest.php
+++ b/tests/Unit/Repositories/Cts/ExamResultRepositoryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Unit\Repositories\Cts;
+
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalResult;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use App\Repositories\Cts\ExamResultRepository;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ExamResultRepositoryTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected ExamResultRepository $repository;
+
+    protected Account $user;
+
+    protected array $examBookings = [];
+
+    protected array $practicalResults = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = app(ExamResultRepository::class);
+        $this->user = Account::factory()->create(['id' => 9000000]);
+        Member::factory()->create(['id' => $this->user->id, 'cid' => $this->user->id]);
+
+        // Create exam data for all levels
+        $this->createExamData();
+    }
+
+    private function createExamData(): void
+    {
+        $examLevels = ['OBS', 'TWR', 'APP', 'CTR'];
+
+        foreach ($examLevels as $level) {
+            // Create a student account and member
+            $student = Account::factory()->create();
+            $studentMember = Member::factory()->create([
+                'id' => $student->id,
+                'cid' => $student->id,
+            ]);
+
+            // Create an exam booking
+            $examBooking = ExamBooking::factory()->create([
+                'taken' => 1,
+                'finished' => ExamBooking::FINISHED_FLAG,
+                'exam' => $level,
+                'student_id' => $studentMember->id,
+                'student_rating' => Qualification::code('S1')->first()->vatsim,
+                'position_1' => 'EGKK_'.$level,
+            ]);
+
+            // Create examiners
+            $examBooking->examiners()->create([
+                'examid' => $examBooking->id,
+                'senior' => $this->user->id,
+            ]);
+
+            // Create a practical result
+            $practicalResult = PracticalResult::factory()->create([
+                'examid' => $examBooking->id,
+                'student_id' => $studentMember->id,
+                'result' => PracticalResult::PASSED,
+                'exam' => $level,
+                'date' => now()->subDays(rand(1, 30)),
+            ]);
+
+            $this->examBookings[$level] = $examBooking;
+            $this->practicalResults[$level] = $practicalResult;
+        }
+    }
+
+    #[Test]
+    public function it_filters_exam_history_by_exam_levels_collection()
+    {
+        $examLevels = collect(['OBS', 'TWR']);
+
+        $query = $this->repository->getExamHistoryQueryForLevels($examLevels);
+        $results = $query->get();
+
+        // Should only return OBS and TWR results from our test data
+        $obsResults = $results->where('exam', 'OBS');
+        $twrResults = $results->where('exam', 'TWR');
+        $appResults = $results->where('exam', 'APP');
+        $ctrResults = $results->where('exam', 'CTR');
+
+        $this->assertGreaterThanOrEqual(1, $obsResults->count(), 'Should contain at least 1 OBS result');
+        $this->assertGreaterThanOrEqual(1, $twrResults->count(), 'Should contain at least 1 TWR result');
+        $this->assertEquals(0, $appResults->count(), 'Should contain no APP results');
+        $this->assertEquals(0, $ctrResults->count(), 'Should contain no CTR results');
+    }
+
+    #[Test]
+    public function it_returns_empty_query_when_no_exam_levels()
+    {
+        $examLevels = collect([]); // No exam levels
+
+        $query = $this->repository->getExamHistoryQueryForLevels($examLevels);
+        $results = $query->get();
+
+        // Should return no results
+        $this->assertCount(0, $results);
+    }
+
+    #[Test]
+    public function it_returns_all_exams_when_all_levels_provided()
+    {
+        $examLevels = collect(['OBS', 'TWR', 'APP', 'CTR']);
+
+        $query = $this->repository->getExamHistoryQueryForLevels($examLevels);
+        $results = $query->get();
+
+        // Should return all 4 exam types from our test data
+        $this->assertTrue($results->contains('exam', 'OBS'), 'Should contain OBS results');
+        $this->assertTrue($results->contains('exam', 'TWR'), 'Should contain TWR results');
+        $this->assertTrue($results->contains('exam', 'APP'), 'Should contain APP results');
+        $this->assertTrue($results->contains('exam', 'CTR'), 'Should contain CTR results');
+
+        // Verify we have at least our 4 test results
+        $this->assertGreaterThanOrEqual(4, $results->count(), 'Should contain at least 4 results');
+    }
+
+    #[Test]
+    public function it_accepts_collection_of_exam_levels()
+    {
+        $examLevels = collect(['OBS', 'TWR']);
+
+        $query = $this->repository->getExamHistoryQueryForLevels($examLevels);
+        $results = $query->get();
+
+        // Should only return OBS and TWR results from our test data
+        $obsResults = $results->where('exam', 'OBS');
+        $twrResults = $results->where('exam', 'TWR');
+        $appResults = $results->where('exam', 'APP');
+        $ctrResults = $results->where('exam', 'CTR');
+
+        $this->assertGreaterThanOrEqual(1, $obsResults->count(), 'Should contain at least 1 OBS result');
+        $this->assertGreaterThanOrEqual(1, $twrResults->count(), 'Should contain at least 1 TWR result');
+        $this->assertEquals(0, $appResults->count(), 'Should contain no APP results');
+        $this->assertEquals(0, $ctrResults->count(), 'Should contain no CTR results');
+    }
+
+    #[Test]
+    public function it_filters_single_exam_level()
+    {
+        $examLevels = collect(['CTR']);
+
+        $query = $this->repository->getExamHistoryQueryForLevels($examLevels);
+        $results = $query->get();
+
+        // Should return only CTR results from our test data
+        $obsResults = $results->where('exam', 'OBS');
+        $twrResults = $results->where('exam', 'TWR');
+        $appResults = $results->where('exam', 'APP');
+        $ctrResults = $results->where('exam', 'CTR');
+
+        $this->assertEquals(0, $obsResults->count(), 'Should contain no OBS results');
+        $this->assertEquals(0, $twrResults->count(), 'Should contain no TWR results');
+        $this->assertEquals(0, $appResults->count(), 'Should contain no APP results');
+        $this->assertGreaterThanOrEqual(1, $ctrResults->count(), 'Should contain at least 1 CTR result');
+    }
+
+    #[Test]
+    public function it_includes_proper_relationships_in_query()
+    {
+        $examLevels = collect(['TWR']);
+
+        $query = $this->repository->getExamHistoryQueryForLevels($examLevels);
+
+        // Verify that the query includes the expected relationships
+        $this->assertArrayHasKey('student', $query->getEagerLoads());
+        $this->assertArrayHasKey('examBooking', $query->getEagerLoads());
+    }
+
+    #[Test]
+    public function it_returns_builder_instance()
+    {
+        $examLevels = collect(['OBS']);
+
+        $query = $this->repository->getExamHistoryQueryForLevels($examLevels);
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, $query);
+    }
+
+    #[Test]
+    public function it_handles_empty_exam_levels_collection()
+    {
+        $examLevels = collect([]);
+
+        $query = $this->repository->getExamHistoryQueryForLevels($examLevels);
+        $results = $query->get();
+
+        // Should return no results
+        $this->assertCount(0, $results);
+    }
+
+    #[Test]
+    public function it_handles_invalid_exam_levels()
+    {
+        $examLevels = collect(['INVALID', 'NONEXISTENT']);
+
+        $query = $this->repository->getExamHistoryQueryForLevels($examLevels);
+        $results = $query->get();
+
+        // Should return no results since none of the levels match existing exam types
+        $this->assertCount(0, $results);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Filament-based UI for viewing exam history and individual exam reports, along with supporting backend changes to enable filtering and display of exam results and criteria assessments. The changes include new Filament pages, repository query methods, model relationships, and custom infolist components to provide a detailed and permission-aware exam reporting experience.

**New Filament pages for exam history and exam report:**

* Added `ExamHistory` and `ViewExamReport` Filament pages, allowing users to view a table of exam results and detailed reports for individual exams, with access control based on user permissions. (`app/Filament/Training/Pages/ExamHistory.php` [[1]](diffhunk://#diff-b9bbbbdc51e66268ef25ffaa95a2fdf159888b690768c2732ac1abf33ab78a41R1-R60) `app/Filament/Training/Pages/ViewExamReport.php` [[2]](diffhunk://#diff-a2d4c9681dfa62639fb237993b9047db5750ea257dd944dd607773e0ebc8a4b7R1-R94)
* Created corresponding Blade views for these pages to render tables and infolists. (`resources/views/filament/training/pages/exam-history.blade.php` [[1]](diffhunk://#diff-16f62110e54a60ceaafe81a6f1b7c2d5d61819f97fb33fd8f61e55eeb14a39a4R1-R3) `resources/views/filament/training/pages/view-exam-report.blade.php` [[2]](diffhunk://#diff-c9580455524c2fe867f421ddc41b2e78d457c282faeafaf65920070432698443R1-R7)

**Backend support for exam filtering and relationships:**

* Added `getExamHistoryQueryForLevels` method to `ExamResultRepository` to filter practical results by exam levels for the history table. (`app/Repositories/Cts/ExamResultRepository.php` [app/Repositories/Cts/ExamResultRepository.phpR44-R55](diffhunk://#diff-048659990f32f1885fe03aefb38a9c13ef34152d2e8201fcb7c0e45d63dba819R44-R55))
* Established new Eloquent relationships: `criteria()` in `PracticalResult` and `examCriteria()` in `ExamCriteriaAssessment`, enabling access to criteria assessments and their definitions. (`app/Models/Cts/PracticalResult.php` [[1]](diffhunk://#diff-449a9e8c156902b804fe26b29851d44208e9f0344f400fcc281071b7540444abR49-R53) `app/Models/Cts/ExamCriteriaAssessment.php` [[2]](diffhunk://#diff-0394c26daecdfdc7be2c6e4a1434cf7fbb31c138b1065f539a0b874dc2eb2065R39-R56)
* Added computed attribute `resultHuman` to `ExamCriteriaAssessment` for human-readable result display. (`app/Models/Cts/ExamCriteriaAssessment.php` [app/Models/Cts/ExamCriteriaAssessment.phpR39-R56](diffhunk://#diff-0394c26daecdfdc7be2c6e4a1434cf7fbb31c138b1065f539a0b874dc2eb2065R39-R56))

**Custom infolist component for criteria result display:**

* Introduced `PracticalExamCriteriaResult` component to visually display criteria results with color coding and text color based on result status. (`app/Infolists/Components/PracticalExamCriteriaResult.php` [[1]](diffhunk://#diff-a1a059a52ddfb237b431f62ac5c31e0a2d224b91d7e82e606d657fdd965e3e98R1-R34) `resources/views/infolists/components/practical-exam-criteria-result.blade.php` [[2]](diffhunk://#diff-1befd6d4b2a708d214b3cefffb20aa4acf0f8741c8c3c3212e6b35bc4fe3e91aR1-R6)

**UI and theme improvements:**

* Configured Filament panel to use a custom Tailwind CSS theme for consistent styling. (`app/Providers/Filament/TrainingPanelProvider.php` [app/Providers/Filament/TrainingPanelProvider.phpL49-R50](diffhunk://#diff-2e1473ead0707b4d7b9f6d5fed2e973f436e3f5a3e39b720dee7083f4615ed08L49-R50))

These changes collectively enhance the training module by providing a robust, permission-aware interface for exam history and reporting, with detailed criteria breakdowns and improved visual presentation.