### PR TITLE
Show total number of cancelled sessions in training place view

### DIFF
--- a/app/Filament/Training/Pages/TrainingPlace/Widgets/MentoringSessionStatsWidget.php
+++ b/app/Filament/Training/Pages/TrainingPlace/Widgets/MentoringSessionStatsWidget.php
@@ -17,13 +17,19 @@ class MentoringSessionStatsWidget extends BaseWidget
     {
         $sessionRepository = app(SessionRepository::class);
 
+        $ctsStudentId = $this->trainingPlace->waitingListAccount->account->member->id;
+
         return [
-            Stat::make('Total Sessions', $sessionRepository->getTotalSessionsForPositions($this->trainingPlace->trainingPosition->cts_positions, $this->trainingPlace->waitingListAccount->account->member->id))
+            Stat::make('Total Sessions', $sessionRepository->getTotalSessionsForPositions($this->trainingPlace->trainingPosition->cts_positions, $ctsStudentId))
                 ->icon('heroicon-o-document-text')
                 ->description('Includes Sweatbox sessions')
                 ->color('primary'),
 
-            Stat::make('Total No Show Sessions', $sessionRepository->getTotalNoShowSessionsForPositions($this->trainingPlace->trainingPosition->cts_positions))
+            Stat::make('Total Cancelled Sessions', $sessionRepository->getTotalCancelledSessionsForPositions($this->trainingPlace->trainingPosition->cts_positions, $ctsStudentId))
+                ->icon('heroicon-o-document-text')
+                ->color('warning'),
+
+            Stat::make('Total No Show Sessions', $sessionRepository->getTotalNoShowSessionsForPositions($this->trainingPlace->trainingPosition->cts_positions, $ctsStudentId))
                 ->icon('heroicon-o-document-text')
                 ->color('danger'),
         ];

--- a/app/Repositories/Cts/SessionRepository.php
+++ b/app/Repositories/Cts/SessionRepository.php
@@ -45,4 +45,12 @@ class SessionRepository
             ->where('noShow', '=', 1)
             ->count();
     }
+
+    public function getTotalCancelledSessionsForPositions(array $positionCallsigns, int $studentId)
+    {
+        return Session::where('student_id', $studentId)
+            ->whereIn('position', $positionCallsigns)
+            ->whereNotNull('cancelled_datetime')
+            ->count();
+    }
 }


### PR DESCRIPTION
This pull request updates the mentoring session statistics widget to provide more detailed session counts and adds a new method to the session repository for tracking cancelled sessions. The main changes are grouped below:

**Widget statistics improvements:**

* The `MentoringSessionStatsWidget` now displays a count of "Total Cancelled Sessions" for the relevant student and training positions, in addition to the existing statistics.

**Repository enhancements:**

* Added a new method `getTotalCancelledSessionsForPositions` to `SessionRepository` to count cancelled sessions for a given student and set of positions.