### PR TITLE
feat: add exam cancellations table to training place page

### DIFF
--- a/app/Livewire/Training/LeaveOfAbsencesTable.php
+++ b/app/Livewire/Training/LeaveOfAbsencesTable.php
@@ -145,7 +145,8 @@ class LeaveOfAbsencesTable extends Component implements HasActions, HasForms, Ha
                             ->send();
                     }),
             ])
-            ->emptyStateHeading('No leaves of absences');
+            ->emptyStateHeading('No leaves of absences')
+            ->emptyStateDescription('There are no LOAs for this training place');
     }
 
     private function abortIfOverlapping(CreateAction $action, array $data): void

--- a/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
+++ b/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Livewire\Training;
+
+use App\Models\Cts\CancelReason;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Livewire\Component;
+
+class TrainingPlaceExamCancellationsTable extends Component implements HasForms, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+    use InteractsWithTable;
+
+    public TrainingPlace $trainingPlace;
+
+    public function table(Table $table): Table
+    {
+        $position = $this->trainingPlace->trainingPosition->position->callsign;
+
+        return $table
+            ->heading('Exam Cancellations')
+            ->query(
+                CancelReason::query()
+                    ->select('cancel_reason.*')
+                    ->join('exam_book', 'cancel_reason.sesh_id', '=', 'exam_book.id')
+                    ->where('cancel_reason.sesh_type', 'EX')
+                    ->where('exam_book.position_1', $position)
+                    ->orderBy('cancel_reason.date', 'desc')
+            )
+            ->columns([
+                TextColumn::make('date')
+                    ->label('Date/Time')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+                TextColumn::make('reason')
+                    ->label('Reason')
+                    ->tooltip(fn ($state) => $state)
+                    ->wrap(),
+                TextColumn::make('reason_by')
+                    ->label('Cancelled By'),
+            ])
+            ->emptyStateHeading('No exam cancellations found for this training place.');
+    }
+
+    public function render()
+    {
+        return view('livewire.training.training-place-exam-cancellations-table');
+    }
+}

--- a/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
+++ b/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
@@ -27,14 +27,7 @@ class TrainingPlaceExamCancellationsTable extends Component implements HasForms,
 
         return $table
             ->heading('Exam Cancellations')
-            ->query(
-                CancelReason::query()
-                    ->select('cancel_reason.*')
-                    ->join('exam_book', 'cancel_reason.sesh_id', '=', 'exam_book.id')
-                    ->where('cancel_reason.sesh_type', 'EX')
-                    ->where('exam_book.position_1', $position)
-                    ->orderBy('cancel_reason.date', 'desc')
-            )
+            ->query($this->cancellationsQuery())
             ->columns([
                 TextColumn::make('date')
                     ->label('Date/Time')
@@ -53,5 +46,22 @@ class TrainingPlaceExamCancellationsTable extends Component implements HasForms,
     public function render()
     {
         return view('livewire.training.training-place-exam-cancellations-table');
+    }
+
+    public function hasExamCancellations(): bool
+    {
+        return $this->cancellationsQuery()->exists();
+    }
+
+    private function cancellationsQuery()
+    {
+        $position = $this->trainingPlace->trainingPosition->exam_callsign;
+
+        return CancelReason::query()
+            ->select('cancel_reason.*')
+            ->join('exam_book', 'cancel_reason.sesh_id', '=', 'exam_book.id')
+            ->where('cancel_reason.sesh_type', 'EX')
+            ->where('exam_book.position_1', $position)
+            ->orderBy('cancel_reason.date', 'desc');
     }
 }

--- a/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
+++ b/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
@@ -23,7 +23,7 @@ class TrainingPlaceExamCancellationsTable extends Component implements HasForms,
 
     public function table(Table $table): Table
     {
-        $position = $this->trainingPlace->trainingPosition->position->callsign;
+        $position = $this->trainingPlace->trainingPosition->exam_callsign;
 
         return $table
             ->heading('Exam Cancellations')

--- a/app/Models/Cts/CancelReason.php
+++ b/app/Models/Cts/CancelReason.php
@@ -2,10 +2,13 @@
 
 namespace App\Models\Cts;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class CancelReason extends Model
 {
+    use HasFactory;
+
     protected $connection = 'cts';
 
     protected $table = 'cancel_reason';

--- a/database/factories/Cts/CancelReasonFactory.php
+++ b/database/factories/Cts/CancelReasonFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories\Cts;
+
+use App\Models\Cts\CancelReason;
+use App\Models\Cts\ExamBooking;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CancelReasonFactory extends Factory
+{
+    protected $model = CancelReason::class;
+
+    public function definition(): array
+    {
+        return [
+            'sesh_id' => ExamBooking::factory(),
+            'sesh_type' => 'EX',
+            'reason' => $this->faker->sentence(),
+            'reason_by' => $this->faker->randomNumber(7, true),
+            'date' => now(),
+            'used' => 0,
+        ];
+    }
+}

--- a/resources/views/filament/training/pages/view-training-place.blade.php
+++ b/resources/views/filament/training/pages/view-training-place.blade.php
@@ -20,4 +20,6 @@
     @endif
 
     @livewire(\App\Livewire\Training\LeaveOfAbsencesTable::class, ['trainingPlace' => $this->trainingPlace], key('leave-of-absences-table'))
+
+    @livewire(\App\Livewire\Training\TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace], key('exam-cancellations-table'))
 </x-filament-panels::page>

--- a/resources/views/livewire/training/training-place-exam-cancellations-table.blade.php
+++ b/resources/views/livewire/training/training-place-exam-cancellations-table.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ $this->table }}
+</div>

--- a/resources/views/livewire/training/training-place-exam-cancellations-table.blade.php
+++ b/resources/views/livewire/training/training-place-exam-cancellations-table.blade.php
@@ -1,3 +1,5 @@
 <div>
-    {{ $this->table }}
+    @if($this->hasExamCancellations())
+        {{ $this->table }}
+    @endif
 </div>

--- a/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceExamCancellationsTableTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceExamCancellationsTableTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\Training;
+
+use App\Livewire\Training\TrainingPlaceExamCancellationsTable;
+use App\Models\Atc\Position;
+use App\Models\Cts\CancelReason;
+use App\Models\Cts\ExamBooking;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class TrainingPlaceExamCancellationsTableTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    protected TrainingPlace $trainingPlace;
+
+    protected string $callsign = 'EGKK_APP';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->trainingPlace = TrainingPlace::factory()->for(TrainingPosition::factory()->for(Position::factory(['callsign' => $this->callsign]), 'position'), 'trainingPosition')->create();
+        $this->trainingPlace->trainingPosition->position->update(['callsign' => $this->callsign]);
+    }
+
+    #[Test]
+    public function it_renders_successfully(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace])
+            ->assertStatus(200);
+    }
+
+    #[Test]
+    public function it_lists_exam_cancellations_matching_the_training_place_position(): void
+    {
+        $matchingBooking = ExamBooking::factory()->create(['position_1' => $this->callsign]);
+        $matchingCancellation = CancelReason::factory()->create([
+            'sesh_id' => $matchingBooking->id,
+            'sesh_type' => 'EX',
+            'reason' => 'Matching Exam Cancellation',
+        ]);
+
+        $wrongPositionBooking = ExamBooking::factory()->create(['position_1' => 'EGCC_TWR']);
+        $wrongPositionCancellation = CancelReason::factory()->create([
+            'sesh_id' => $wrongPositionBooking->id,
+            'sesh_type' => 'EX',
+            'reason' => 'Wrong Position Cancellation',
+        ]);
+
+        $mentoringBooking = ExamBooking::factory()->create(['position_1' => $this->callsign]);
+        $mentoringCancellation = CancelReason::factory()->create([
+            'sesh_id' => $mentoringBooking->id,
+            'sesh_type' => 'ME',
+            'reason' => 'Mentoring Cancellation',
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace])
+            ->assertCanSeeTableRecords([$matchingCancellation])
+            ->assertCanNotSeeTableRecords([$wrongPositionCancellation, $mentoringCancellation]);
+    }
+
+    #[Test]
+    public function it_shows_empty_state_when_no_cancellations_exist(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace])
+            ->assertSee('No exam cancellations found for this training place.');
+    }
+}

--- a/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceExamCancellationsTableTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceExamCancellationsTableTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature\TrainingPanel\Training;
 
 use App\Livewire\Training\TrainingPlaceExamCancellationsTable;
-use App\Models\Atc\Position;
 use App\Models\Cts\CancelReason;
 use App\Models\Cts\ExamBooking;
 use App\Models\Training\TrainingPlace\TrainingPlace;
@@ -27,8 +26,8 @@ class TrainingPlaceExamCancellationsTableTest extends BaseTrainingPanelTestCase
     {
         parent::setUp();
 
-        $this->trainingPlace = TrainingPlace::factory()->for(TrainingPosition::factory()->for(Position::factory(['callsign' => $this->callsign]), 'position'), 'trainingPosition')->create();
-        $this->trainingPlace->trainingPosition->position->update(['callsign' => $this->callsign]);
+        $this->trainingPlace = TrainingPlace::factory()
+            ->for(TrainingPosition::factory()->state(['exam_callsign' => $this->callsign]), 'trainingPosition')->create();
     }
 
     #[Test]
@@ -40,7 +39,7 @@ class TrainingPlaceExamCancellationsTableTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
-    public function it_lists_exam_cancellations_matching_the_training_place_position(): void
+    public function it_lists_exam_cancellations_matching_the_training_place_exam_callsign(): void
     {
         $matchingBooking = ExamBooking::factory()->create(['position_1' => $this->callsign]);
         $matchingCancellation = CancelReason::factory()->create([
@@ -67,13 +66,5 @@ class TrainingPlaceExamCancellationsTableTest extends BaseTrainingPanelTestCase
             ->test(TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace])
             ->assertCanSeeTableRecords([$matchingCancellation])
             ->assertCanNotSeeTableRecords([$wrongPositionCancellation, $mentoringCancellation]);
-    }
-
-    #[Test]
-    public function it_shows_empty_state_when_no_cancellations_exist(): void
-    {
-        Livewire::actingAs($this->panelUser)
-            ->test(TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace])
-            ->assertSee('No exam cancellations found for this training place.');
     }
 }


### PR DESCRIPTION
# Summary of changes
- Added exam cancellations table to training place page. Exams are linked to training places via the position. So a TP on "EGKK_APP" will show any exam cancellations on "EGKK_APP"
- Fixed some weird null state text on the LOA table

# Screenshots (if necessary)
<img width="779" height="243" alt="image" src="https://github.com/user-attachments/assets/652f6c3a-430d-47ad-ba37-188f1bbafec0" />
