### PR TITLE
Add re-usable reference to ATC training handbook URL

### DIFF
--- a/resources/lang/en/atc.php
+++ b/resources/lang/en/atc.php
@@ -8,4 +8,6 @@ return [
     'type.app' => 'Approach',
     'type.ctr' => 'En-Route',
     'type.fss' => 'Flight Service Station',
+
+    'handbook.url' => 'https://community.vatsim.uk/files/downloads/file/230-atc-training-handbook/',
 ];

--- a/resources/views/emails/training/exams/exam_accepted_examiner.blade.php
+++ b/resources/views/emails/training/exams/exam_accepted_examiner.blade.php
@@ -26,14 +26,12 @@ You should consider whether or not to ping for adjacent ATC or pilots to support
 It is the responsibility of you as the primary examiner to arrange for these pings if required.
 </p>
 
-<p>You should brief the candidate at the beginning of the exam in accordance with the <a href="https://community.vatsim.uk/files/downloads/file/230-atc-training-handbook/">ATC Training Handbook</a>.</p>
+<p>You should brief the candidate at the beginning of the exam in accordance with the <a href="{{ __('atc.handbook.url') }}">ATC Training Handbook</a>.</p>
 
-<p>Should the candidate fail to attend, please notify the relevant TGI.
-In the event of either failure or success, feedback on the exam should be summarised to the training group in question.
-</p>
+<p>Should the candidate fail to attend, please notify the relevant TGI. In the event of either failure or success, feedback on the exam should be summarised to the training group in question.</p>
 
-@stop
+@endsection
 
 @section('signature')
 VATSIM UK Training Department
-@stop
+@endsection

--- a/resources/views/site/atc/newcontroller-process.blade.php
+++ b/resources/views/site/atc/newcontroller-process.blade.php
@@ -83,7 +83,7 @@ We aim to keep this wait under one month by only running seminars when this ‘b
 
 ### Step 5 - Practical training
 
-Where applicable, eligibility criteria are defined in the relevant sections of the [ATC Training Handbook](https://community.vatsim.uk/files/downloads/file/230-atc-training-handbook/).
+Where applicable, eligibility criteria are defined in the relevant sections of the [ATC Training Handbook]({{ __('atc.handbook.url') }}).
 Once a training place is available, training staff will offer it to you by email/ticket.
 You will have 84 hours (3.5 days) to respond before the place is offered to the next eligible student on the waiting list.
 Places may be offered on any of the UK’s training aerodromes.
@@ -121,7 +121,7 @@ To progress to your S2 rating, you will need to have controlled as an S1 for 50 
 
 To do this, submit a ticket to ATC Training via the [helpdesk](https://helpdesk.vatsim.uk/). You may be offered a training place at any UK aerodrome.
 
-Further information on our training programmes is available in the [ATC Training Handbook](https://community.vatsim.uk/files/downloads/file/230-atc-training-handbook/).
+Further information on our training programmes is available in the [ATC Training Handbook]({{ __('atc.handbook.url') }}).
 
 Your S2 training will review and solidify what you’ve learnt during your S1 training, so you should use the waiting time to practice your skills.
 


### PR DESCRIPTION
Will likely be useful in the future for static content.