### PR TITLE
fix: Update the link to the UKCP download

### DIFF
--- a/resources/views/ukcp/token/guide.blade.php
+++ b/resources/views/ukcp/token/guide.blade.php
@@ -42,7 +42,7 @@
                     EuroScope allows you to load plugins from one simple file.<br/>
                     Click below to download the latest version of the UK Controller Plugin.<br/>
                     <br/>
-                    <a href="https://community.vatsim.uk/files/downloads/file/215-uk-controller-plugin/"
+                    <a href="https://github.com/VATSIM-UK/uk-controller-plugin/releases/"
                        target="_blank">
                         <button class="btn btn-primary center-block">Download UK Controller Plugin</button>
                     </a>


### PR DESCRIPTION
Fixes #4442 

# Summary of changes
- The link to the forums to download UKCP, on https://www.vatsim.uk/ukcp, no longer works. Link to the Github releases page instead.

# Screenshots (if necessary)

