### PR TITLE
Do not send availability warnings during LoA on training place

### DIFF
--- a/app/Enums/AvailabilityCheckStatus.php
+++ b/app/Enums/AvailabilityCheckStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum AvailabilityCheckStatus: string
+{
+    case Passed = 'passed';
+    case Failed = 'failed';
+    case OnLeave = 'on_leave';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Passed => 'Passed',
+            self::Failed => 'Failed',
+            self::OnLeave => 'On leave',
+        };
+    }
+}

--- a/app/Models/Training/TrainingPlace/AvailabilityCheck.php
+++ b/app/Models/Training/TrainingPlace/AvailabilityCheck.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Training\TrainingPlace;
 
+use App\Enums\AvailabilityCheckStatus;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -15,6 +18,18 @@ class AvailabilityCheck extends Model
     use HasUlids;
 
     protected $guarded = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'status' => AvailabilityCheckStatus::class,
+    ];
+
+    public function getStatusLabelAttribute(): string
+    {
+        return $this->status->label();
+    }
 
     public function trainingPlace(): BelongsTo
     {

--- a/database/factories/Training/TrainingPlace/AvailabilityCheckFactory.php
+++ b/database/factories/Training/TrainingPlace/AvailabilityCheckFactory.php
@@ -2,6 +2,8 @@
 
 namespace Database\Factories\Training\TrainingPlace;
 
+use App\Enums\AvailabilityCheckStatus;
+use App\Models\Training\TrainingPlace\TrainingPlace;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -17,22 +19,29 @@ class AvailabilityCheckFactory extends Factory
     public function definition(): array
     {
         return [
-            'training_place_id' => \App\Models\Training\TrainingPlace\TrainingPlace::factory(),
-            'status' => 'passed',
+            'training_place_id' => TrainingPlace::factory(),
+            'status' => AvailabilityCheckStatus::Passed,
         ];
     }
 
     public function passed(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status' => 'passed',
+            'status' => AvailabilityCheckStatus::Passed,
         ]);
     }
 
     public function failed(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status' => 'failed',
+            'status' => AvailabilityCheckStatus::Failed,
+        ]);
+    }
+
+    public function onLeave(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => AvailabilityCheckStatus::OnLeave,
         ]);
     }
 }

--- a/database/migrations/2026_03_01_140000_add_on_leave_status_to_availability_checks_table.php
+++ b/database/migrations/2026_03_01_140000_add_on_leave_status_to_availability_checks_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE availability_checks MODIFY status ENUM('passed', 'failed', 'on_leave') NOT NULL");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE availability_checks MODIFY status ENUM('passed', 'failed') NOT NULL");
+    }
+};


### PR DESCRIPTION
Ensures a member who is on LOA for a training place still gets a check record, but doesn't get sent any warnings.