### PR TITLE
fix: resolve error when using the search on the exam history page

### DIFF
--- a/app/Filament/Training/Pages/Exam/ExamHistory.php
+++ b/app/Filament/Training/Pages/Exam/ExamHistory.php
@@ -51,7 +51,10 @@ class ExamHistory extends Page implements HasTable
         $query = $examResultRepository->getExamHistoryQueryForLevels($typesToShow);
 
         return $table->query($query)->columns([
-            TextColumn::make('student.account.id')->label('CID')->searchable(),
+            TextColumn::make('student.account.id')->label('CID')
+                ->searchable(query: function ($query, string $search): void {
+                    $query->where('student_id', 'like', "%{$search}%");
+                }),
             TextColumn::make('student.account.name')->label('Name'),
             TextColumn::make('examBooking.exam')->label('Exam'),
             TextColumn::make('result')->getStateUsing(fn ($record) => $record->resultHuman())->badge()->color(fn ($state) => match ($state) {


### PR DESCRIPTION
Fixes [error](https://app.bugsnag.com/vatsim-uk/core-1/errors/66a3bc884bfebb681929641f?filters[error.status]=for_review&filters[event.since]=30d&filters[app.release_stage]=production&pivot_tab=event)

Previously searching anything into the exam history search bar would bring back the following error, `Unknown column 'student' in 'where clause'`

# Summary of changes
- The search bar now works correctly

# Screenshots (if necessary)