### PR TITLE
fix: replace `discord.new` with `mship.manage.dashboard`

### DIFF
--- a/app/Http/Controllers/Discord/Registration.php
+++ b/app/Http/Controllers/Discord/Registration.php
@@ -21,7 +21,7 @@ class Registration extends BaseController
 
     public function show()
     {
-        return $this->viewMake('discord.new');
+        return redirect()->route('mship.manage.dashboard');
     }
 
     public function create(Request $request)


### PR DESCRIPTION
Fixes [error](https://app.bugsnag.com/vatsim-uk/core-1/errors/696fdf4d465de18423d7db86?filters[error.status]=open&filters[event.since]=30d)

# Summary of changes
- Replaced `discord.new` with `mship.manage.dashboard` as `discord.new` no longer exists. The discord options are now on the `mship.manage.dashboard` page

# Screenshots (if necessary)
