### PR TITLE
Add exam forward action to training place view

### DIFF
--- a/app/Filament/Training/Pages/TheoryExamHistory.php
+++ b/app/Filament/Training/Pages/TheoryExamHistory.php
@@ -2,7 +2,7 @@
 
 namespace App\Filament\Training\Pages;
 
-use App\Repositories\Cts\TheoryExamResultRepository as CtsTheoryExamResultRepository;
+use App\Repositories\Cts\TheoryExamResultRepository;
 use Carbon\Carbon;
 use Filament\Forms;
 use Filament\Infolists\Components\Fieldset;
@@ -28,11 +28,13 @@ class TheoryExamHistory extends Page implements HasTable
 
     public static function canAccess(): bool
     {
+
         return auth()->user()->can('training.theory.access');
     }
 
     protected function buildQuestionPlaceholders($record): array
     {
+
         if (! $record) {
             return [];
         }
@@ -81,7 +83,7 @@ class TheoryExamHistory extends Page implements HasTable
 
         $typesToShow = collect($userPermissionsTruthTable)->filter(fn ($value) => $value)->keys();
 
-        $theoryExamResultRepository = app(CtsTheoryExamResultRepository::class);
+        $theoryExamResultRepository = app(TheoryExamResultRepository::class);
         $query = $theoryExamResultRepository->getTheoryExamHistoryQueryForLevels($typesToShow);
 
         return $table->query($query)->columns([


### PR DESCRIPTION
# Summary of changes

Big forward button which forwards a member to a practical exam (same logic as exam setup)
Added a small checkbox indicating the the member already has a pending exam booking (which disables the forward button)

_modal for forwarding, position is set to default but is editable_
<img width="927" height="452" alt="image" src="https://github.com/user-attachments/assets/8e374a2f-1c58-4481-aa64-9ded350486bd" />

_exam booking already exist_
<img width="1272" height="584" alt="image" src="https://github.com/user-attachments/assets/733d5954-3146-4ae9-b7e2-3a00867e8f1c" />
