### PR TITLE
fix: attempt to read property "name" on null on roster page

### DIFF
--- a/resources/views/livewire/roster/show.blade.php
+++ b/resources/views/livewire/roster/show.blade.php
@@ -34,7 +34,7 @@
                                     @endif
                                             </span>
                                 <span
-                                    class="text-xs text-left opacity-50">Covers: {{ $endorsement->endorsable->description }}</span>
+                                    class="text-xs text-left opacity-50">Covers: {{ $endorsement->endorsable?->description ?? 'No description available' }}</span>
                             @endforeach
                         @endforeach
                     </div>


### PR DESCRIPTION
Fixes [error](https://app.bugsnag.com/vatsim-uk/core-1/errors/66de113aa82a2b76fa4c6c42?filters[error.status]=open&filters[event.since]=30d)

# Summary of changes
- Added safe handling for endorsements returning null on the roster page

# Screenshots (if necessary)
