### PR TITLE
Fixes #4367 - Allow examiners in the exam history section of the training panel to see their past exams

### DIFF
--- a/app/Filament/Training/Pages/ExamHistory.php
+++ b/app/Filament/Training/Pages/ExamHistory.php
@@ -41,8 +41,13 @@ class ExamHistory extends Page implements HasTable
 
         $examResultRepository = app(ExamResultRepository::class);
         $query = $examResultRepository->getExamHistoryQueryForLevels($typesToShow);
-        $query->orWhereHas('examBooking', function ($q) {
-            $q->where('exmr_id', auth()->user()->id);
+
+        $query->where(function ($q) use ($typesToShow) {
+            $q->whereIn('exam', $typesToShow->toArray());
+
+            $q->orWhereHas('examBooking', function ($qb) {
+                $qb->where('exmr_id', auth()->id());
+            });
         });
 
         return $table->query($query)->columns([


### PR DESCRIPTION
Fixes #4367 

# Summary of changes
Allows examiners to see exams they conducted even if they no longer have that level of permissions anymore.

# Screenshots (if necessary)