### PR TITLE
feat: add exam cancellations table to exam history page

### DIFF
--- a/app/Livewire/Training/ExamCancellationsTable.php
+++ b/app/Livewire/Training/ExamCancellationsTable.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Livewire\Training;
+
+use App\Enums\PilotExamType;
+use App\Filament\Training\Support\TrainingMemberAccountSearch;
+use App\Models\Cts\CancelReason;
+use App\Models\Mship\Account;
+use App\Services\Training\ExamHistoryService;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Component;
+
+class ExamCancellationsTable extends Component implements HasForms, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+    use InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        $examHistoryService = app(ExamHistoryService::class);
+
+        return $table
+            ->heading('Exam Cancellations')
+            ->query(
+                CancelReason::query()
+                    ->where('sesh_type', 'EX')
+                    ->with(['examBooking', 'examBooking.student'])
+            )
+            ->columns([
+                TextColumn::make('examBooking.student.cid')
+                    ->label('Student CID')
+                    ->searchable(),
+
+                TextColumn::make('examBooking.student.account.name')
+                    ->label('Student Name'),
+
+                TextColumn::make('examBooking.exam')
+                    ->label('Exam'),
+
+                TextColumn::make('reason')
+                    ->label('Reason')
+                    ->wrap()
+                    ->limit(50)
+                    ->tooltip(fn ($state) => $state),
+
+                TextColumn::make('date')
+                    ->label('Cancelled Date')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                Filter::make('student')
+                    ->schema([
+                        Select::make('student_id')
+                            ->label('Student')
+                            ->searchable()
+                            ->getSearchResultsUsing(fn (string $search): array => TrainingMemberAccountSearch::searchAccountsForSelect($search, 50))
+                            ->getOptionLabelUsing(fn ($value): ?string => Account::query()->find($value)?->name.' ('.$value.')')
+                            ->required(),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query->when(
+                            $data['student_id'],
+                            fn (Builder $query, $vatsimCid): Builder => $query->whereHas('examBooking.student',
+                                fn ($q) => $q->where('cid', $vatsimCid)
+                            )
+                        );
+                    }),
+                Filter::make('position')->schema([
+                    Select::make('atc_positions')
+                        ->options([
+                            'OBS' => 'Observer',
+                            'TWR' => 'Tower',
+                            'APP' => 'Approach',
+                            'CTR' => 'Enroute',
+                        ])
+                        ->multiple()
+                        ->label('ATC position'),
+                    Select::make('pilot_positions')
+                        ->options(collect(PilotExamType::cases())
+                            ->mapWithKeys(fn ($type) => [$type->label() => $type->label()])
+                            ->toArray()
+                        )
+                        ->multiple()
+                        ->label('Pilot rating'),
+                ])->query(fn (Builder $query, array $data) => $examHistoryService->applyPositionFilter($query, $data))
+                    ->label('Position'),
+            ])
+            ->defaultSort('date', 'desc')
+            ->emptyStateHeading('No cancelled exams found');
+    }
+
+    public function render()
+    {
+        return view('livewire.training.exam-cancellations-table');
+    }
+}

--- a/app/Livewire/Training/ExamCancellationsTable.php
+++ b/app/Livewire/Training/ExamCancellationsTable.php
@@ -57,6 +57,10 @@ class ExamCancellationsTable extends Component implements HasForms, HasTable
                     ->label('Cancelled Date')
                     ->dateTime()
                     ->sortable(),
+
+                TextColumn::make('reason_by')
+                    ->label('Cancelled By CID')
+                    ->searchable(),
             ])
             ->filters([
                 Filter::make('student')

--- a/app/Livewire/Training/ExamCancellationsTable.php
+++ b/app/Livewire/Training/ExamCancellationsTable.php
@@ -28,12 +28,18 @@ class ExamCancellationsTable extends Component implements HasForms, HasTable
     public function table(Table $table): Table
     {
         $examHistoryService = app(ExamHistoryService::class);
+        $user = auth()->user();
+
+        $allowedTypes = $examHistoryService->getTypesToShow($user);
 
         return $table
             ->heading('Exam Cancellations')
             ->query(
                 CancelReason::query()
                     ->where('sesh_type', 'EX')
+                    ->whereHas('examBooking', function (Builder $query) use ($allowedTypes) {
+                        $query->whereIn('exam', $allowedTypes);
+                    })
                     ->with(['examBooking', 'examBooking.student'])
             )
             ->columns([

--- a/app/Livewire/Training/ExamCancellationsTable.php
+++ b/app/Livewire/Training/ExamCancellationsTable.php
@@ -3,9 +3,7 @@
 namespace App\Livewire\Training;
 
 use App\Enums\PilotExamType;
-use App\Filament\Training\Support\TrainingMemberAccountSearch;
 use App\Models\Cts\CancelReason;
-use App\Models\Mship\Account;
 use App\Services\Training\ExamHistoryService;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Forms\Components\Select;
@@ -48,7 +46,8 @@ class ExamCancellationsTable extends Component implements HasForms, HasTable
                     ->searchable(),
 
                 TextColumn::make('examBooking.student.account.name')
-                    ->label('Student Name'),
+                    ->label('Student Name')
+                    ->searchable(),
 
                 TextColumn::make('examBooking.exam')
                     ->label('Exam'),
@@ -69,23 +68,6 @@ class ExamCancellationsTable extends Component implements HasForms, HasTable
                     ->searchable(),
             ])
             ->filters([
-                Filter::make('student')
-                    ->schema([
-                        Select::make('student_id')
-                            ->label('Student')
-                            ->searchable()
-                            ->getSearchResultsUsing(fn (string $search): array => TrainingMemberAccountSearch::searchAccountsForSelect($search, 50))
-                            ->getOptionLabelUsing(fn ($value): ?string => Account::query()->find($value)?->name.' ('.$value.')')
-                            ->required(),
-                    ])
-                    ->query(function (Builder $query, array $data): Builder {
-                        return $query->when(
-                            $data['student_id'],
-                            fn (Builder $query, $vatsimCid): Builder => $query->whereHas('examBooking.student',
-                                fn ($q) => $q->where('cid', $vatsimCid)
-                            )
-                        );
-                    }),
                 Filter::make('position')->schema([
                     Select::make('atc_positions')
                         ->options([

--- a/app/Models/Cts/CancelReason.php
+++ b/app/Models/Cts/CancelReason.php
@@ -27,6 +27,11 @@ class CancelReason extends Model
         return $this->belongsTo(Member::class, 'reason_by', 'id');
     }
 
+    public function examBooking()
+    {
+        return $this->belongsTo(ExamBooking::class, 'sesh_id', 'id');
+    }
+
     public function isExam(): bool
     {
         return $this->sesh_type === 'EX';

--- a/app/Models/Cts/CancelReason.php
+++ b/app/Models/Cts/CancelReason.php
@@ -2,10 +2,13 @@
 
 namespace App\Models\Cts;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class CancelReason extends Model
 {
+    use HasFactory;
+
     protected $connection = 'cts';
 
     protected $table = 'cancel_reason';

--- a/app/Models/Cts/ExamBooking.php
+++ b/app/Models/Cts/ExamBooking.php
@@ -83,4 +83,11 @@ class ExamBooking extends Model
         return $this->where('taken', 1)
             ->where('finished', self::NOT_FINISHED_FLAG);
     }
+
+    public function cancelReasons()
+    {
+        return $this->hasMany(CancelReason::class, 'sesh_id', 'id')
+            ->where('sesh_type', 'EX')
+            ->orderBy('date', 'desc');
+    }
 }

--- a/database/factories/Cts/CancelReasonFactory.php
+++ b/database/factories/Cts/CancelReasonFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories\Cts;
+
+use App\Models\Cts\CancelReason;
+use App\Models\Cts\ExamBooking;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CancelReasonFactory extends Factory
+{
+    protected $model = CancelReason::class;
+
+    public function definition(): array
+    {
+        return [
+            'sesh_id' => ExamBooking::factory(),
+            'sesh_type' => 'EX',
+            'reason' => $this->faker->sentence(),
+            'reason_by' => $this->faker->randomNumber(7, true),
+            'date' => now(),
+            'used' => 0,
+        ];
+    }
+}

--- a/resources/views/filament/training/pages/exam-history.blade.php
+++ b/resources/views/filament/training/pages/exam-history.blade.php
@@ -1,3 +1,5 @@
 <x-filament-panels::page>
     {{ $this->table }}
+
+    @livewire(\App\Livewire\Training\ExamCancellationsTable::class, key('exam-cancellations-table'))
 </x-filament-panels::page>

--- a/resources/views/livewire/training/exam-cancellations-table.blade.php
+++ b/resources/views/livewire/training/exam-cancellations-table.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ $this->table }}
+</div>

--- a/tests/Feature/TrainingPanel/Exams/ExamCancellationsTableTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamCancellationsTableTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\Training;
+
+use App\Livewire\Training\ExamCancellationsTable;
+use App\Models\Cts\CancelReason;
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class ExamCancellationsTableTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    private function createCancellation(string $examType, string $reason = 'Test Reason'): CancelReason
+    {
+        $studentAccount = Account::factory()->create();
+        $student = Member::factory()->create(['cid' => $studentAccount->id]);
+
+        $booking = ExamBooking::factory()->create([
+            'student_id' => $student->id,
+            'exam' => $examType,
+            'position_1' => 'EGKK_TWR',
+        ]);
+
+        return CancelReason::factory()->create([
+            'sesh_id' => $booking->id,
+            'sesh_type' => 'EX',
+            'reason' => $reason,
+            'reason_by' => 1234567,
+            'date' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_renders_successfully(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamCancellationsTable::class)
+            ->assertStatus(200);
+    }
+
+    #[Test]
+    public function it_shows_cancellations_the_user_has_permission_to_see(): void
+    {
+        $this->panelUser->givePermissionTo('training.exams.conduct.twr');
+
+        $twrCancellation = $this->createCancellation('twr', 'Tower Cancellation');
+        $appCancellation = $this->createCancellation('app', 'Approach Cancellation');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamCancellationsTable::class)
+            ->assertCanSeeTableRecords([$twrCancellation])
+            ->assertCanNotSeeTableRecords([$appCancellation]);
+    }
+
+    #[Test]
+    public function it_can_filter_by_atc_position(): void
+    {
+        $this->panelUser->givePermissionTo('training.exams.conduct.twr');
+
+        $twrCancellation = $this->createCancellation('twr');
+        $twrCancellation->examBooking->update(['position_1' => 'EGCC_APP']);
+
+        $anotherCancellation = $this->createCancellation('twr');
+        $anotherCancellation->examBooking->update(['position_1' => 'EGKK_TWR']);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamCancellationsTable::class)
+            ->filterTable('position', [
+                'atc_positions' => ['TWR'],
+            ])
+            ->assertCanSeeTableRecords([$anotherCancellation])
+            ->assertCanNotSeeTableRecords([$twrCancellation]);
+    }
+
+    #[Test]
+    public function it_does_not_show_mentoring_cancellations(): void
+    {
+        $this->panelUser->givePermissionTo('training.exams.conduct.twr');
+
+        $examCancellation = $this->createCancellation('twr');
+
+        $mentoringCancellation = CancelReason::factory()->create([
+            'sesh_type' => 'ME',
+            'reason' => 'Mentoring Cancelled',
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamCancellationsTable::class)
+            ->assertCanSeeTableRecords([$examCancellation])
+            ->assertCanNotSeeTableRecords([$mentoringCancellation]);
+    }
+}


### PR DESCRIPTION
# Summary of changes
- Adds exam cancellations table to exam history page

# Screenshots (if necessary)
<img width="781" height="618" alt="image" src="https://github.com/user-attachments/assets/f0e1baa6-e905-44be-956b-82c543d0f5bc" />
