### PR TITLE
Reference account relationship throughout instead of waiting list account for training place adjacent actions

### DIFF
--- a/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
+++ b/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
@@ -59,12 +59,19 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
             abort(403, 'You do not have permission to view training places.');
         }
 
-        $this->trainingPlace = TrainingPlace::withTrashed()->where('id', $this->trainingPlaceId)->with('waitingListAccount', 'trainingPosition')->firstOrFail();
+        $this->trainingPlace = TrainingPlace::withTrashed()
+            ->where('id', $this->trainingPlaceId)
+            ->with([
+                'account',
+                'waitingListAccount',
+                'trainingPosition.position',
+            ])
+            ->firstOrFail();
     }
 
     public function getTitle(): string|Htmlable
     {
-        return "View Training Place - {$this->trainingPlace->waitingListAccount->account->name}";
+        return "View Training Place - {$this->trainingPlace->account->name}";
     }
 
     protected function getHeaderWidgets(): array
@@ -97,12 +104,12 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
                         ->preload(),
                     TextInput::make('student_name')
                         ->label('Student Name')
-                        ->default(fn () => $this->trainingPlace->waitingListAccount->account->name)
+                        ->default(fn () => $this->trainingPlace->account->name)
                         ->readOnly()
                         ->dehydrated(false),
                     TextInput::make('student_cid')
                         ->label('Student CID')
-                        ->default(fn () => $this->trainingPlace->waitingListAccount->account->id)
+                        ->default(fn () => $this->trainingPlace->account->id)
                         ->readOnly()
                         ->dehydrated(false),
                 ])
@@ -121,12 +128,11 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
                 ->modalSubmitActionLabel('Restore')
                 ->requiresConfirmation()
                 ->action(function () {
-                    $studentAccount = $this->trainingPlace->waitingListAccount->account;
                     $callsign = $this->trainingPlace->trainingPosition->position->callsign;
 
                     $this->trainingPlace->restore();
 
-                    $studentAccount->addNote('training', "Training place restored on {$callsign}.", Auth::user()->id);
+                    $this->trainingPlace->account->addNote('training', "Training place restored on {$callsign}.", Auth::user()->id);
 
                     Notification::make()
                         ->title('Training place restored successfully')
@@ -152,7 +158,7 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
                         ->required(),
                 ])
                 ->action(function (array $data) {
-                    $this->trainingPlace->revokeTrainingPlace($data['reason'], Auth()->user());
+                    $this->trainingPlace->revokeTrainingPlace($data['reason'], Auth::user());
 
                     Notification::make()
                         ->title('Training place revoked successfully')
@@ -166,7 +172,13 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
 
     private function hasPendingExam(): bool
     {
-        return ExamBooking::where('student_id', $this->trainingPlace->waitingListAccount->account->member->id)
+        $memberId = $this->trainingPlace->account->member?->id;
+
+        if (! $memberId) {
+            return false;
+        }
+
+        return ExamBooking::where('student_id', $memberId)
             ->where('finished', ExamBooking::NOT_FINISHED_FLAG)
             ->exists();
     }
@@ -176,7 +188,7 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
         try {
             // Get the position from the provided ID
             $trainingPosition = TrainingPosition::where('position_id', $positionId)->firstOrFail();
-            $ctsMember = $this->trainingPlace->waitingListAccount->account->member;
+            $ctsMember = $this->trainingPlace->account->member;
 
             if (! $trainingPosition || ! $ctsMember) {
                 Notification::make()
@@ -238,11 +250,14 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
                         ->dateTime('d/m/Y \a\t H:i'),
                 ]),
             Section::make('Training Place Details')->columnSpanFull()->schema([
-                TextEntry::make('waitingListAccount.account.name')->label('Name'),
-                TextEntry::make('waitingListAccount.account.id')->label('CID'),
+                TextEntry::make('account.name')->label('Name'),
+                TextEntry::make('account.id')->label('CID'),
                 TextEntry::make('trainingPosition.position.name')->label('Position'),
                 TextEntry::make('created_at')->label('Training Start')->date('d/m/Y'),
-                TextEntry::make('waitingListAccount.created_at')->label('Waiting List Join Date')->date('d/m/Y'),
+                TextEntry::make('waitingListAccount.created_at')
+                    ->label('Waiting List Join Date')
+                    ->date('d/m/Y')
+                    ->visible(fn (): bool => (bool) $this->trainingPlace->waiting_list_account_id),
                 IconEntry::make('has_pending_exam')
                     ->label('Has Pending Exam Booking')
                     ->getStateUsing(fn () => $this->hasPendingExam())
@@ -256,7 +271,10 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
         return $table
             ->heading('Mentoring session history')
             ->queryStringIdentifier('mentoring')
-            ->query((new SessionRepository)->getAllAcceptedSessionsForPositionsQuery($this->trainingPlace->trainingPosition->cts_positions, $this->trainingPlace->waitingListAccount->account->member->id))
+            ->query((new SessionRepository)->getAllAcceptedSessionsForPositionsQuery(
+                $this->trainingPlace->trainingPosition->cts_positions,
+                $this->trainingPlace->account->member?->id ?? 0
+            ))
             ->defaultSort('taken_date', 'desc')
             ->paginated([10])
             ->defaultPaginationPageOption(10)

--- a/app/Filament/Training/Pages/TrainingPlace/Widgets/MentoringSessionStatsWidget.php
+++ b/app/Filament/Training/Pages/TrainingPlace/Widgets/MentoringSessionStatsWidget.php
@@ -17,7 +17,7 @@ class MentoringSessionStatsWidget extends BaseWidget
     {
         $sessionRepository = app(SessionRepository::class);
 
-        $ctsStudentId = $this->trainingPlace->waitingListAccount->account->member->id;
+        $ctsStudentId = $this->trainingPlace->account->member?->id ?? 0;
 
         return [
             Stat::make('Total Sessions', $sessionRepository->getTotalSessionsForPositions($this->trainingPlace->trainingPosition->cts_positions, $ctsStudentId))

--- a/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
@@ -60,6 +60,7 @@ class TrainingPlaceResource extends Resource
         return $table
             ->modifyQueryUsing(fn (Builder $query) => $query
                 ->with([
+                    'account',
                     'waitingListAccount.account',
                     'waitingListAccount.waitingList',
                     'trainingPosition.position',
@@ -74,13 +75,13 @@ class TrainingPlaceResource extends Resource
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
 
-                TextColumn::make('waitingListAccount.account.name')
+                TextColumn::make('account.name')
                     ->label('Student')
                     ->searchable(['name_first', 'name_last'])
                     ->sortable()
                     ->url(fn (TrainingPlace $record) => ViewTrainingPlace::getUrl(['trainingPlaceId' => $record->id])),
 
-                TextColumn::make('waitingListAccount.account_id')
+                TextColumn::make('account_id')
                     ->label('CID')
                     ->searchable()
                     ->sortable(),

--- a/app/Jobs/Training/ActionExpiredAvailabilityWarningRemoval.php
+++ b/app/Jobs/Training/ActionExpiredAvailabilityWarningRemoval.php
@@ -46,7 +46,7 @@ class ActionExpiredAvailabilityWarningRemoval implements ShouldQueue
             return;
         }
 
-        $account = $trainingPlace->waitingListAccount->account;
+        $account = $trainingPlace->account;
 
         try {
             DB::transaction(function () use ($trainingPlace, $account): void {

--- a/app/Jobs/Training/ActionFourthAvailabilityFailureRemoval.php
+++ b/app/Jobs/Training/ActionFourthAvailabilityFailureRemoval.php
@@ -44,7 +44,7 @@ class ActionFourthAvailabilityFailureRemoval implements ShouldQueue
             return;
         }
 
-        $account = $trainingPlace->waitingListAccount->account;
+        $account = $trainingPlace->account;
 
         try {
             DB::transaction(function () use ($trainingPlace, $account): void {

--- a/app/Jobs/Training/CheckAvailability.php
+++ b/app/Jobs/Training/CheckAvailability.php
@@ -45,7 +45,12 @@ class CheckAvailability implements ShouldQueue
             return;
         }
 
-        $account = $this->trainingPlace->waitingListAccount->account;
+        $account = $this->trainingPlace->account;
+
+        if (! $account->member) {
+            return;
+        }
+
         $memberId = $account->member->id;
 
         // Check if availability exists for the student

--- a/app/Jobs/Training/CreateCtsSessionRequestForTrainingPlace.php
+++ b/app/Jobs/Training/CreateCtsSessionRequestForTrainingPlace.php
@@ -25,11 +25,10 @@ class CreateCtsSessionRequestForTrainingPlace implements ShouldQueue
     {
         $this->trainingPlace->loadMissing([
             'trainingPosition',
-            'waitingListAccount.account',
+            'account',
         ]);
 
-        $account = $this->trainingPlace->waitingListAccount?->account;
-        $member = $account?->member;
+        $member = $this->trainingPlace->account->member;
 
         if (! $member) {
             Log::warning('Skipping training place without CTS member attached', [

--- a/app/Livewire/Training/LeaveOfAbsencesTable.php
+++ b/app/Livewire/Training/LeaveOfAbsencesTable.php
@@ -137,7 +137,7 @@ class LeaveOfAbsencesTable extends Component implements HasActions, HasForms, Ha
                     ->action(function (TrainingPlaceLeaveOfAbsence $record, array $data) {
                         $record->update(['ends_at' => now()]);
 
-                        $record->trainingPlace->waitingListAccount->account->addNote('training', "Leave of absence ended early. Reason: {$data['reason']}", auth()->id());
+                        $record->trainingPlace->account->addNote('training', "Leave of absence ended early. Reason: {$data['reason']}", auth()->id());
 
                         Notification::make()
                             ->title('Leave of absence ended early')

--- a/app/Livewire/Training/RecentControllingTable.php
+++ b/app/Livewire/Training/RecentControllingTable.php
@@ -29,7 +29,7 @@ class RecentControllingTable extends Component implements HasActions, HasForms, 
             ->heading('Controlling during training')
             ->queryStringIdentifier('recent-controlling')
             ->query(
-                Atc::query()->where('account_id', $this->trainingPlace->waitingListAccount->account_id)
+                Atc::query()->where('account_id', $this->trainingPlace->account_id)
                     ->where('created_at', '>=', $this->trainingPlace->created_at)
                     ->isUk()
             )

--- a/app/Livewire/Training/TrainingPlaceSoloEndorsement.php
+++ b/app/Livewire/Training/TrainingPlaceSoloEndorsement.php
@@ -74,7 +74,7 @@ class TrainingPlaceSoloEndorsement extends Component implements HasActions, HasF
                     ->visible(fn () => auth()->check() && auth()->user()->can('endorsement.create.temporary'))
                     ->disabled(fn () => EndorsementService::hasActiveSoloEndorsement(
                         $this->trainingPlace->trainingPosition->position,
-                        $this->trainingPlace->waitingListAccount->account
+                        $this->trainingPlace->account
                     ))
                     ->form([
                         TextInput::make('days')
@@ -88,8 +88,17 @@ class TrainingPlaceSoloEndorsement extends Component implements HasActions, HasF
                     ])
                     ->action(function (array $data) {
                         $position = $this->trainingPlace->trainingPosition->position;
-                        $account = $this->trainingPlace->waitingListAccount->account;
+                        $account = $this->trainingPlace->account;
                         $creator = auth()->user();
+
+                        if (! $creator) {
+                            Notification::make()
+                                ->title('Unable to issue solo endorsement')
+                                ->danger()
+                                ->send();
+
+                            return;
+                        }
 
                         EndorsementService::createTemporary(
                             $position,
@@ -105,7 +114,7 @@ class TrainingPlaceSoloEndorsement extends Component implements HasActions, HasF
                     })
                     ->requiresConfirmation()
                     ->modalHeading('Issue Solo Endorsement')
-                    ->modalDescription(fn () => 'Issue a solo endorsement for '.$this->trainingPlace->trainingPosition->position->name.' to '.$this->trainingPlace->waitingListAccount->account->name)
+                    ->modalDescription(fn () => 'Issue a solo endorsement for '.$this->trainingPlace->trainingPosition->position->name.' to '.$this->trainingPlace->account->name)
                     ->modalSubmitActionLabel('Issue Endorsement'),
             ])
             ->emptyStateHeading('No solo endorsements found');

--- a/app/Models/Training/TrainingPlace/TrainingPlace.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlace.php
@@ -43,15 +43,6 @@ class TrainingPlace extends Model
         return $this->belongsTo(Account::class, 'account_id');
     }
 
-    /**
-     * Transitional accessor to resolve the student account from the new direct FK
-     * (preferred) or the legacy waiting-list relationship (fallback).
-     */
-    public function studentAccount(): ?Account
-    {
-        return $this->account ?? $this->waitingListAccount?->account;
-    }
-
     public function trainingPosition(): BelongsTo
     {
         return $this->belongsTo(TrainingPosition::class, 'training_position_id');
@@ -96,11 +87,10 @@ class TrainingPlace extends Model
     {
         $this->loadMissing([
             'trainingPosition',
-            'waitingListAccount.account',
+            'account',
         ]);
 
-        $account = $this->waitingListAccount?->account;
-        $member = $account?->member;
+        $member = $this->account->member;
 
         if (! $member) {
             return;
@@ -124,7 +114,8 @@ class TrainingPlace extends Model
 
     public function revokeTrainingPlace(string $reason, Account $admin): void
     {
-        $this->waitingListAccount->account->addNote('training', "Training place revoked on {$this->trainingPosition->position->callsign}. Reason: {$reason}", $admin->id);
+        $this->account->addNote('training', "Training place revoked on {$this->trainingPosition->position->callsign}. Reason: {$reason}", $admin->id);
+
         $this->delete();
     }
 }

--- a/app/Notifications/Training/AvailabilityWarningCreated.php
+++ b/app/Notifications/Training/AvailabilityWarningCreated.php
@@ -40,9 +40,6 @@ class AvailabilityWarningCreated extends Notification
      */
     public function toMail($notifiable)
     {
-        $trainingPlace = $this->availabilityWarning->trainingPlace;
-        $waitingListAccount = $trainingPlace->waitingListAccount;
-        $waitingListName = $waitingListAccount->waitingList->name ?? 'N/A';
         $expiresAt = $this->availabilityWarning->expires_at;
 
         $daysToExpire = (int) ceil(now()->diffInHours($expiresAt, false) / 24);
@@ -52,7 +49,6 @@ class AvailabilityWarningCreated extends Notification
             ->subject('Action Required: Update Your Availability')
             ->view('emails.training.availability_warning', [
                 'recipient' => $notifiable,
-                'waiting_list_name' => $waitingListName,
                 'expires_at' => $expiresAt,
                 'days_to_expire' => $daysToExpire.' '.Str::plural('day', $daysToExpire),
             ]);

--- a/app/Services/Training/EndorsementService.php
+++ b/app/Services/Training/EndorsementService.php
@@ -50,7 +50,7 @@ class EndorsementService
     public static function getSoloEndorsementsForTrainingPlace(TrainingPlace $trainingPlace): Builder
     {
         return Endorsement::query()
-            ->where('account_id', $trainingPlace->waitingListAccount->account_id)
+            ->where('account_id', $trainingPlace->account_id)
             ->where('endorsable_id', $trainingPlace->trainingPosition->position_id)
             ->where('endorsable_type', Position::class)
             ->whereNotNull('expires_at')
@@ -78,7 +78,7 @@ class EndorsementService
                 END as endorsement_category',
                 [$position->id]
             )
-            ->where('account_id', $trainingPlace->waitingListAccount->account_id)
+            ->where('account_id', $trainingPlace->account_id)
             ->whereIn('endorsable_id', $positionIds)
             ->where('endorsable_type', Position::class)
             ->whereNotNull('expires_at')

--- a/app/Services/Training/TrainingPlaceService.php
+++ b/app/Services/Training/TrainingPlaceService.php
@@ -19,13 +19,7 @@ class TrainingPlaceService
 {
     public function assignMentoringPermissions(TrainingPlace $trainingPlace): void
     {
-        $student = $trainingPlace->studentAccount();
-
-        if (! $student) {
-            Log::error('Training place does not have an account associated');
-
-            return;
-        }
+        $student = $trainingPlace->account;
 
         if (! $student->member) {
             Log::error('Student does not have a CTS member model attached');
@@ -67,13 +61,7 @@ class TrainingPlaceService
 
     public function revokeMentoringPermissions(TrainingPlace $trainingPlace): void
     {
-        $student = $trainingPlace->studentAccount();
-
-        if (! $student) {
-            Log::error('Training place does not have an account associated');
-
-            return;
-        }
+        $student = $trainingPlace->account;
 
         if (! $student->member) {
             Log::error('Student does not have a CTS member model attached');
@@ -146,14 +134,14 @@ class TrainingPlaceService
 
         $removal = new Removal(RemovalReason::TrainingPlace, Auth::user()->id);
 
-        $trainingPlace->waitingListAccount->waitingList->removeFromWaitingList($trainingPlace->waitingListAccount->account, $removal);
+        $trainingPlace->waitingListAccount->waitingList->removeFromWaitingList($trainingPlace->account, $removal);
     }
 
     public function hasPendingExam(TrainingPlace $trainingPlace): bool
     {
-        $student = $trainingPlace->studentAccount();
+        $student = $trainingPlace->account;
 
-        if (! $student?->member) {
+        if (! $student->member) {
             Log::error('Student does not have a CTS member model attached');
 
             return false;

--- a/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
@@ -129,8 +129,8 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
             ->test(ListTrainingPlaces::class)
             ->assertSuccessful()
             ->assertCanSeeTableRecords([$trainingPlace])
-            ->assertTableColumnExists('waitingListAccount.account.name')
-            ->assertTableColumnExists('waitingListAccount.account_id')
+            ->assertTableColumnExists('account.name')
+            ->assertTableColumnExists('account_id')
             ->assertTableColumnExists('trainingPosition.position.callsign');
     }
 

--- a/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
@@ -89,8 +89,8 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         Livewire::test(ViewTrainingPlace::class, ['trainingPlaceId' => $trainingPlace->id])
             ->assertStatus(200)
-            ->assertSee($trainingPlace->waitingListAccount->account->name)
-            ->assertSee($trainingPlace->waitingListAccount->account->id)
+            ->assertSee($trainingPlace->account->name)
+            ->assertSee($trainingPlace->account->id)
             ->assertSee($trainingPlace->trainingPosition->position->name);
     }
 
@@ -117,7 +117,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
             'position' => $cts_positions[0],
             'taken' => 1,
             'taken_date' => now()->subDays(5),
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
         ]);
 
         Livewire::test(ViewTrainingPlace::class, ['trainingPlaceId' => $trainingPlace->id])
@@ -132,7 +132,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         // Create a session for a different position
         $otherSession = Session::factory()->create([
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'position' => 'EGKK_TWR', // Different position
             'taken' => 1,
             'taken_date' => now()->subDays(5),
@@ -150,7 +150,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         $mentor = Member::factory()->create();
         $session = Session::factory()->create([
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'position' => $cts_positions[0],
             'taken_date' => now()->subDays(5),
             'taken' => 1,
@@ -171,7 +171,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
         $session = Session::factory()->create([
             'position' => $cts_positions[0],
             'taken_date' => now()->subDays(5),
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'noShow' => 0, // Explicitly set to 0 to ensure it's false
             'cancelled_datetime' => null, // Explicitly set to null
             'session_done' => 0, // Explicitly set to 0 to ensure it's false
@@ -189,7 +189,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
         $cts_positions = $trainingPlace->trainingPosition->cts_positions;
 
         $session = Session::factory()->create([
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'position' => $cts_positions[0],
             'taken_date' => now()->subDays(5),
             'noShow' => 0,
@@ -210,7 +210,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
         $cts_positions = $trainingPlace->trainingPosition->cts_positions;
 
         $session = Session::factory()->create([
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'position' => $cts_positions[0],
             'taken_date' => now()->subDays(5),
             'noShow' => 1, // Explicitly set to 1 to ensure it's true
@@ -230,7 +230,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
         $cts_positions = $trainingPlace->trainingPosition->cts_positions;
 
         $session = Session::factory()->create([
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'position' => $cts_positions[0],
             'taken_date' => now()->subDays(5),
             'cancelled_datetime' => now()->subDays(6)->toDateTimeString(),
@@ -254,7 +254,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
             'position' => $cts_positions[0],
             'taken' => 1,
             'taken_date' => now()->subDays(5),
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
         ]);
 
         $expectedUrl = "https://cts.vatsim.uk/mentors/report.php?id={$session->getKey()}&view=report";
@@ -279,14 +279,14 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         // Create sessions for both positions
         $session1 = Session::factory()->create([
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'position' => 'EGLL_APP',
             'taken_date' => now()->subDays(5),
             'taken' => 1,
         ]);
 
         $session2 = Session::factory()->create([
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'position' => 'EGLL_TWR',
             'taken_date' => now()->subDays(3),
             'taken' => 1,
@@ -337,7 +337,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         // Create a pending exam booking for the student
         ExamBooking::factory()->create([
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'finished' => ExamBooking::NOT_FINISHED_FLAG,
         ]);
 
@@ -382,7 +382,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
         $this->panelUser->givePermissionTo('training.exams.setup');
 
         // Remove ATC qualification from the member's account
-        $trainingPlace->waitingListAccount->account->update(['qualification_atc' => 0]);
+        $trainingPlace->account->update(['qualification_atc' => 0]);
 
         $position = Position::factory()->create([
             'callsign' => 'EGKK_TWR',
@@ -404,7 +404,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         // Create a pending exam booking
         ExamBooking::factory()->create([
-            'student_id' => $trainingPlace->waitingListAccount->account->member->id,
+            'student_id' => $trainingPlace->account->member->id,
             'finished' => ExamBooking::NOT_FINISHED_FLAG,
         ]);
 
@@ -422,8 +422,8 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
         Livewire::actingAs($this->panelUser)
             ->test(ViewTrainingPlace::class, ['trainingPlaceId' => $trainingPlace->id])
             ->assertStatus(200)
-            ->assertSee($trainingPlace->waitingListAccount->account->name)
-            ->assertSee((string) $trainingPlace->waitingListAccount->account->id);
+            ->assertSee($trainingPlace->account->name)
+            ->assertSee((string) $trainingPlace->account->id);
     }
 
     /**
@@ -457,6 +457,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
         // Create and return training place
         return TrainingPlace::factory()->create([
             'waiting_list_account_id' => $waitingListAccount->id,
+            'account_id' => $student->id,
             'training_position_id' => $trainingPosition->id,
         ]);
     }
@@ -511,7 +512,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
             ->callAction('revokeTrainingPlace', data: ['reason' => $reason]);
 
         $this->assertDatabaseHas('mship_account_note', [
-            'account_id' => $trainingPlace->waitingListAccount->account->id,
+            'account_id' => $trainingPlace->account->id,
             'content' => "Training place revoked on {$trainingPlace->trainingPosition->position->callsign}. Reason: {$reason}",
         ]);
     }
@@ -591,6 +592,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         return TrainingPlace::factory()->create([
             'waiting_list_account_id' => $waitingListAccount->id,
+            'account_id' => $student->id,
             'training_position_id' => $trainingPosition->id,
         ]);
     }
@@ -613,7 +615,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         Livewire::test(ViewTrainingPlace::class, ['trainingPlaceId' => $trainingPlace->id])
             ->assertStatus(200)
-            ->assertSee($trainingPlace->waitingListAccount->account->name)
+            ->assertSee($trainingPlace->account->name)
             ->assertSee($trainingPlace->trainingPosition->position->name);
     }
 

--- a/tests/Unit/Notifications/Training/AvailabilityWarningCreatedNotificationTest.php
+++ b/tests/Unit/Notifications/Training/AvailabilityWarningCreatedNotificationTest.php
@@ -83,7 +83,6 @@ class AvailabilityWarningCreatedNotificationTest extends TestCase
 
         $this->assertEquals('emails.training.availability_warning', $mailMessage->view);
         $this->assertArrayHasKey('recipient', $mailMessage->viewData);
-        $this->assertArrayHasKey('waiting_list_name', $mailMessage->viewData);
         $this->assertArrayHasKey('expires_at', $mailMessage->viewData);
         $this->assertArrayHasKey('days_to_expire', $mailMessage->viewData);
     }

--- a/tests/Unit/Notifications/Training/AvailabilityWarningCreatedNotificationTest.php
+++ b/tests/Unit/Notifications/Training/AvailabilityWarningCreatedNotificationTest.php
@@ -89,16 +89,6 @@ class AvailabilityWarningCreatedNotificationTest extends TestCase
     }
 
     #[Test]
-    public function it_includes_waiting_list_name_in_view_data(): void
-    {
-        $notification = new AvailabilityWarningCreated($this->availabilityWarning);
-
-        $mailMessage = $notification->toMail($this->account);
-
-        $this->assertEquals('Test Waiting List', $mailMessage->viewData['waiting_list_name']);
-    }
-
-    #[Test]
     public function it_includes_expiry_date_in_view_data(): void
     {
         $notification = new AvailabilityWarningCreated($this->availabilityWarning);

--- a/tests/Unit/Training/TrainingPlace/AdhocTrainingPlaceCreationTest.php
+++ b/tests/Unit/Training/TrainingPlace/AdhocTrainingPlaceCreationTest.php
@@ -39,7 +39,7 @@ class AdhocTrainingPlaceCreationTest extends TestCase
         $this->assertNull($trainingPlace->waiting_list_account_id);
         $this->assertEquals($student->id, $trainingPlace->account_id);
         $this->assertEquals($trainingPosition->id, $trainingPlace->training_position_id);
-        $this->assertTrue($trainingPlace->studentAccount()->is($student));
+        $this->assertTrue($trainingPlace->account->is($student));
 
         $this->assertDatabaseHas('mship_account_note', [
             'account_id' => $student->id,

--- a/tests/Unit/Training/TrainingPlace/TrainingPlaceAccountRelationshipTest.php
+++ b/tests/Unit/Training/TrainingPlace/TrainingPlaceAccountRelationshipTest.php
@@ -31,6 +31,5 @@ class TrainingPlaceAccountRelationshipTest extends TestCase
         ]);
 
         $this->assertTrue($trainingPlace->account->is($account));
-        $this->assertTrue($trainingPlace->studentAccount()->is($account));
     }
 }


### PR DESCRIPTION
This pull request refactors the way student account information is accessed throughout the training place and related features. The code now consistently uses the direct `account` relationship on the `TrainingPlace` model instead of accessing the student via the nested `waitingListAccount->account` relationship. This change simplifies data access, improves code clarity, and reduces legacy dependencies. Additionally, transitional helpers and some legacy code paths have been removed.

The most important changes are:

**Refactoring to use direct `account` relationship:**
- Updated all references from `waitingListAccount->account` to the direct `account` relationship in the `TrainingPlace` model and related code, including display, logic, and notification features. [[1]](diffhunk://#diff-78c2c1303adcea320fd3c93f5b7c0aabb0611878f49ad7be062657e87335582cL62-R74) [[2]](diffhunk://#diff-78c2c1303adcea320fd3c93f5b7c0aabb0611878f49ad7be062657e87335582cL100-R112) [[3]](diffhunk://#diff-78c2c1303adcea320fd3c93f5b7c0aabb0611878f49ad7be062657e87335582cL124-R135) [[4]](diffhunk://#diff-78c2c1303adcea320fd3c93f5b7c0aabb0611878f49ad7be062657e87335582cL169-R181) [[5]](diffhunk://#diff-78c2c1303adcea320fd3c93f5b7c0aabb0611878f49ad7be062657e87335582cL179-R191) [[6]](diffhunk://#diff-78c2c1303adcea320fd3c93f5b7c0aabb0611878f49ad7be062657e87335582cL241-R260) [[7]](diffhunk://#diff-78c2c1303adcea320fd3c93f5b7c0aabb0611878f49ad7be062657e87335582cL259-R277) [[8]](diffhunk://#diff-72844d25ceb6313261acf79d42df6dd3051e91899b26bcd7f0c9f730c2aae1f4L20-R20) [[9]](diffhunk://#diff-0c4095ee466195f311b2b591b99deefb22db4acc3b387442de2aef82d3e0c22aR63) [[10]](diffhunk://#diff-0c4095ee466195f311b2b591b99deefb22db4acc3b387442de2aef82d3e0c22aL77-R84) [[11]](diffhunk://#diff-05501868ba5561ef1835548aef1db795127022ed92d1cd2247eb3cd48509d469L49-R49) [[12]](diffhunk://#diff-c73c959a3a43210b6489bba90dc7530575e019aa8c0d3ffded9a2e6d74e817d7L47-R47) [[13]](diffhunk://#diff-895052482424d72b38672e089393dd1bed877342cfd5adb691021ee2ac1f4ea3L48-R53) [[14]](diffhunk://#diff-8de431c4c466975c162e20bb69194f404c335917924e77627cf83158dd16771cL28-R31) [[15]](diffhunk://#diff-b36f73bd169f95080b4f0bf1e07e6d45d16fb72bf53aa1549b2f3dd02cef889dL140-R140) [[16]](diffhunk://#diff-f4548997fd51eb0345ad78ebcf0496921b3b305a358dbf631b54cbf121e0fb7eL32-R32) [[17]](diffhunk://#diff-8996467bb56d51d1895a34debb774ef5bb8f3da9df16ece0c7a36ff0c941a7adL77-R77) [[18]](diffhunk://#diff-8996467bb56d51d1895a34debb774ef5bb8f3da9df16ece0c7a36ff0c941a7adL91-R102) [[19]](diffhunk://#diff-8996467bb56d51d1895a34debb774ef5bb8f3da9df16ece0c7a36ff0c941a7adL108-R117) [[20]](diffhunk://#diff-8d8fdbb4f246092c22d809461b12102e795966d3a926b806178e57c7249d3b74L99-R93) [[21]](diffhunk://#diff-8d8fdbb4f246092c22d809461b12102e795966d3a926b806178e57c7249d3b74L127-R118) [[22]](diffhunk://#diff-3350fea3ce34ba1c6372d75fd22776ec53e952f33e46bae975d1cc3f801df057L53-R53)

**Model and codebase cleanup:**
- Removed the transitional `studentAccount()` accessor from the `TrainingPlace` model, as all code now uses the direct relationship.
- Updated eager loading and relationship loading to use the direct `account` relationship, reducing complexity and potential for bugs. [[1]](diffhunk://#diff-0c4095ee466195f311b2b591b99deefb22db4acc3b387442de2aef82d3e0c22aR63) [[2]](diffhunk://#diff-8d8fdbb4f246092c22d809461b12102e795966d3a926b806178e57c7249d3b74L99-R93)

**Legacy/unused code removal:**
- Cleaned up unused variables and legacy references in notification and mail logic, reflecting the new relationship structure. [[1]](diffhunk://#diff-12d97168417d1a622888027d6a22bf698276cffd1c011c5490e4acfbdca5bc14L43-L45) [[2]](diffhunk://#diff-12d97168417d1a622888027d6a22bf698276cffd1c011c5490e4acfbdca5bc14L55)

**Improved robustness:**
- Added checks for missing members to prevent errors when the `account` or its `member` is not present. [[1]](diffhunk://#diff-78c2c1303adcea320fd3c93f5b7c0aabb0611878f49ad7be062657e87335582cL169-R181) [[2]](diffhunk://#diff-895052482424d72b38672e089393dd1bed877342cfd5adb691021ee2ac1f4ea3L48-R53) [[3]](diffhunk://#diff-8de431c4c466975c162e20bb69194f404c335917924e77627cf83158dd16771cL28-R31) [[4]](diffhunk://#diff-72844d25ceb6313261acf79d42df6dd3051e91899b26bcd7f0c9f730c2aae1f4L20-R20)

These changes make the codebase more maintainable and future-proof by standardizing on the direct foreign key relationship for student accounts.