### PR TITLE
fix: move 'My Training' to top of navigation and reorder exam navigation items

### DIFF
--- a/app/Filament/Training/Pages/Exam/ExamHistory.php
+++ b/app/Filament/Training/Pages/Exam/ExamHistory.php
@@ -24,7 +24,7 @@ class ExamHistory extends Page implements HasTable
 
     protected string $view = 'filament.training.pages.exam-history';
 
-    protected static ?int $navigationSort = 3;
+    protected static ?int $navigationSort = 30;
 
     protected static string|\UnitEnum|null $navigationGroup = 'Exams';
 

--- a/app/Filament/Training/Pages/Exam/ExamHistory.php
+++ b/app/Filament/Training/Pages/Exam/ExamHistory.php
@@ -24,6 +24,8 @@ class ExamHistory extends Page implements HasTable
 
     protected string $view = 'filament.training.pages.exam-history';
 
+    protected static ?int $navigationSort = 3;
+
     protected static string|\UnitEnum|null $navigationGroup = 'Exams';
 
     public static function canAccess(): bool

--- a/app/Filament/Training/Pages/Exam/ExamSetup.php
+++ b/app/Filament/Training/Pages/Exam/ExamSetup.php
@@ -31,6 +31,8 @@ class ExamSetup extends Page implements HasForms
 
     protected string $view = 'filament.training.pages.exam-setup';
 
+    protected static ?int $navigationSort = 2;
+
     protected static string|\UnitEnum|null $navigationGroup = 'Exams';
 
     public static function canAccess(): bool

--- a/app/Filament/Training/Pages/Exam/ExamSetup.php
+++ b/app/Filament/Training/Pages/Exam/ExamSetup.php
@@ -31,7 +31,7 @@ class ExamSetup extends Page implements HasForms
 
     protected string $view = 'filament.training.pages.exam-setup';
 
-    protected static ?int $navigationSort = 2;
+    protected static ?int $navigationSort = 20;
 
     protected static string|\UnitEnum|null $navigationGroup = 'Exams';
 

--- a/app/Filament/Training/Pages/Exam/Exams.php
+++ b/app/Filament/Training/Pages/Exam/Exams.php
@@ -10,7 +10,7 @@ class Exams extends Page
 
     protected string $view = 'filament.training.pages.exams';
 
-    protected static ?int $navigationSort = 1;
+    protected static ?int $navigationSort = 10;
 
     protected static string|\UnitEnum|null $navigationGroup = 'Exams';
 

--- a/app/Filament/Training/Pages/Exam/Exams.php
+++ b/app/Filament/Training/Pages/Exam/Exams.php
@@ -10,6 +10,8 @@ class Exams extends Page
 
     protected string $view = 'filament.training.pages.exams';
 
+    protected static ?int $navigationSort = 1;
+
     protected static string|\UnitEnum|null $navigationGroup = 'Exams';
 
     public static function canAccess(): bool

--- a/app/Filament/Training/Pages/Exam/ManageExaminers.php
+++ b/app/Filament/Training/Pages/Exam/ManageExaminers.php
@@ -26,7 +26,7 @@ class ManageExaminers extends Page implements HasTable
 
     protected string $view = 'filament.training.pages.manage-examiners';
 
-    protected static ?int $navigationSort = 4;
+    protected static ?int $navigationSort = 40;
 
     protected static string|\UnitEnum|null $navigationGroup = 'Exams';
 

--- a/app/Filament/Training/Pages/Exam/ManageExaminers.php
+++ b/app/Filament/Training/Pages/Exam/ManageExaminers.php
@@ -26,6 +26,8 @@ class ManageExaminers extends Page implements HasTable
 
     protected string $view = 'filament.training.pages.manage-examiners';
 
+    protected static ?int $navigationSort = 4;
+
     protected static string|\UnitEnum|null $navigationGroup = 'Exams';
 
     protected static ?string $navigationLabel = 'Manage Examiners';

--- a/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
+++ b/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
@@ -14,7 +14,7 @@ class MyExamHistory extends Page
 
     protected static ?string $navigationLabel = 'My Exam History';
 
-    protected static ?int $navigationSort = 2;
+    protected static ?int $navigationSort = 20;
 
     public static function canAccess(): bool
     {

--- a/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
+++ b/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
@@ -28,7 +28,7 @@ class MyPendingExams extends Page implements HasTable
 
     protected static ?string $navigationLabel = 'My Pending Exams';
 
-    protected static ?int $navigationSort = 1;
+    protected static ?int $navigationSort = 10;
 
     public static function canAccess(): bool
     {

--- a/app/Providers/Filament/TrainingPanelProvider.php
+++ b/app/Providers/Filament/TrainingPanelProvider.php
@@ -52,6 +52,12 @@ class TrainingPanelProvider extends PanelProvider
             ])
             ->brandLogo(asset('images/branding/vatsimuk_blackblue.png'))
             ->darkModeBrandLogo(asset('images/branding/vatsimuk_whiteblue.png'))
+            ->navigationGroups([
+                'My Training',
+                'Exams',
+                'Training',
+                'Theory',
+            ])
             ->navigationItems([
                 NavigationItem::make('Admin Panel')
                     ->url(fn () => route('filament.app.pages.dashboard'))


### PR DESCRIPTION
# Summary of changes
- Reordered navigation groups so My Training is at the top
- Reordered the exam navigation items into a more logical order

# Screenshots (if necessary)
<img width="325" height="825" alt="image" src="https://github.com/user-attachments/assets/d825cea2-2dba-4196-9977-ce03a9b72849" />
