### PR TITLE
Add basic training place list view

### DIFF
--- a/app/Filament/Training/Resources/TrainingPlaceResource.php
+++ b/app/Filament/Training/Resources/TrainingPlaceResource.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Training\Resources;
+
+use App\Filament\Training\Pages\TrainingPlace\ViewTrainingPlace;
+use App\Filament\Training\Resources\TrainingPlaceResource\Pages;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class TrainingPlaceResource extends Resource
+{
+    protected static ?string $model = TrainingPlace::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-academic-cap';
+
+    protected static ?string $navigationLabel = 'Training Places';
+
+    protected static ?string $navigationGroup = 'Training';
+
+    protected static ?int $navigationSort = 2;
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query
+                ->with([
+                    'waitingListAccount.account',
+                    'waitingListAccount.waitingList',
+                    'trainingPosition.position',
+                ])
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('ID')
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+
+                Tables\Columns\TextColumn::make('waitingListAccount.account.name')
+                    ->label('Student')
+                    ->searchable(['name_first', 'name_last'])
+                    ->sortable()
+                    ->url(fn (TrainingPlace $record) => ViewTrainingPlace::getUrl(['trainingPlaceId' => $record->id])),
+
+                Tables\Columns\TextColumn::make('waitingListAccount.account_id')
+                    ->label('CID')
+                    ->searchable()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('trainingPosition.position.callsign')
+                    ->label('Position')
+                    ->searchable()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('waiting_list')
+                    ->relationship('waitingListAccount.waitingList', 'name')
+                    ->label('Waiting List')
+                    ->preload()
+                    ->searchable(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make()
+                    ->url(fn (TrainingPlace $record) => url("/training/training-places/{$record->id}")),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->persistSearchInSession()
+            ->persistFiltersInSession()
+            ->persistColumnSearchesInSession()
+            ->paginated(['25', '50', '100'])
+            ->defaultPaginationPageOption(25);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTrainingPlaces::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Training/Resources/TrainingPlaceResource/Pages/ListTrainingPlaces.php
+++ b/app/Filament/Training/Resources/TrainingPlaceResource/Pages/ListTrainingPlaces.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Filament\Training\Resources\TrainingPlaceResource\Pages;
+
+use App\Filament\Training\Resources\TrainingPlaceResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTrainingPlaces extends ListRecords
+{
+    protected static string $resource = TrainingPlaceResource::class;
+
+    protected static ?string $title = 'Training Places';
+}

--- a/app/Policies/TrainingPlacePolicy.php
+++ b/app/Policies/TrainingPlacePolicy.php
@@ -12,7 +12,7 @@ class TrainingPlacePolicy
      */
     public function viewAny(Account $account): bool
     {
-        return false;
+        return $account->hasPermissionTo('training-places.view.*');
     }
 
     /**
@@ -20,7 +20,7 @@ class TrainingPlacePolicy
      */
     public function view(Account $account, TrainingPlace $trainingPlace): bool
     {
-        return false;
+        return $account->hasPermissionTo('training-places.view.*');
     }
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -7,6 +7,7 @@ use App\Models\Mship\Account\Ban;
 use App\Models\Mship\Account\EndorsementRequest;
 use App\Models\Mship\Account\Note;
 use App\Models\Mship\Feedback\Feedback;
+use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\WaitingList;
 use App\Models\Training\WaitingList\WaitingListRetentionCheck;
 use App\Models\VisitTransfer;
@@ -20,6 +21,7 @@ use App\Policies\RolePolicy;
 use App\Policies\Training\WaitingList\WaitingListRetentionChecksPolicy;
 use App\Policies\Training\WaitingListFlagsPolicy;
 use App\Policies\Training\WaitingListPolicy;
+use App\Policies\TrainingPlacePolicy;
 use App\Policies\VisitTransfer\ApplicationPolicy;
 use App\Policies\VisitTransfer\ReferencePolicy;
 use App\Registrars\PermissionRegistrar as RegistrarsPermissionRegistrar;
@@ -53,6 +55,7 @@ class AuthServiceProvider extends ServiceProvider
         Role::class => RolePolicy::class,
         Note::class => NotePolicy::class,
         WaitingListRetentionCheck::class => WaitingListRetentionChecksPolicy::class,
+        TrainingPlace::class => TrainingPlacePolicy::class,
     ];
 
     /**

--- a/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature\TrainingPanel\TrainingPlace;
+
+use App\Filament\Training\Resources\TrainingPlaceResource\Pages\ListTrainingPlaces;
+use App\Models\Cts\Member;
+use App\Models\Cts\Position as CtsPosition;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Models\Training\WaitingList;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_can_render_training_places_list_page_with_permission()
+    {
+        // Arrange
+        $user = Account::factory()->create();
+        $user->givePermissionTo('training-places.view.*');
+
+        // Act & Assert
+        Livewire::actingAs($user)
+            ->test(ListTrainingPlaces::class)
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_cannot_render_training_places_list_page_without_permission()
+    {
+        // Arrange
+        $user = Account::factory()->create();
+
+        // Act & Assert
+        Livewire::actingAs($user)
+            ->test(ListTrainingPlaces::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_displays_training_places_in_table()
+    {
+        // Arrange
+        $ctsPosition = CtsPosition::factory()->create(['callsign' => 'EGLL_TWR']);
+        $trainingPosition = TrainingPosition::factory()->withCtsPositions([$ctsPosition->callsign])->create();
+
+        $waitingList = WaitingList::factory()->create(['name' => 'Test Waiting List']);
+        $student = Account::factory()->create();
+        Member::factory()->create(['cid' => $student->id]);
+
+        $waitingListAccount = $waitingList->addToWaitingList($student, $this->privacc);
+
+        $trainingPlace = TrainingPlace::create([
+            'waiting_list_account_id' => $waitingListAccount->id,
+            'training_position_id' => $trainingPosition->id,
+        ]);
+
+        // Act & Assert
+        Livewire::actingAs($this->privacc)
+            ->test(ListTrainingPlaces::class)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$trainingPlace])
+            ->assertTableColumnExists('waitingListAccount.account.name')
+            ->assertTableColumnExists('waitingListAccount.account_id')
+            ->assertTableColumnExists('trainingPosition.position.callsign');
+    }
+
+    #[Test]
+    public function it_can_filter_by_waiting_list()
+    {
+        // Arrange
+        $ctsPosition = CtsPosition::factory()->create(['callsign' => 'EGLL_APP']);
+        $trainingPosition = TrainingPosition::factory()->withCtsPositions([$ctsPosition->callsign])->create();
+
+        $waitingList1 = WaitingList::factory()->create(['name' => 'List One']);
+        $waitingList2 = WaitingList::factory()->create(['name' => 'List Two']);
+
+        $student1 = Account::factory()->create();
+        $student2 = Account::factory()->create();
+        Member::factory()->create(['cid' => $student1->id]);
+        Member::factory()->create(['cid' => $student2->id]);
+
+        $waitingListAccount1 = $waitingList1->addToWaitingList($student1, $this->privacc);
+        $waitingListAccount2 = $waitingList2->addToWaitingList($student2, $this->privacc);
+
+        $trainingPlace1 = TrainingPlace::create([
+            'waiting_list_account_id' => $waitingListAccount1->id,
+            'training_position_id' => $trainingPosition->id,
+        ]);
+
+        $trainingPlace2 = TrainingPlace::create([
+            'waiting_list_account_id' => $waitingListAccount2->id,
+            'training_position_id' => $trainingPosition->id,
+        ]);
+
+        // Act & Assert - Filter by first waiting list
+        Livewire::actingAs($this->privacc)
+            ->test(ListTrainingPlaces::class)
+            ->filterTable('waiting_list', $waitingList1->id)
+            ->assertCanSeeTableRecords([$trainingPlace1])
+            ->assertCanNotSeeTableRecords([$trainingPlace2]);
+    }
+
+    #[Test]
+    public function it_can_search_by_student_name()
+    {
+        // Arrange
+        $ctsPosition = CtsPosition::factory()->create(['callsign' => 'EGKK_TWR']);
+        $trainingPosition = TrainingPosition::factory()->withCtsPositions([$ctsPosition->callsign])->create();
+
+        $waitingList = WaitingList::factory()->create();
+        $student = Account::factory()->create([
+            'name_first' => 'John',
+            'name_last' => 'Smith',
+        ]);
+        Member::factory()->create(['cid' => $student->id]);
+
+        $waitingListAccount = $waitingList->addToWaitingList($student, $this->privacc);
+
+        $trainingPlace = TrainingPlace::create([
+            'waiting_list_account_id' => $waitingListAccount->id,
+            'training_position_id' => $trainingPosition->id,
+        ]);
+
+        // Act & Assert
+        Livewire::actingAs($this->privacc)
+            ->test(ListTrainingPlaces::class)
+            ->searchTable('John')
+            ->assertCanSeeTableRecords([$trainingPlace]);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Filament resource for managing and viewing training places, adds authorization policies and service provider bindings, and includes a comprehensive feature test suite for the new resource. The changes ensure that only users with the appropriate permissions can access the training places listing and that the UI supports searching and filtering.

**New Filament Resource and Pages:**
- Added `TrainingPlaceResource` and its associated `ListTrainingPlaces` page, providing a searchable, sortable, and filterable table for training places, with relationships loaded for efficient display. [[1]](diffhunk://#diff-6aa2b7badb066dd10160ce2a162d434105b72ea05b171129da90bfe58cdcb099R1-R83) [[2]](diffhunk://#diff-3e5d94ede8470181272955d05ed4216c342fe037ee526423e6d53c4ba37200b6R1-R13)

**Authorization and Policy Integration:**
- Implemented and registered `TrainingPlacePolicy` to restrict access to users with the `training-places.view.*` permission, updating both the policy logic and service provider bindings. [[1]](diffhunk://#diff-d567dca547f01635ca82367a8547cd2d8569ae4276fe8241979dac65387391d8L15-R23) [[2]](diffhunk://#diff-9d0a077acda375ef8f06f27e2f823037207bcbaa21c2c87cf4c113a13a3eb0c4R10) [[3]](diffhunk://#diff-9d0a077acda375ef8f06f27e2f823037207bcbaa21c2c87cf4c113a13a3eb0c4R24) [[4]](diffhunk://#diff-9d0a077acda375ef8f06f27e2f823037207bcbaa21c2c87cf4c113a13a3eb0c4R58)

**Testing:**
- Added a feature test suite `ListTrainingPlacesTest` to verify permission checks, table rendering, filtering by waiting list, and searching by student name.