### PR TITLE
chore: stop logging when members' Discord server limit being reached

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -24,6 +24,7 @@ class Handler extends ExceptionHandler
         \Illuminate\Validation\ValidationException::class,
         \Illuminate\Queue\MaxAttemptsExceededException::class,
         \League\OAuth2\Server\Exception\OAuthServerException::class,
+        \App\Exceptions\Discord\DiscordUserInviteException::class,
     ];
 
     /**

--- a/app/Libraries/Discord.php
+++ b/app/Libraries/Discord.php
@@ -145,6 +145,7 @@ class Discord
         );
 
         if ($response->status() > 300 && $response->json()['code'] == 30001) {
+            Log::warning('Discord invite: server limit reached', $context);
             throw new DiscordUserInviteException($response, 'You have reached your Discord server limit! You must leave a server before you can join another one');
         }
 


### PR DESCRIPTION
# Summary of changes
- Remove logging when members' Discord server limit being reached

# Screenshots (if necessary)
