### PR TITLE
fix: improve styling of create note modal

### DIFF
--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/NotesRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/NotesRelationManager.php
@@ -48,13 +48,16 @@ class NotesRelationManager extends RelationManager
 
         return $schema
             ->components([
-                Textarea::make('content')
-                    ->required()
-                    ->minLength(5),
                 Select::make('type')
                     ->required()
                     ->options($usableTypes)
-                    ->default($usableTypes->keys()->first()),
+                    ->default($usableTypes->keys()->first())
+                    ->columnSpanFull(),
+                Textarea::make('content')
+                    ->required()
+                    ->minLength(5)
+                    ->rows(6)
+                    ->columnSpanFull(),
             ]);
     }
 


### PR DESCRIPTION
# Summary of changes
- Improve the styling of the create note modal

# Screenshots (if necessary)
Before:
<img width="967" height="281" alt="image" src="https://github.com/user-attachments/assets/6e5e985b-42f0-4e3d-91f2-32fbacfe93c0" />

After:
<img width="984" height="491" alt="image" src="https://github.com/user-attachments/assets/3ec39796-62d2-4215-b926-6fcf3d90df66" />
