### PR TITLE
feat: Add link to training panel on admin

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -68,7 +68,7 @@ class AdminPanelProvider extends PanelProvider
                 NavigationItem::make('Training Panel')
                     ->url(fn () => route('filament.training.pages.dashboard'))
                     ->icon('heroicon-o-academic-cap')
-                    ->visible(fn () => request()->user()->hasPermissionTo('training.access')),         
+                    ->visible(fn () => request()->user()->hasPermissionTo('training.access')),
                 NavigationItem::make('Horizon')
                     ->group('Technology')
                     ->icon('heroicon-o-bars-arrow-down')


### PR DESCRIPTION
Fixes #4371 

# Summary of changes

Adds a link to the training panel from the admin panel for those with access.

# Screenshots
<img width="1178" height="419" alt="image" src="https://github.com/user-attachments/assets/b86c4917-668e-4c68-bd81-396fa0c90065" />

