### PR TITLE
fix: standardise styling across admin and training panels

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -60,6 +60,7 @@ class AdminPanelProvider extends PanelProvider
             ->navigationGroups([
                 NavigationGroup::make('Technology'),
             ])
+            ->viteTheme('resources/assets/css/tailwind.css')
             ->navigationItems([
                 NavigationItem::make('Training Panel')
                     ->url(fn () => route('filament.training.pages.dashboard'))


### PR DESCRIPTION
# Summary of changes
- standardise styling across admin and training panels

# Screenshots (if necessary)
(admin left, training right)
Before:
<img width="587" height="196" alt="image" src="https://github.com/user-attachments/assets/8eacf69f-6788-43a2-8073-617bf879dced" />

After:
<img width="608" height="197" alt="image" src="https://github.com/user-attachments/assets/1b8e6e83-592b-4ce1-a647-b9f16b52ab62" />
