### PR TITLE
fix: Permanent Instruction link

### DIFF
--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -146,7 +146,7 @@
 
                                     <li class="dropdown-header">Operations</li>
                                     <li><a href="https://docs.vatsim.uk/">ATC Documentation</a></li>
-                                    <li><a href="https://docs.vatsim.uk/Briefing/">ATC Procedure Changes</a></li>
+                                    <li><a href="https://docs.vatsim.uk/Briefing/">ATC Permanent Instructions</a></li>
                                     <li><a href="https://docs.vatsim.uk/General/">ATC Software</a></li>
                                     <li class="divider"></li>
 


### PR DESCRIPTION
Fixes #dead links and old naming

# Summary of changes

Links to the docs briefing area where PIs, TIs, and NOTs (ATC Notices) are now hosted.

Also changes software link to the general section, where it's a bit more obvious where to go. Feel free to strip this out though.