### PR TITLE
Allow solo endorsement to be issued without request from training place view

### DIFF
--- a/app/Livewire/Training/TrainingPlaceSoloEndorsement.php
+++ b/app/Livewire/Training/TrainingPlaceSoloEndorsement.php
@@ -4,8 +4,11 @@ namespace App\Livewire\Training;
 
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Services\Training\EndorsementService;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Tables\Actions\Action;
 use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
@@ -60,6 +63,47 @@ class TrainingPlaceSoloEndorsement extends Component implements HasForms, HasTab
                             default => 'primary',
                         }
                     ),
+            ])
+            ->headerActions([
+                Action::make('issue_solo_endorsement')
+                    ->label('Issue Solo Endorsement')
+                    ->color('primary')
+                    ->visible(fn () => auth()->check() && auth()->user()->can('endorsement.create.temporary'))
+                    ->disabled(fn () => EndorsementService::hasActiveSoloEndorsement(
+                        $this->trainingPlace->trainingPosition->position,
+                        $this->trainingPlace->waitingListAccount->account
+                    ))
+                    ->form([
+                        TextInput::make('days')
+                            ->label('Duration (Days)')
+                            ->numeric()
+                            ->required()
+                            ->minValue(1)
+                            ->maxValue(90)
+                            ->default(7)
+                            ->helperText('Number of days the solo endorsement will be valid for'),
+                    ])
+                    ->action(function (array $data) {
+                        $position = $this->trainingPlace->trainingPosition->position;
+                        $account = $this->trainingPlace->waitingListAccount->account;
+                        $creator = auth()->user();
+
+                        EndorsementService::createTemporary(
+                            $position,
+                            $account,
+                            $creator,
+                            (int) $data['days']
+                        );
+
+                        Notification::make()
+                            ->title('Solo endorsement issued successfully')
+                            ->success()
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->modalHeading('Issue Solo Endorsement')
+                    ->modalDescription(fn () => 'Issue a solo endorsement for '.$this->trainingPlace->trainingPosition->position->name.' to '.$this->trainingPlace->waitingListAccount->account->name)
+                    ->modalSubmitActionLabel('Issue Endorsement'),
             ])
             ->emptyStateHeading('No solo endorsements found');
     }

--- a/app/Services/Training/EndorsementService.php
+++ b/app/Services/Training/EndorsementService.php
@@ -23,6 +23,30 @@ class EndorsementService
         ]);
     }
 
+    public static function createTemporary(Endorseable $endorsable, Account $account, Account $creator, int $days)
+    {
+        return Endorsement::create([
+            'account_id' => $account->id,
+            'created_by' => $creator->id,
+            'endorsable_type' => $endorsable::class,
+            'endorsable_id' => $endorsable->id,
+            'expires_at' => now()->addDays($days),
+            'endorsement_request_id' => null,
+        ]);
+    }
+
+    public static function hasActiveSoloEndorsement(Position $position, Account $account): bool
+    {
+        return $account
+            ->endorsements()
+            ->where('expires_at', '>=', now())
+            ->whereHasMorph('endorsable',
+                Position::class,
+                fn ($query) => $query->where('id', $position->id)
+            )
+            ->exists();
+    }
+
     public static function getSoloEndorsementsForTrainingPlace(TrainingPlace $trainingPlace): Builder
     {
         return Endorsement::query()


### PR DESCRIPTION
This pull request adds support for issuing temporary solo endorsements for training positions, including backend logic, UI integration, and comprehensive test coverage. The changes introduce a new action in the training place endorsement table to issue a solo endorsement for a specified duration, ensure only eligible users can issue endorsements, and prevent duplicate active endorsements.

### Feature: Temporary Solo Endorsements

* Added `createTemporary` method to `EndorsementService` to allow creation of solo endorsements with a specified expiry date (`expires_at`).
* Implemented `hasActiveSoloEndorsement` in `EndorsementService` to check if an account already has an active solo endorsement for a given position, preventing duplicate endorsements.

### UI Integration

* Added a new "Issue Solo Endorsement" header action to the training place solo endorsement table, including a form for specifying duration, confirmation modal, and success notification. The action is only visible to authorized users and is disabled if an active endorsement already exists.

### Test Coverage

* Added multiple unit tests to `EndorsementServiceTest` to verify the logic of `hasActiveSoloEndorsement` under various scenarios (active, expired, different position/account, permanent endorsements, etc.).

### Dependency Updates

* Imported necessary Filament components for forms, notifications, and actions in `TrainingPlaceSoloEndorsement.php` to support the new UI functionality.