### PR TITLE
feat: allow members to cancel a pending exam request via the training panel

### DIFF
--- a/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
+++ b/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
@@ -2,14 +2,23 @@
 
 namespace App\Filament\Training\Pages\MyTraining;
 
+use App\Models\Cts\Booking;
+use App\Models\Cts\CancelReason;
 use App\Models\Cts\ExamBooking;
 use App\Models\Cts\ExamSetup;
+use App\Models\Cts\Reminder;
+use App\Notifications\Training\Exams\ExamCancelledStudentNotification;
 use Carbon\Carbon;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Forms\Components\Textarea;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\DB;
 
 class MyPendingExams extends Page implements HasTable
 {
@@ -72,6 +81,50 @@ class MyPendingExams extends Page implements HasTable
                         return Carbon::parse($record->start_date)->format('H:i').'Z – '.Carbon::parse($record->end_date)->format('H:i').'Z';
                     })
                     ->placeholder('Not yet scheduled'),
+            ])
+            ->actions([
+                ActionGroup::make([
+                    Action::make('cancelExamRequest')
+                        ->label('Cancel Exam Request')
+                        ->color('danger')
+                        ->icon('heroicon-o-x-circle')
+                        ->visible(fn (ExamBooking $record) => ! $record->taken)
+                        ->requiresConfirmation()
+                        ->modalHeading('Cancel Exam Request')
+                        ->modalDescription('Are you sure you want to cancel this exam request? This action cannot be undone.')
+                        ->form([
+                            Textarea::make('reason')
+                                ->label('Reason for cancellation')
+                                ->required()
+                                ->rows(4),
+                        ])
+                        ->action(function (ExamBooking $record, array $data): void {
+                            $user = auth()->user();
+                            $reason = strip_tags($data['reason']);
+
+                            DB::connection('cts')->transaction(function () use ($record, $reason, $user) {
+                                CancelReason::create([
+                                    'sesh_id' => $record->id,
+                                    'sesh_type' => 'EX',
+                                    'reason' => $reason,
+                                    'reason_by' => $user->id,
+                                ]);
+
+                                $record->setup()->update(['booked' => 0]);
+
+                                Booking::where('type_id', $record->id)->where('type', 'EX')->delete();
+                                Reminder::where('sesh_id', $record->id)->where('sesh_type', 'E')->delete();
+
+                                $user->notify(new ExamCancelledStudentNotification($record, $reason));
+                                $record->delete();
+                            });
+
+                            Notification::make()
+                                ->title('Exam request cancelled')
+                                ->success()
+                                ->send();
+                        }),
+                ]),
             ])
             ->paginated(false)
             ->emptyStateHeading('No pending exam requests')

--- a/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
+++ b/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
@@ -2,12 +2,9 @@
 
 namespace App\Filament\Training\Pages\MyTraining;
 
-use App\Models\Cts\Booking;
-use App\Models\Cts\CancelReason;
 use App\Models\Cts\ExamBooking;
 use App\Models\Cts\ExamSetup;
-use App\Models\Cts\Reminder;
-use App\Notifications\Training\Exams\ExamCancelledStudentNotification;
+use App\Services\Training\CancelPendingExamService;
 use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -18,7 +15,6 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
-use Illuminate\Support\Facades\DB;
 
 class MyPendingExams extends Page implements HasTable
 {
@@ -85,42 +81,27 @@ class MyPendingExams extends Page implements HasTable
             ->actions([
                 ActionGroup::make([
                     Action::make('cancelExamRequest')
-                        ->label('Cancel Exam Request')
+                        ->label('Cancel Exam')
                         ->color('danger')
                         ->icon('heroicon-o-x-circle')
-                        ->visible(fn (ExamBooking $record) => ! $record->taken)
+                        ->visible(fn (ExamBooking $record) => $record->taken)
                         ->requiresConfirmation()
-                        ->modalHeading('Cancel Exam Request')
-                        ->modalDescription('Are you sure you want to cancel this exam request? This action cannot be undone.')
+                        ->modalHeading(fn (ExamBooking $record) => "Cancel {$record->exam} Exam")
+                        ->modalDescription(fn (ExamBooking $record) => implode(' ', [
+                            'You are about to cancel your', $record->exam, 'scheduled for', Carbon::parse($record->taken_date)->format('l jS M Y'), 'at', Carbon::parse($record->taken_from)->format('H:i').'Z –', Carbon::parse($record->taken_to)->format('H:i').'Z.', 'Your examiner will be notified.']))
                         ->form([
                             Textarea::make('reason')
                                 ->label('Reason for cancellation')
+                                ->helperText('This will be sent to your examiner.')
                                 ->required()
                                 ->rows(4),
                         ])
-                        ->action(function (ExamBooking $record, array $data): void {
-                            $user = auth()->user();
-                            $reason = strip_tags($data['reason']);
-
-                            DB::connection('cts')->transaction(function () use ($record, $reason, $user) {
-                                CancelReason::create([
-                                    'sesh_id' => $record->id,
-                                    'sesh_type' => 'EX',
-                                    'reason' => $reason,
-                                    'reason_by' => $user->id,
-                                ]);
-
-                                $record->setup()->update(['booked' => 0]);
-
-                                Booking::where('type_id', $record->id)->where('type', 'EX')->delete();
-                                Reminder::where('sesh_id', $record->id)->where('sesh_type', 'E')->delete();
-
-                                $user->notify(new ExamCancelledStudentNotification($record, $reason));
-                                $record->delete();
-                            });
+                        ->action(function (ExamBooking $record, array $data, CancelPendingExamService $service): void {
+                            $service->cancel($record, strip_tags($data['reason']), auth()->user());
 
                             Notification::make()
-                                ->title('Exam request cancelled')
+                                ->title('Exam cancelled')
+                                ->body('Your examiner has been notified.')
                                 ->success()
                                 ->send();
                         }),

--- a/app/Models/Cts/CancelReason.php
+++ b/app/Models/Cts/CancelReason.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models\Cts;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CancelReason extends Model
+{
+    protected $connection = 'cts';
+
+    protected $table = 'cancel_reason';
+
+    protected $guarded = [];
+
+    public const CREATED_AT = 'date';
+
+    public const UPDATED_AT = null;
+
+    protected $attributes = [
+        'used' => 0,
+        'sesh_id' => 0,
+        'reason_by' => 0,
+    ];
+
+    public function member()
+    {
+        return $this->belongsTo(Member::class, 'reason_by', 'id');
+    }
+
+    public function isExam(): bool
+    {
+        return $this->sesh_type === 'EX';
+    }
+
+    public function isMentoring(): bool
+    {
+        return $this->sesh_type === 'ME';
+    }
+}

--- a/app/Models/Cts/ExamBooking.php
+++ b/app/Models/Cts/ExamBooking.php
@@ -44,6 +44,11 @@ class ExamBooking extends Model
         return $this->hasOne(PracticalExaminers::class, 'examid', 'id');
     }
 
+    public function setup(): HasOne
+    {
+        return $this->hasOne(ExamSetup::class, 'bookid', 'id');
+    }
+
     public function startDate(): Attribute
     {
         return Attribute::make(

--- a/app/Models/Cts/Reminder.php
+++ b/app/Models/Cts/Reminder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models\Cts;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Reminder extends Model
+{
+    protected $connection = 'cts';
+
+    protected $table = 'reminders';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    protected $attributes = [
+        'sesh_type' => '',
+        'who' => '',
+        'reminder' => '',
+        'set' => 0,
+        'sent' => 0,
+    ];
+
+    public function scopeExams($query)
+    {
+        return $query->where('sesh_type', 'E');
+    }
+
+    public function scopeMentoring($query)
+    {
+        return $query->where('sesh_type', 'M');
+    }
+}

--- a/app/Notifications/Training/Exams/ExamCancelledExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamCancelledExaminerNotification.php
@@ -7,7 +7,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExamCancelledStudentNotification extends Notification
+class ExamCancelledExaminerNotification extends Notification
 {
     use Queueable;
 
@@ -16,6 +16,9 @@ class ExamCancelledStudentNotification extends Notification
         private string $reason,
     ) {}
 
+    /**
+     * @return array<int, string>
+     */
     public function via(object $notifiable): array
     {
         return ['mail'];
@@ -25,6 +28,9 @@ class ExamCancelledStudentNotification extends Notification
     {
         $examBooking = $this->examBooking->load(['student']);
 
+        $studentName = $examBooking->student?->account?->name ?? 'Unknown';
+        $studentCid = $examBooking->student?->account?->id ?? 'Unknown';
+
         $position = collect([$examBooking->position_1, $examBooking->position_2])
             ->filter()
             ->implode(' / ');
@@ -32,7 +38,7 @@ class ExamCancelledStudentNotification extends Notification
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject("{$examBooking->exam} Practical Exam Cancelled")
-            ->view('emails.training.exams.exam_cancelled_student', [
+            ->view('emails.training.exams.exam_cancelled_examiner', [
                 'recipient' => $notifiable,
                 'examBooking' => $examBooking,
                 'examType' => $examBooking->exam,
@@ -40,6 +46,9 @@ class ExamCancelledStudentNotification extends Notification
                 'takenDate' => $examBooking->taken_date,
                 'takenFrom' => $examBooking->taken_from,
                 'takenTo' => $examBooking->taken_to,
+                'studentName' => $studentName,
+                'studentCid' => $studentCid,
+                'reason' => $this->reason,
             ]);
     }
 }

--- a/app/Notifications/Training/Exams/ExamCancelledExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamCancelledExaminerNotification.php
@@ -31,10 +31,6 @@ class ExamCancelledExaminerNotification extends Notification
         $studentName = $examBooking->student?->account?->name ?? 'Unknown';
         $studentCid = $examBooking->student?->account?->id ?? 'Unknown';
 
-        $position = collect([$examBooking->position_1, $examBooking->position_2])
-            ->filter()
-            ->implode(' / ');
-
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject("{$examBooking->exam} Practical Exam Cancelled")
@@ -42,7 +38,7 @@ class ExamCancelledExaminerNotification extends Notification
                 'recipient' => $notifiable,
                 'examBooking' => $examBooking,
                 'examType' => $examBooking->exam,
-                'position' => $position,
+                'position' => $examBooking->position_1,
                 'takenDate' => $examBooking->taken_date,
                 'takenFrom' => $examBooking->taken_from,
                 'takenTo' => $examBooking->taken_to,

--- a/app/Notifications/Training/Exams/ExamCancelledStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamCancelledStudentNotification.php
@@ -25,10 +25,6 @@ class ExamCancelledStudentNotification extends Notification
     {
         $examBooking = $this->examBooking->load(['student']);
 
-        $position = collect([$examBooking->position_1, $examBooking->position_2])
-            ->filter()
-            ->implode(' / ');
-
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject("{$examBooking->exam} Practical Exam Cancelled")
@@ -36,7 +32,7 @@ class ExamCancelledStudentNotification extends Notification
                 'recipient' => $notifiable,
                 'examBooking' => $examBooking,
                 'examType' => $examBooking->exam,
-                'position' => $position,
+                'position' => $examBooking->position_1,
                 'takenDate' => $examBooking->taken_date,
                 'takenFrom' => $examBooking->taken_from,
                 'takenTo' => $examBooking->taken_to,

--- a/app/Notifications/Training/Exams/ExamCancelledStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamCancelledStudentNotification.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Notifications\Training\Exams;
+
+use App\Models\Cts\ExamBooking;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ExamCancelledStudentNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        private ExamBooking $examBooking,
+        private string $reason
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $examType = $this->examBooking->exam;
+        $position = $this->examBooking->position_1;
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
+            ->subject("Cancellation Confirmation: {$examType} Practical Exam")
+            ->view('emails.training.exams.exam_cancelled_student', [
+                'recipient' => $notifiable,
+                'examType' => $examType,
+                'position' => $position,
+                'reason' => $this->reason,
+            ]);
+    }
+}

--- a/app/Services/Training/CancelPendingExamService.php
+++ b/app/Services/Training/CancelPendingExamService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services\Training;
+
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\PracticalExaminers;
+use App\Models\Mship\Account;
+use App\Notifications\Training\Exams\ExamCancelledExaminerNotification;
+use App\Notifications\Training\Exams\ExamCancelledStudentNotification;
+use Illuminate\Support\Facades\DB;
+
+class CancelPendingExamService
+{
+    public function cancel(ExamBooking $examBooking, string $reason, Account $cancelledBy): void
+    {
+        DB::transaction(function () use ($examBooking, $reason, $cancelledBy): void {
+            DB::connection('cts')->table('cancel_reason')->insert([
+                'sesh_id' => $examBooking->id,
+                'sesh_type' => 'EX',
+                'reason' => $reason,
+                'used' => 0,
+                'reason_by' => $cancelledBy->id,
+                'date' => now(),
+            ]);
+
+            $examinerAccount = $examBooking->examiners?->primaryExaminer->account;
+
+            $cancelledBy->notify(new ExamCancelledStudentNotification($examBooking, $reason));
+            $examinerAccount?->notify(new ExamCancelledExaminerNotification($examBooking, $reason));
+
+            $examBooking->update([
+                'taken' => 0,
+                'taken_date' => null,
+                'taken_from' => null,
+                'taken_to' => null,
+                'exmr_id' => null,
+                'exmr_rating' => null,
+                'time_book' => null,
+            ]);
+
+            $examBooking->setup->update([
+                'booked' => 0,
+            ]);
+
+            PracticalExaminers::where('examid', $examBooking->id)->delete();
+        });
+    }
+}

--- a/resources/views/emails/training/exams/exam_cancelled_examiner.blade.php
+++ b/resources/views/emails/training/exams/exam_cancelled_examiner.blade.php
@@ -1,0 +1,22 @@
+@extends('emails.messages.post')
+
+@section('body')
+<p>
+{{ $studentName }} ({{ $studentCid }}) has cancelled their {{ $examType }} practical exam. The details are shown below.
+</p>
+
+<h4>Exam Details:</h4>
+<ul>
+    <li><strong>Exam Type:</strong> {{ $examType }}</li>
+    <li><strong>Position:</strong> {{ $position }}</li>
+    <li><strong>Scheduled Date:</strong> {{ \Carbon\Carbon::parse($takenDate)->format('l jS M Y') }}</li>
+    <li><strong>Scheduled Time:</strong> {{ \Carbon\Carbon::parse($takenFrom)->format('H:i') }}Z &ndash; {{ \Carbon\Carbon::parse($takenTo)->format('H:i') }}Z</li>
+</ul>
+
+<h4>Reason for cancellation:</h4>
+<p>{{ $reason }}</p>
+@stop
+
+@section('signature')
+VATSIM UK Training Department
+@stop

--- a/resources/views/emails/training/exams/exam_cancelled_student.blade.php
+++ b/resources/views/emails/training/exams/exam_cancelled_student.blade.php
@@ -1,0 +1,7 @@
+@extends('emails.messages.post')
+
+@section('body')
+
+@section('signature')
+VATSIM UK Training Department
+@stop

--- a/resources/views/emails/training/exams/exam_cancelled_student.blade.php
+++ b/resources/views/emails/training/exams/exam_cancelled_student.blade.php
@@ -1,6 +1,14 @@
 @extends('emails.messages.post')
 
 @section('body')
+<p>
+Your {{ $examType }} practical exam on <strong>{{ $position }}</strong> scheduled for
+<strong>{{ \Carbon\Carbon::parse($takenDate)->format('l jS M Y') }}</strong> at
+<strong>{{ \Carbon\Carbon::parse($takenFrom)->format('H:i') }}Z &ndash; {{ \Carbon\Carbon::parse($takenTo)->format('H:i') }}Z</strong>
+has been successfully cancelled.
+</p>
+
+@stop
 
 @section('signature')
 VATSIM UK Training Department

--- a/tests/Database/MockCtsDatabase.php
+++ b/tests/Database/MockCtsDatabase.php
@@ -462,6 +462,35 @@ class MockCtsDatabase
             PRIMARY KEY (`answer_id`)
             ) ENGINE=InnoDB AUTO_INCREMENT=479361 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
         );
+
+        DB::connection('cts')->statement(
+            "CREATE TABLE `cancel_reason` (
+            `id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+            `sesh_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+            `sesh_type` char(2) NOT NULL DEFAULT '',
+            `reason` longtext NOT NULL,
+            `used` tinyint(3) unsigned NOT NULL DEFAULT '0',
+            `reason_by` int(10) unsigned NOT NULL DEFAULT '0',
+            `date` datetime DEFAULT NULL,
+            PRIMARY KEY (`id`),
+            KEY `sesh_id` (`sesh_id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"
+        );
+
+        DB::connection('cts')->statement(
+            "CREATE TABLE `reminders` (
+            `id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+            `sesh_id` int(11) NOT NULL,
+            `sesh_type` char(1) NOT NULL DEFAULT '',
+            `who` char(3) NOT NULL DEFAULT '',
+            `reminder` char(3) NOT NULL DEFAULT '',
+            `reminder_date` datetime DEFAULT NULL,
+            `set` tinyint(3) unsigned NOT NULL DEFAULT '0',
+            `sent` tinyint(3) unsigned NOT NULL DEFAULT '0',
+            PRIMARY KEY (`id`),
+            KEY `sesh_search` (`sesh_id`, `sesh_type`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"
+        );
     }
 
     public static function destroy()

--- a/tests/Unit/Training/Exams/CancelPendingExamTest.php
+++ b/tests/Unit/Training/Exams/CancelPendingExamTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Training\Exams;
+
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\ExamSetup;
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalExaminers;
+use App\Models\Mship\Account;
+use App\Notifications\Training\Exams\ExamCancelledExaminerNotification;
+use App\Notifications\Training\Exams\ExamCancelledStudentNotification;
+use App\Services\Training\CancelPendingExamService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Notification;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CancelPendingExamTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private CancelPendingExamService $service;
+
+    protected Account $studentAccount;
+
+    protected Member $studentMember;
+
+    protected Account $examinerAccount;
+
+    protected Member $examinerMember;
+
+    protected ExamBooking $examBooking;
+
+    protected ExamSetup $examSetup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new CancelPendingExamService;
+
+        $this->studentAccount = Account::factory()->create();
+        $this->studentMember = Member::factory()->create([
+            'id' => $this->studentAccount->id,
+            'cid' => $this->studentAccount->id,
+        ]);
+
+        $this->examinerAccount = Account::factory()->create();
+        $this->examinerMember = Member::factory()->create([
+            'id' => $this->examinerAccount->id,
+            'cid' => $this->examinerAccount->id,
+            'examiner' => true,
+        ]);
+
+        $this->examBooking = ExamBooking::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'taken' => 1,
+            'taken_date' => now()->addDays(3)->format('Y-m-d'),
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+            'exmr_id' => $this->examinerMember->id,
+            'exmr_rating' => 3,
+            'time_book' => now(),
+            'finished' => ExamBooking::NOT_FINISHED_FLAG,
+            'exam' => 'TWR',
+            'position_1' => 'EGKK_TWR',
+            'student_rating' => 1,
+        ]);
+
+        $this->examSetup = ExamSetup::create([
+            'rts_id' => 1,
+            'student_id' => $this->studentMember->id,
+            'position_1' => 'EGKK_TWR',
+            'exam' => 'TWR',
+            'bookid' => $this->examBooking->id,
+            'booked' => 1,
+        ]);
+
+        PracticalExaminers::create([
+            'examid' => $this->examBooking->id,
+            'senior' => $this->examinerMember->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_resets_booking_taken_fields_to_pre_acceptance_state(): void
+    {
+        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+
+        $this->examBooking->refresh();
+
+        $this->assertEquals(0, $this->examBooking->taken);
+        $this->assertNull($this->examBooking->taken_date);
+        $this->assertNull($this->examBooking->taken_from);
+        $this->assertNull($this->examBooking->taken_to);
+        $this->assertNull($this->examBooking->exmr_id);
+        $this->assertNull($this->examBooking->exmr_rating);
+        $this->assertNull($this->examBooking->time_book);
+    }
+
+    #[Test]
+    public function it_resets_exam_setup_booked_flag(): void
+    {
+        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+        $this->examSetup->refresh();
+
+        $this->assertEquals(0, $this->examSetup->booked);
+    }
+
+    #[Test]
+    public function it_deletes_practical_examiner_record(): void
+    {
+        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+
+        $this->assertDatabaseMissing('practical_examiners', ['examid' => $this->examBooking->id], 'cts');
+    }
+
+    #[Test]
+    public function it_inserts_cancel_reason_record(): void
+    {
+        $reason = 'I have a scheduling conflict.';
+
+        $this->service->cancel($this->examBooking, $reason, $this->studentAccount);
+
+        $this->assertDatabaseHas('cancel_reason', [
+            'sesh_id' => $this->examBooking->id,
+            'sesh_type' => 'EX',
+            'reason' => $reason,
+            'used' => 0,
+            'reason_by' => $this->studentAccount->id], 'cts');
+    }
+
+    #[Test]
+    public function it_sends_student_cancellation_notification(): void
+    {
+        Notification::fake();
+        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+
+        Notification::assertSentTo($this->studentAccount, ExamCancelledStudentNotification::class);
+    }
+
+    #[Test]
+    public function it_sends_examiner_cancellation_notification(): void
+    {
+        Notification::fake();
+        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+
+        Notification::assertSentTo($this->examinerAccount, ExamCancelledExaminerNotification::class);
+    }
+}


### PR DESCRIPTION
# Summary of changes
- Allows members to cancel their exam request via the training panel, only before the examiner has booken
- Sends email confirmation to the member and examiner

# Screenshots (if necessary)
<img width="770" height="182" alt="image" src="https://github.com/user-attachments/assets/0934b3f2-bdd0-4cfe-bb59-2445cb7c32c7" />

<img width="537" height="510" alt="image" src="https://github.com/user-attachments/assets/bdd4ccf3-cf3f-443f-9e13-94439cf4250e" />

Student Email:
<img width="804" height="243" alt="image" src="https://github.com/user-attachments/assets/f43e83d9-ba23-442e-b4ad-d2f6947e755a" />

Examiner Email:
<img width="797" height="412" alt="image" src="https://github.com/user-attachments/assets/1d41b0fb-c9f3-4dd9-83ed-fceb3de11e17" />

