### PR TITLE
Allow ad-hoc creation of training place without link to waiting list

### DIFF
--- a/app/Filament/Training/Resources/TrainingPlaces/Pages/ListTrainingPlaces.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/Pages/ListTrainingPlaces.php
@@ -2,10 +2,21 @@
 
 namespace App\Filament\Training\Resources\TrainingPlaces\Pages;
 
+use App\Filament\Admin\Forms\Components\AccountSelect;
+use App\Filament\Training\Pages\TrainingPlace\ViewTrainingPlace;
 use App\Filament\Training\Resources\TrainingPlaces\TrainingPlaceResource;
 use App\Filament\Training\Resources\TrainingPlaces\Widgets\TrainingPlaceCategoryChart;
 use App\Filament\Training\Resources\TrainingPlaces\Widgets\TrainingPlaceOffersOverview;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\TrainingPlaceService;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Support\Facades\Auth;
 
 class ListTrainingPlaces extends ListRecords
 {
@@ -24,6 +35,83 @@ class ListTrainingPlaces extends ListRecords
     {
         return [
             TrainingPlaceOffersOverview::class,
+        ];
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('createAdhocTrainingPlace')
+                ->label('Create Ad-hoc Training Place')
+                ->icon('heroicon-o-plus-circle')
+                ->color('primary')
+                ->visible(function (): bool {
+                    /** @var Account|null $user */
+                    $user = Auth::user();
+
+                    return (bool) ($user?->can('createAdhoc', TrainingPlace::class));
+                })
+                ->schema([
+                    AccountSelect::make('account')
+                        ->label('Student')
+                        ->required(),
+
+                    Select::make('training_position_id')
+                        ->label('Training Position')
+                        ->required()
+                        ->searchable()
+                        ->preload()
+                        ->options(fn (): array => TrainingPosition::query()
+                            ->with('position')
+                            ->orderBy('id')
+                            ->get()
+                            ->mapWithKeys(function (TrainingPosition $trainingPosition): array {
+                                $label = $trainingPosition->position?->callsign
+                                    ?? collect($trainingPosition->cts_positions)->filter()->first();
+
+                                return [$trainingPosition->id => $label];
+                            })
+                            ->all()),
+
+                    Textarea::make('reason')
+                        ->label('Reason')
+                        ->helperText('This will be saved on the member account to explain why this training place was created outside the usual waiting list flow.')
+                        ->rows(4)
+                        ->required()
+                        ->minLength(10),
+                ])
+                ->modalHeading('Create Ad-hoc Training Place')
+                ->modalDescription('Create a training place for a member without requiring a waiting list record.')
+                ->modalSubmitActionLabel('Create Training Place')
+                ->action(function (array $data): void {
+                    /** @var Account $actor */
+                    $actor = Auth::user();
+                    abort_unless($actor instanceof Account, 403);
+                    abort_unless($actor->can('createAdhoc', TrainingPlace::class), 403);
+
+                    $student = Account::query()->findOrFail($data['account_id']);
+                    $trainingPosition = TrainingPosition::query()->with('position')->findOrFail($data['training_position_id']);
+
+                    $reason = trim((string) $data['reason']);
+
+                    $trainingPlace = app(TrainingPlaceService::class)->createAdhocTrainingPlace(
+                        $student,
+                        $trainingPosition,
+                        $reason,
+                        $actor,
+                    );
+
+                    Notification::make()
+                        ->title('Ad-hoc training place created')
+                        ->success()
+                        ->actions([
+                            Action::make('view')
+                                ->label('View Training Place')
+                                ->url(ViewTrainingPlace::getUrl(['trainingPlaceId' => $trainingPlace->id]))
+                                ->markAsRead(),
+                        ])
+                        ->send();
+                }),
         ];
     }
 }

--- a/app/Policies/TrainingPlacePolicy.php
+++ b/app/Policies/TrainingPlacePolicy.php
@@ -55,6 +55,11 @@ class TrainingPlacePolicy
         return $account->hasPermissionTo('training-places.restore.*');
     }
 
+    public function createAdhoc(Account $account): bool
+    {
+        return $account->hasPermissionTo('training-places.create-adhoc');
+    }
+
     /**
      * Determine whether the user can permanently delete the model.
      */

--- a/app/Services/Training/TrainingPlaceService.php
+++ b/app/Services/Training/TrainingPlaceService.php
@@ -112,13 +112,30 @@ class TrainingPlaceService
         return $trainingPlace;
     }
 
-    public function createAdhocTrainingPlace(Account $account, TrainingPosition $trainingPosition): TrainingPlace
-    {
-        return TrainingPlace::create([
+    public function createAdhocTrainingPlace(
+        Account $account,
+        TrainingPosition $trainingPosition,
+        string $reason,
+        Account $actor,
+    ): TrainingPlace {
+        $trainingPosition->loadMissing('position');
+
+        $trainingPlace = TrainingPlace::create([
             'account_id' => $account->id,
             'training_position_id' => $trainingPosition->id,
             'waiting_list_account_id' => null,
         ]);
+
+        $callsign = $trainingPosition->position?->callsign
+            ?? collect($trainingPosition->cts_positions)->filter()->first();
+
+        $account->addNote(
+            'training',
+            "Ad-hoc training place created on {$callsign} outside the usual waiting list flow. Reason: {$reason}",
+            $actor->id,
+        );
+
+        return $trainingPlace;
     }
 
     public function removeFromWaitingList(TrainingPlace $trainingPlace): void

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -151,6 +151,7 @@ class RolesAndPermissionsSeeder extends Seeder
             // Training Places Permissions
             'training-places.view.*',
             'training-places.manual-setup',
+            'training-places.create-adhoc',
             'training-places.revoke.*',
             'training-places.restore.*',
             'training-places.loas.create.*',

--- a/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
@@ -19,6 +19,68 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
     use DatabaseTransactions;
 
     #[Test]
+    public function it_shows_create_adhoc_training_place_action_when_user_has_permission()
+    {
+        $this->panelUser->givePermissionTo('training-places.view.*');
+        $this->panelUser->givePermissionTo('training-places.create-adhoc');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ListTrainingPlaces::class)
+            ->assertSuccessful()
+            ->assertActionVisible('createAdhocTrainingPlace');
+    }
+
+    #[Test]
+    public function it_hides_create_adhoc_training_place_action_without_permission()
+    {
+        $this->panelUser->givePermissionTo('training-places.view.*');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ListTrainingPlaces::class)
+            ->assertSuccessful()
+            ->assertActionHidden('createAdhocTrainingPlace');
+    }
+
+    #[Test]
+    public function it_can_create_an_adhoc_training_place_from_the_list_page()
+    {
+        $this->panelUser->givePermissionTo('training-places.view.*');
+        $this->panelUser->givePermissionTo('training-places.create-adhoc');
+
+        $ctsPosition = CtsPosition::factory()->create(['callsign' => 'EGLL_GND']);
+        $trainingPosition = TrainingPosition::factory()->withCtsPositions([$ctsPosition->callsign])->create();
+
+        $student = Account::factory()->create();
+        Member::factory()->create([
+            'cid' => $student->id,
+            'name' => 'Adhoc Student',
+        ]);
+
+        $reason = 'This is a valid reason for creating an ad-hoc training place.';
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ListTrainingPlaces::class)
+            ->callAction('createAdhocTrainingPlace', data: [
+                'account_id' => $student->id,
+                'training_position_id' => $trainingPosition->id,
+                'reason' => $reason,
+            ])
+            ->assertNotified();
+
+        $this->assertDatabaseHas('training_places', [
+            'account_id' => $student->id,
+            'training_position_id' => $trainingPosition->id,
+            'waiting_list_account_id' => null,
+        ]);
+
+        $this->assertDatabaseHas('mship_account_note', [
+            'account_id' => $student->id,
+            'writer_id' => $this->panelUser->id,
+            'content' => "Ad-hoc training place created on {$ctsPosition->callsign} outside the usual waiting list flow. Reason: {$reason}",
+        ]);
+    }
+
+    #[Test]
     public function it_can_render_training_places_list_page_with_permission()
     {
         // Arrange

--- a/tests/Unit/Training/TrainingPlace/AdhocTrainingPlaceCreationTest.php
+++ b/tests/Unit/Training/TrainingPlace/AdhocTrainingPlaceCreationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Training\TrainingPlace;
 
+use App\Models\Cts\Position as CtsPosition;
 use App\Models\Mship\Account;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\TrainingPosition\TrainingPosition;
@@ -26,14 +27,24 @@ class AdhocTrainingPlaceCreationTest extends TestCase
     public function it_can_create_a_training_place_without_a_waiting_list_account(): void
     {
         $student = Account::factory()->create();
-        $trainingPosition = TrainingPosition::factory()->create();
+        $ctsPosition = CtsPosition::factory()->create(['callsign' => 'EGLL_TWR']);
+        $trainingPosition = TrainingPosition::factory()->withCtsPositions([$ctsPosition->callsign])->create();
 
-        $trainingPlace = $this->service->createAdhocTrainingPlace($student, $trainingPosition);
+        $reason = 'This is a valid reason for creating an ad-hoc training place.';
+        $actor = $this->privacc;
+
+        $trainingPlace = $this->service->createAdhocTrainingPlace($student, $trainingPosition, $reason, $actor);
 
         $this->assertInstanceOf(TrainingPlace::class, $trainingPlace);
         $this->assertNull($trainingPlace->waiting_list_account_id);
         $this->assertEquals($student->id, $trainingPlace->account_id);
         $this->assertEquals($trainingPosition->id, $trainingPlace->training_position_id);
         $this->assertTrue($trainingPlace->studentAccount()->is($student));
+
+        $this->assertDatabaseHas('mship_account_note', [
+            'account_id' => $student->id,
+            'writer_id' => $actor->id,
+            'content' => "Ad-hoc training place created on {$ctsPosition->callsign} outside the usual waiting list flow. Reason: {$reason}",
+        ]);
     }
 }


### PR DESCRIPTION
#### Filament Training panel: Training Places index
- Updated `app/Filament/Training/Resources/TrainingPlaces/Pages/ListTrainingPlaces.php`
  - Adds a header action: **`createAdhocTrainingPlace`**
  - **Visibility**: `Auth::user()->can('createAdhoc', TrainingPlace::class)`
  - **Form**:
    - `AccountSelect::make('account')` (student; persists as `account_id` in action data)
    - `Select::make('training_position_id')` listing all `TrainingPosition` records (searchable/preloaded)
    - `Textarea::make('reason')` (required, `minLength(10)`)
  - **Submit**:
    - Authorizes the actor (`Account`) + permission
    - Calls `TrainingPlaceService::createAdhocTrainingPlace($student, $trainingPosition, $reason, $actor)`
    - Shows a success notification with a link to `ViewTraingPlace`

#### Permissions + policy
- Updated `database/seeders/RolesAndPermissionsSeeder.php`
  - Registers **`training-places.create-adhoc`**
- Updated `app/Policies/TrainingPlacePolicy.php`
  - Adds `createAdhoc(Account $account): bool` mapping to `training-places.create-adhoc`

#### Service: ad-hoc creation + audit trail
- Updated `app/Services/Training/TrainingPlaceService.php`
  - Expands `createAdhocTrainingPlace(...)` to accept **`$reason`** and **`$actor`**
  - Creates the `TrainingPlace` with:
    - `account_id` set
    - `waiting_list_account_id` null
  - Writes a **`training` account note** on the student including callsign/CTS label context + reason + writer id

#### Tests
- Updated `tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php`
  - Asserts action visibility with/without permission
  - End-to-end `callAction(...)` asserts DB rows for `training_places` + `mship_account_note`
- Updated `tests/Unit/Training/TrainingPlace/AdhocTrainingPlaceCreationTest.php`
  - Matches new service signature and asserts the note content

