### PR TITLE
fix: improvement to the my exam history page

### DIFF
--- a/app/Filament/Training/Support/TheoryExamViewTrait.php
+++ b/app/Filament/Training/Support/TheoryExamViewTrait.php
@@ -54,7 +54,7 @@ trait TheoryExamViewTrait
             Fieldset::make('Exam Information')
                 ->columnSpanFull()
                 ->schema([
-                    TextEntry::make('cid')->label('CID')->getStateUsing(fn ($record) => $record->student_id),
+                    TextEntry::make('cid')->label('CID')->getStateUsing(fn ($record) => $record->student?->account?->id),
 
                     TextEntry::make('Name')->label('Name')->getStateUsing(fn ($record) => $record->student?->account?->name ?? 'Unknown'),
 

--- a/app/Repositories/Cts/TheoryExamResultRepository.php
+++ b/app/Repositories/Cts/TheoryExamResultRepository.php
@@ -15,6 +15,7 @@ class TheoryExamResultRepository
     {
         return TheoryResult::query()
             ->with('student')
-            ->whereIn('exam', $examLevels);
+            ->whereIn('exam', $examLevels)
+            ->where('submitted', '1');
     }
 }

--- a/tests/Feature/TrainingPanel/Exams/TheoryExamHistoryTest.php
+++ b/tests/Feature/TrainingPanel/Exams/TheoryExamHistoryTest.php
@@ -46,6 +46,7 @@ class TheoryExamHistoryTest extends BaseTrainingPanelTestCase
                 'exam' => $level,
                 'pass' => 1,
                 'submitted_time' => now()->subDays(rand(1, 30)),
+                'submitted' => 1,
             ]);
 
             $this->theoryResults[$level] = $theoryResult;

--- a/tests/Feature/TrainingPanel/MyTraining/MyExamHistoryTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyExamHistoryTest.php
@@ -66,6 +66,7 @@ class MyExamHistoryTest extends BaseTrainingPanelTestCase
             'correct' => 2,
             'questions' => 2,
             'pass' => 1,
+            'submitted' => 1,
             'submitted_time' => now()->subDays(10),
         ]);
 

--- a/tests/Feature/TrainingPanel/MyTraining/MyExamHistoryTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyExamHistoryTest.php
@@ -222,6 +222,7 @@ class MyExamHistoryTest extends BaseTrainingPanelTestCase
             'correct' => 1,
             'questions' => 2,
             'pass' => 0,
+            'submitted' => 1,
         ]);
 
         $component = Livewire::actingAs($this->studentAccount)
@@ -241,6 +242,7 @@ class MyExamHistoryTest extends BaseTrainingPanelTestCase
             'correct' => 2,
             'questions' => 2,
             'pass' => 1,
+            'submitted' => 1,
         ]);
 
         $component = Livewire::actingAs($this->studentAccount)


### PR DESCRIPTION
# Summary of changes
- Uses core id for member id
- Hides not submitted theory results

# Screenshots (if necessary)
