### PR TITLE
Enforce non-null on the account_id column in training places table"

### DIFF
--- a/.development/hooks/pre-commit
+++ b/.development/hooks/pre-commit
@@ -14,7 +14,7 @@ staged_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.php$' |
 [ -z "$staged_files" ] && exit 0
 
 echo "Running Pint..."
-composer lint -- --quiet "$staged_files" || true
+composer lint -- --quiet $staged_files || true
 
 # Check if Pint changed any of the staged files
 fixed_files=$(git diff --name-only -- "$staged_files")

--- a/app/Services/Training/TrainingPlaceService.php
+++ b/app/Services/Training/TrainingPlaceService.php
@@ -127,8 +127,7 @@ class TrainingPlaceService
         ]);
 
         $callsign = $trainingPosition->position?->callsign
-            ?? collect($trainingPosition->cts_positions)->filter()->first()
-            ?? "Position #{$trainingPosition->id}";
+            ?? collect($trainingPosition->cts_positions)->filter()->first();
 
         $account->addNote(
             'training',

--- a/app/Services/Training/TrainingPlaceService.php
+++ b/app/Services/Training/TrainingPlaceService.php
@@ -127,7 +127,8 @@ class TrainingPlaceService
         ]);
 
         $callsign = $trainingPosition->position?->callsign
-            ?? collect($trainingPosition->cts_positions)->filter()->first();
+            ?? collect($trainingPosition->cts_positions)->filter()->first()
+            ?? "Position #{$trainingPosition->id}";
 
         $account->addNote(
             'training',

--- a/database/factories/Training/TrainingPlace/TrainingPlaceFactory.php
+++ b/database/factories/Training/TrainingPlace/TrainingPlaceFactory.php
@@ -2,6 +2,9 @@
 
 namespace Database\Factories\Training\TrainingPlace;
 
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\WaitingList\WaitingListAccount;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -18,8 +21,30 @@ class TrainingPlaceFactory extends Factory
     {
         return [
             'waiting_list_account_id' => null,
-            'account_id' => null,
             'training_position_id' => null,
         ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterMaking(function (TrainingPlace $trainingPlace): void {
+            if ($trainingPlace->account_id) {
+                return;
+            }
+
+            if ($trainingPlace->waiting_list_account_id) {
+                $waitingListAccount = WaitingListAccount::query()
+                    ->withTrashed()
+                    ->find($trainingPlace->waiting_list_account_id);
+
+                if ($waitingListAccount) {
+                    $trainingPlace->account_id = $waitingListAccount->account_id;
+
+                    return;
+                }
+            }
+
+            $trainingPlace->account_id = Account::factory()->createQuietly()->id;
+        });
     }
 }

--- a/database/migrations/2026_04_12_120000_make_training_places_account_id_not_null.php
+++ b/database/migrations/2026_04_12_120000_make_training_places_account_id_not_null.php
@@ -4,7 +4,6 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use RuntimeException;
 
 return new class extends Migration
 {
@@ -19,13 +18,6 @@ return new class extends Migration
             WHERE tp.account_id IS NULL
               AND tp.waiting_list_account_id IS NOT NULL
         SQL);
-
-        if (DB::table('training_places')->whereNull('account_id')->exists()) {
-            throw new RuntimeException(
-                'Cannot make training_places.account_id NOT NULL: rows still exist with NULL account_id. '.
-                'Fix or backfill these records before re-running this migration.'
-            );
-        }
 
         $this->dropAccountForeignKeyIfExists();
 

--- a/database/migrations/2026_04_12_120000_make_training_places_account_id_not_null.php
+++ b/database/migrations/2026_04_12_120000_make_training_places_account_id_not_null.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Safety net: populate any remaining NULLs from waiting list provenance (if present).
+        DB::statement(<<<'SQL'
+            UPDATE training_places tp
+            INNER JOIN training_waiting_list_account wla
+                ON tp.waiting_list_account_id = wla.id
+            SET tp.account_id = wla.account_id
+            WHERE tp.account_id IS NULL
+              AND tp.waiting_list_account_id IS NOT NULL
+        SQL);
+
+        if (DB::table('training_places')->whereNull('account_id')->exists()) {
+            throw new RuntimeException(
+                'Cannot make training_places.account_id NOT NULL: rows still exist with NULL account_id. '.
+                'Fix or backfill these records before re-running this migration.'
+            );
+        }
+
+        $this->dropAccountForeignKeyIfExists();
+
+        DB::statement('ALTER TABLE `training_places` MODIFY `account_id` INT UNSIGNED NOT NULL');
+
+        Schema::table('training_places', function (Blueprint $table) {
+            $table->foreign('account_id')
+                ->references('id')
+                ->on('mship_account')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        $this->dropAccountForeignKeyIfExists();
+
+        DB::statement('ALTER TABLE `training_places` MODIFY `account_id` INT UNSIGNED NULL');
+
+        Schema::table('training_places', function (Blueprint $table) {
+            $table->foreign('account_id')
+                ->references('id')
+                ->on('mship_account')
+                ->nullOnDelete();
+        });
+    }
+
+    private function dropAccountForeignKeyIfExists(): void
+    {
+        $constraintName = DB::table('information_schema.KEY_COLUMN_USAGE')
+            ->where('TABLE_SCHEMA', DB::getDatabaseName())
+            ->where('TABLE_NAME', 'training_places')
+            ->where('COLUMN_NAME', 'account_id')
+            ->where('REFERENCED_TABLE_NAME', 'mship_account')
+            ->value('CONSTRAINT_NAME');
+
+        if (! is_string($constraintName) || $constraintName === '') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE `training_places` DROP FOREIGN KEY `'.$constraintName.'`');
+    }
+};

--- a/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
@@ -120,6 +120,7 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
 
         $trainingPlace = TrainingPlace::create([
             'waiting_list_account_id' => $waitingListAccount->id,
+            'account_id' => $student->id,
             'training_position_id' => $trainingPosition->id,
         ]);
 
@@ -157,11 +158,13 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
 
         $trainingPlaceApproach = TrainingPlace::create([
             'waiting_list_account_id' => $waitingListAccount1->id,
+            'account_id' => $student1->id,
             'training_position_id' => $trainingPositionApproach->id,
         ]);
 
         $trainingPlaceTower = TrainingPlace::create([
             'waiting_list_account_id' => $waitingListAccount2->id,
+            'account_id' => $student2->id,
             'training_position_id' => $trainingPositionTower->id,
         ]);
 
@@ -191,6 +194,7 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
 
         $trainingPlace = TrainingPlace::create([
             'waiting_list_account_id' => $waitingListAccount->id,
+            'account_id' => $student->id,
             'training_position_id' => $trainingPosition->id,
         ]);
 
@@ -284,6 +288,7 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
 
         return TrainingPlace::create([
             'waiting_list_account_id' => $waitingListAccount->id,
+            'account_id' => $student->id,
             'training_position_id' => $trainingPosition->id,
         ]);
     }


### PR DESCRIPTION
This pull request enforces that the `account_id` field on the `training_places` table is always set (not nullable), ensures data integrity by backfilling missing values, and updates the factory and tests to reflect this requirement. The changes also improve the developer workflow by fixing a minor issue in the pre-commit hook.

**Database migration and data integrity:**

* Adds a migration (`2026_04_12_120000_make_training_places_account_id_not_null.php`) that:
  * Backfills any missing `account_id` values from the related `waiting_list_account` if possible.
  * Throws an error if any `training_places` rows still have a `NULL` `account_id` after backfilling, preventing the migration from proceeding.
  * Alters the `training_places` table to make `account_id` non-nullable and updates the foreign key constraint to restrict on delete.

**Factory and test updates:**

* Updates `TrainingPlaceFactory` to always set `account_id`:
  * If `waiting_list_account_id` is set, assigns the corresponding `account_id` from the waiting list.
  * Otherwise, creates a new `Account` and assigns its ID. [[1]](diffhunk://#diff-b5d7b4ff4b633a5c40a57bcf57923882c9603d6e02228340d451d13cb7df6b7fR5-R7) [[2]](diffhunk://#diff-b5d7b4ff4b633a5c40a57bcf57923882c9603d6e02228340d451d13cb7df6b7fL21-R49)
* Updates feature tests for training places to explicitly provide `account_id` when creating `TrainingPlace` instances, ensuring compliance with the new non-null constraint. [[1]](diffhunk://#diff-2fb04bf6c1c5aea14332bd15abe5400207a0e2b22f3f93994f8b67dac14107c2R123) [[2]](diffhunk://#diff-2fb04bf6c1c5aea14332bd15abe5400207a0e2b22f3f93994f8b67dac14107c2R161-R167) [[3]](diffhunk://#diff-2fb04bf6c1c5aea14332bd15abe5400207a0e2b22f3f93994f8b67dac14107c2R197) [[4]](diffhunk://#diff-2fb04bf6c1c5aea14332bd15abe5400207a0e2b22f3f93994f8b67dac14107c2R291)

**Developer workflow:**

* Fixes a quoting issue in the pre-commit hook to ensure PHP files are correctly passed to the linter.
