### PR TITLE
Fixes #4394 - Text does no wrap and leaks from div on exam report additional comments 

### DIFF
--- a/app/Filament/Training/Pages/Exam/ViewExamReport.php
+++ b/app/Filament/Training/Pages/Exam/ViewExamReport.php
@@ -76,7 +76,7 @@ class ViewExamReport extends Page implements HasInfolists
                     default => 'gray',
                 })->getStateUsing(fn ($record) => $record->resultHuman()),
 
-                TextEntry::make('notes')->html()->extraAttributes(['style' => 'word-break:break-word',])->label('Additional Comments'),
+                TextEntry::make('notes')->html()->extraAttributes(['style' => 'word-break:break-word'])->label('Additional Comments'),
 
             ])->columns(2)->extraAttributes(['class' => 'items-stretch']),
         ]);


### PR DESCRIPTION
Fixes #4394 

# Summary of changes
- Added `word-break:break-word` style to ensure text wrapped correctly

# Screenshots (if necessary)
Before:
<img width="1254" height="337" alt="image" src="https://github.com/user-attachments/assets/dd29ffb4-188b-445f-ae48-01bc8489bc92" />


After:
<img width="1246" height="379" alt="image" src="https://github.com/user-attachments/assets/7588c3cd-89e6-4d32-9651-1782af030077" />
