### PR TITLE
Add direct (not yet used) account relationship to training place model

### DIFF
--- a/app/Models/Training/TrainingPlace/TrainingPlace.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlace.php
@@ -38,6 +38,20 @@ class TrainingPlace extends Model
             ->withTrashed();
     }
 
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'account_id');
+    }
+
+    /**
+     * Transitional accessor to resolve the student account from the new direct FK
+     * (preferred) or the legacy waiting-list relationship (fallback).
+     */
+    public function studentAccount(): ?Account
+    {
+        return $this->account ?? $this->waitingListAccount?->account;
+    }
+
     public function trainingPosition(): BelongsTo
     {
         return $this->belongsTo(TrainingPosition::class, 'training_position_id');

--- a/database/factories/Training/TrainingPlace/TrainingPlaceFactory.php
+++ b/database/factories/Training/TrainingPlace/TrainingPlaceFactory.php
@@ -18,6 +18,7 @@ class TrainingPlaceFactory extends Factory
     {
         return [
             'waiting_list_account_id' => null,
+            'account_id' => null,
             'training_position_id' => null,
         ];
     }

--- a/database/migrations/2026_04_10_134902_add_account_id_to_training_places_table.php
+++ b/database/migrations/2026_04_10_134902_add_account_id_to_training_places_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('training_places', function (Blueprint $table) {
+            $table->unsignedInteger('account_id')
+                ->nullable()
+                ->after('waiting_list_account_id')
+                ->index();
+
+            $table->foreign('account_id')
+                ->references('id')
+                ->on('mship_account')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('training_places', function (Blueprint $table) {
+            $table->dropForeign(['account_id']);
+            $table->dropIndex(['account_id']);
+            $table->dropColumn('account_id');
+        });
+    }
+};

--- a/tests/Unit/Training/TrainingPlace/TrainingPlaceAccountRelationshipTest.php
+++ b/tests/Unit/Training/TrainingPlace/TrainingPlaceAccountRelationshipTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Training\TrainingPlace;
+
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TrainingPlaceAccountRelationshipTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Avoid side effects from observers during unit tests
+        Event::fake();
+    }
+
+    #[Test]
+    public function it_can_resolve_the_direct_account_relationship(): void
+    {
+        $account = Account::factory()->create();
+
+        $trainingPlace = TrainingPlace::factory()->create([
+            'account_id' => $account->id,
+        ]);
+
+        $this->assertTrue($trainingPlace->account->is($account));
+        $this->assertTrue($trainingPlace->studentAccount()->is($account));
+    }
+}


### PR DESCRIPTION
#### Context
`training_places` currently identifies the student **only** via `waiting_list_account_id` → `training_waiting_list_account` → `mship_account`. That coupling prevents creating ad-hoc training places for accounts that were never on a waiting list, and forces UI/service code to dereference the waiting-list relationship even when it’s not conceptually required.

This PR is the **first stage** of a staged rollout to add a **direct** student relationship while retaining the waiting list link for queue/provenance and waiting-time stats.

#### Summary of changes (this PR)
- Adds a new nullable `training_places.account_id` column with:
  - FK to `mship_account.id`
  - index
  - `ON DELETE SET NULL` behavior
- Adds Eloquent relationship `TrainingPlace::account()`.
- Adds transitional accessor `TrainingPlace::studentAccount()` which prefers `account` and falls back to `waitingListAccount?->account` (for staged migration).
- Updates `TrainingPlaceFactory` to include the new `account_id` attribute.
- Adds a small unit test asserting the relationship + accessor resolve correctly.

#### Why this is safe
- Schema change is **additive and nullable**, so existing records and flows continue to work unchanged.
- No production reads have been switched to `account_id` yet (that comes in a later PR after backfill).

#### Testing
- Added `TrainingPlaceAccountRelationshipTest` to cover:
  - `TrainingPlace::account()` relationship resolution
  - `TrainingPlace::studentAccount()` preferring the direct FK

#### Next phase (planned follow-ups)
- **PR2 (dual-write)**: update training place creation paths to always populate `account_id` for new records (including an explicit ad-hoc creation path with no waiting list record).
- **PR3 (backfill)**: migrate existing `training_places` rows to set `account_id` from `training_waiting_list_account.account_id`.
- **PR4 (switch reads)**: update Filament/Livewire/UI to use `trainingPlace->account` for student details; keep `waitingListAccount` only for queue/provenance.
- **PR5 (stats hardening)**: make waiting-time calculations handle `waiting_list_account_id` being null by displaying **N/A** when absent.
- **PR6 (constraint)**: once data + code are fully migrated, enforce `training_places.account_id` as **NOT NULL**.