### PR TITLE
feat: add VATUK logo to training panel

### DIFF
--- a/app/Providers/Filament/TrainingPanelProvider.php
+++ b/app/Providers/Filament/TrainingPanelProvider.php
@@ -50,6 +50,7 @@ class TrainingPanelProvider extends PanelProvider
             ->authMiddleware([
                 TrainingPanelAccessMiddleware::class,
             ])
+            ->brandLogo(asset('images/branding/vatsimuk_whiteblue.png'))
             ->navigationItems([
                 NavigationItem::make('Admin Panel')
                     ->url(fn () => route('filament.app.pages.dashboard'))


### PR DESCRIPTION
# Summary of changes
- Added VATUK logo to training panel inline with the admin panel

# Screenshots (if necessary)
Admin:
<img width="311" height="201" alt="image" src="https://github.com/user-attachments/assets/57357133-364f-42c0-827f-b4046399aba9" />

Training:
<img width="295" height="194" alt="image" src="https://github.com/user-attachments/assets/24eb79c2-0ea1-4cb3-8b80-0a26fc415a49" />
