### PR TITLE
fix: Replace AFV with Track Audio on New Controller page

### DIFF
--- a/resources/views/site/atc/newcontroller.blade.php
+++ b/resources/views/site/atc/newcontroller.blade.php
@@ -53,7 +53,7 @@
 							<a href="https://vatsim.uk/ukcp" rel="external nofollow">UK Controller Plugin</a>
 						</li>
 						<li>
-							<a href="https://audio.vatsim.net/docs/2.0/atc/euroscope" rel="external nofollow">Audio for VATSIM</a>
+							<a href="https://github.com/pierr3/TrackAudio/releases" rel="external nofollow">Track Audio</a>
 						</li>
                         <li>
                             <a href="{{ route('site.community.teamspeak') }}" rel="">Teamspeak</a>&nbsp;Installed


### PR DESCRIPTION
Fixes #4441 

# Summary of changes
- Changed AFV to Track Audio, with a link to the Github releases, in the FAQs section. Track Audio is now required over AFV as of #4170

# Screenshots (if necessary)
<img width="2347" height="610" alt="image" src="https://github.com/user-attachments/assets/f3bf9a4d-49fd-4eba-99fe-36df5f421251" />