### PR TITLE
Add My Statistics back to nav bar

### DIFF
--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -176,6 +176,7 @@
                             <li class="col-sm-12">
                                 <ul>
                                     <li><a href="https://helpdesk.vatsim.uk/">Contact Us</a></li>
+                                    <li><a href="{{ route('networkdata.dashboard') }}">My Statistics</a></li>
                                     <li class="divider"></li>
 
                                     <li class="dropdown-header">Waiting Lists</li>


### PR DESCRIPTION
Fixes #[issue_no]

# Summary of changes
- Added the My Statistics page back to the nav bar under membership.

# Screenshots (if necessary)