### PR TITLE
Add trackaudio version api endpoint

### DIFF
--- a/app/Http/Controllers/Api/TrackAudioController.php
+++ b/app/Http/Controllers/Api/TrackAudioController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+class TrackAudioController
+
+{
+    public function getLatest(Request $request)
+    {
+        $latestVersion = Cache::get('trackaudio_latest_version');
+
+        if ($latestVersion == null) {
+            $latestVersion = $this->fetchLatestVersion();
+
+            if ($latestVersion) {
+                Cache::put('trackaudio_latest_version', $latestVersion, now()->addHours(24));
+            }
+        }
+
+        if ($latestVersion) {
+            return new RedirectResponse("https://github.com/pierr3/TrackAudio/releases/tag/{$latestVersion}");
+        } else {
+            return new RedirectResponse("https://github.com/pierr3/TrackAudio/releases");
+        }
+
+    }
+
+    private function fetchLatestVersion()
+    {
+        try {
+            $response = Http::get('https://raw.githubusercontent.com/pierr3/TrackAudio/refs/heads/main/MANDATORY_VERSION');
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            return trim($response->body());
+
+        } catch (\Exception $e) {
+            \Log::error('Failed to fetch latest TrackAudio version: '.$e->getMessage());
+
+            return null;
+        }
+    }
+}

--- a/app/Http/Controllers/Api/TrackAudioController.php
+++ b/app/Http/Controllers/Api/TrackAudioController.php
@@ -13,7 +13,7 @@ class TrackAudioController
     {
         $latestVersion = Cache::get('trackaudio_latest_version');
 
-        if ($latestVersion == null) {
+        if ($latestVersion === null) {
             $latestVersion = $this->fetchLatestVersion();
 
             if ($latestVersion) {
@@ -21,7 +21,7 @@ class TrackAudioController
             }
         }
 
-        if ($latestVersion) {
+        if ($latestVersion !== null) {
             return new RedirectResponse("https://github.com/pierr3/TrackAudio/releases/tag/{$latestVersion}");
         } else {
             return new RedirectResponse('https://github.com/pierr3/TrackAudio/releases');

--- a/app/Http/Controllers/Api/TrackAudioController.php
+++ b/app/Http/Controllers/Api/TrackAudioController.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 class TrackAudioController
-
 {
     public function getLatest(Request $request)
     {
@@ -25,7 +24,7 @@ class TrackAudioController
         if ($latestVersion) {
             return new RedirectResponse("https://github.com/pierr3/TrackAudio/releases/tag/{$latestVersion}");
         } else {
-            return new RedirectResponse("https://github.com/pierr3/TrackAudio/releases");
+            return new RedirectResponse('https://github.com/pierr3/TrackAudio/releases');
         }
 
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 Route::get('validations')->uses('Api\ValidationsController@view')->name('api.validations');
 Route::get('metar/{airportIcao}')->uses('Site\MetarController@get')->name('api.metar');
 Route::get('/cts/bookings')->uses('Api\CtsController@getBookings')->name('api.cts.bookings');
+Route::get('trackaudio-latest')->uses('Api\TrackAudioController@getLatest')->name('api.trackaudio.latest');
 
 Route::group([
     'middleware' => 'api_auth',

--- a/tests/Feature/API/TrackAudioControllerTest.php
+++ b/tests/Feature/API/TrackAudioControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+class TrackAudioControllerTest extends Tests\TestCase
+{
+    public function test_it_redirects_to_cached_latest_trackaudio_release(): void
+    {
+        Cache::put('trackaudio_latest_version', '1.2.3', now()->addMinutes(5));
+
+        $response = $this->get(route('api.trackaudio.latest'));
+
+        $response->assertRedirect('https://github.com/pierr3/TrackAudio/releases/tag/1.2.3');
+    }
+
+    public function test_it_fetches_latest_trackaudio_release_and_redirects(): void
+    {
+        Cache::forget('trackaudio_latest_version');
+        Http::fake([
+            'raw.githubusercontent.com/*' => Http::response("2.0.1\n", 200),
+        ]);
+
+        $response = $this->get(route('api.trackaudio.latest'));
+
+        $response->assertRedirect('https://github.com/pierr3/TrackAudio/releases/tag/2.0.1');
+        $this->assertSame('2.0.1', Cache::get('trackaudio_latest_version'));
+    }
+}


### PR DESCRIPTION
To be used in docs

Caches the latest version for 24hrs and returns a temporary redirect