### PR TITLE
fix: ensure text wraps in exam reports

### DIFF
--- a/app/Filament/Training/Pages/Exam/ViewExamReport.php
+++ b/app/Filament/Training/Pages/Exam/ViewExamReport.php
@@ -88,7 +88,7 @@ class ViewExamReport extends Page implements HasInfolists
             RepeatableEntry::make('criteria')->label('')->schema([
                 TextEntry::make('examCriteria.criteria')->label(null)->columnSpan(10),
                 PracticalExamCriteriaResult::make('result')->label('Result')->columnSpan(2),
-                TextEntry::make('notes')->html()->label('Notes')->columnSpan(12),
+                TextEntry::make('notes')->extraAttributes(['style' => 'word-break:break-word'])->html()->label('Notes')->columnSpan(12),
             ])->columns(12),
         ]);
     }


### PR DESCRIPTION
# Summary of changes
- Fixed text wrapping within criteria

# Screenshots (if necessary)
Before: 
<img width="1741" height="557" alt="image" src="https://github.com/user-attachments/assets/5acf4bb6-8c7f-4ee3-a441-0b4f6ba8d4bb" />


After:
<img width="1403" height="781" alt="image" src="https://github.com/user-attachments/assets/bdd21472-7ceb-482f-a227-913b484ad31b" />
