### PR TITLE
fix: set page titles for feedback, airports, and data

### DIFF
--- a/app/Http/Controllers/Atc/EndorsementController.php
+++ b/app/Http/Controllers/Atc/EndorsementController.php
@@ -34,6 +34,8 @@ class EndorsementController extends BaseController
         $totalHours = $minutesOnline / 60;
         $hoursMet = $totalHours >= self::HEATHROW_S1_HOURS_REQUIREMENT;
 
+        $this->setTitle('Heathrow Ground (S1) Endorsement');
+
         return $this->viewMake('controllers.endorsements.heathrow_ground_s1')
             ->with('totalHours', $totalHours)
             ->with('progress', ($totalHours / self::HEATHROW_S1_HOURS_REQUIREMENT) * 100)

--- a/app/Http/Controllers/Mship/Feedback.php
+++ b/app/Http/Controllers/Mship/Feedback.php
@@ -23,6 +23,8 @@ class Feedback extends \App\Http\Controllers\BaseController
             $feedbackForms[$f->slug] = $f->name;
         }
 
+        $this->setTitle('Submit Feedback');
+
         return $this->viewMake('mship.feedback.form')
             ->with('feedbackForms', $feedbackForms);
     }
@@ -77,6 +79,8 @@ class Feedback extends \App\Http\Controllers\BaseController
                 old($question->slug, array_get($defaultValues, $question->slug))
             );
         }
+
+        $this->setTitle($form->name ?? 'Submit Feedback');
 
         return $this->viewMake('mship.feedback.form')->with(['form' => $form, 'questions' => $questions]);
     }

--- a/app/Http/Controllers/Mship/Feedback/ViewFeedbackController.php
+++ b/app/Http/Controllers/Mship/Feedback/ViewFeedbackController.php
@@ -17,6 +17,8 @@ class ViewFeedbackController extends \App\Http\Controllers\BaseController
             return Redirect::route('mship.manage.dashboard')->withError('You have no feedback available to view at this time.');
         }
 
+        $this->setTitle('Your Feedback');
+
         return $this->viewMake('mship.feedback.view')
             ->with('feedback', $feedback);
     }

--- a/app/Http/Controllers/Mship/WaitingLists.php
+++ b/app/Http/Controllers/Mship/WaitingLists.php
@@ -32,12 +32,13 @@ class WaitingLists extends BaseController
             }
         }
 
-        return view('mship.waiting-lists.index', [
-            'atcWaitingListAccounts' => $atcWaitingListAccounts,
-            'atcSelfEnrolmentLists' => WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($request->user())->where('department', WaitingList::ATC_DEPARTMENT),
-            'pilotSelfEnrolmentLists' => WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($request->user())->where('department', WaitingList::PILOT_DEPARTMENT),
-            'pilotWaitingListAccounts' => $pilotWaitingListAccounts,
-        ]);
+        $this->setTitle('Waiting Lists');
+
+        return $this->viewMake('mship.waiting-lists.index')
+            ->with('atcWaitingListAccounts', $atcWaitingListAccounts)
+            ->with('atcSelfEnrolmentLists', WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($request->user())->where('department', WaitingList::ATC_DEPARTMENT))
+            ->with('pilotSelfEnrolmentLists', WaitingListSelfEnrolment::getListsAccountCanSelfEnrol($request->user())->where('department', WaitingList::PILOT_DEPARTMENT))
+            ->with('pilotWaitingListAccounts', $pilotWaitingListAccounts);
     }
 
     public function selfEnrol(WaitingList $waitingList, Request $request)

--- a/app/Http/Controllers/NetworkData/MainController.php
+++ b/app/Http/Controllers/NetworkData/MainController.php
@@ -11,6 +11,8 @@ class MainController extends BaseController
         $atcSessions = $this->account->networkDataAtc()->offline()->orderBy('created_at', 'DESC')->paginate(20, ['*'], 'atcSessions');
         $pilotSessions = $this->account->networkDataPilot()->offline()->orderBy('created_at', 'DESC')->paginate(20, ['*'], 'pilotSessions');
 
+        $this->setTitle('Network Data Dashboard');
+
         return $this->viewMake('network-data.dashboard')->with('atcSessions', $atcSessions)->with('pilotSessions', $pilotSessions);
     }
 }

--- a/app/Http/Controllers/Site/AirportController.php
+++ b/app/Http/Controllers/Site/AirportController.php
@@ -20,11 +20,15 @@ class AirportController extends BaseController
     {
         $airports = Airport::uk()->orderBy('name')->get()->split(2);
 
+        $this->setTitle('Airports');
+
         return $this->viewMake('site.airport.index')->with('airports', $airports);
     }
 
     public function show(Airport $airport)
     {
+        $this->setTitle("{$airport->icao} | {$airport->name}");
+
         return $this->viewMake('site.airport.view')
             ->with(
                 [


### PR DESCRIPTION
## Summary
* set explicit titles for feedback forms/views, airports, endorsements, network data dashboard, and waiting lists
* ensure waiting list page uses the base controller so title and layout data are injected

## Rationale
* addresses [Incorrect page titles #4460](https://github.com/VATSIM-UK/core/issues/4460) reports of pages falling back to the generic home title
 
## Changes
* add descriptive titles in controllers for feedback (submit/view), airports (list/detail), endorsement flows, and network data dashboard
* switch waiting list index to the shared view helper and set a title
 
## Test Plan
* CI (lint + PHP) on fork: pass
 
Fixes #4460

Credit to @cnaples79 for this fix I just cleared the conflict so we can close the last issue (at the time of my posting this PR)