### PR TITLE
feat: add banner to alert S1 controllers to the correct Heathrow page

### DIFF
--- a/app/Http/Controllers/Site/ATCPagesController.php
+++ b/app/Http/Controllers/Site/ATCPagesController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers\Site;
 
-use Illuminate\Support\Facades\Redirect;
-
 class ATCPagesController extends \App\Http\Controllers\BaseController
 {
     public function __construct()
@@ -38,14 +36,12 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
 
     public function viewHeathrow()
     {
-        if ($this->account->qualification_atc->isS1) {
-            return Redirect::route('controllers.endorsements.heathrow_ground_s1');
-        }
-
         $this->setTitle('Heathrow Endorsements');
         $this->addBreadcrumb('Heathrow Endorsements', route('site.atc.heathrow'));
 
-        return $this->viewMake('site.atc.heathrow');
+        return $this->viewMake('site.atc.heathrow')->with([
+            'account' => $this->account,
+        ]);
     }
 
     public function viewBecomingAMentor()

--- a/app/Http/Controllers/Site/ATCPagesController.php
+++ b/app/Http/Controllers/Site/ATCPagesController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Site;
 
+use Illuminate\Support\Facades\Redirect;
+
 class ATCPagesController extends \App\Http\Controllers\BaseController
 {
     public function __construct()
@@ -36,6 +38,10 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
 
     public function viewHeathrow()
     {
+        if ($this->account->qualification_atc->isS1) {
+            return Redirect::route('controllers.endorsements.heathrow_ground_s1');
+        }
+
         $this->setTitle('Heathrow Endorsements');
         $this->addBreadcrumb('Heathrow Endorsements', route('site.atc.heathrow'));
 

--- a/resources/views/site/atc/heathrow-faqs.blade.php
+++ b/resources/views/site/atc/heathrow-faqs.blade.php
@@ -9,9 +9,8 @@ On the live network and via offline training (sweatbox).
 
 **What do I need before attending my sessions?**
 
-- An installed version of [Euroscope](http://www.euroscope.hu/)
+- An installed version of [Euroscope](https://euroscope.hu/install/EuroScopeSetup.3.2.3.2.msi)
 - [UK Controller Pack](https://docs.vatsim.uk/General/Software%20Downloads/Controller%20Pack%20%26%20Sector%20File/)
-- [UK Controller Plugin](https://vatsim.uk/ukcp)
-- [Audio for VATSIM](https://audio.vatsim.net/docs/2.0/atc/euroscope)
+- [TrackAudio]({{ route('api.trackaudio.latest') }})
 - [Teamspeak]({{ route('site.community.teamspeak') }}) Installed
 </x-markdown>

--- a/resources/views/site/atc/heathrow.blade.php
+++ b/resources/views/site/atc/heathrow.blade.php
@@ -1,7 +1,7 @@
 @extends('layout')
 
 @section('content')
-    @if($account->qualification_atc->isS1)
+    @if($account->qualification_atc?->isS1)
             <div class="alert alert-danger">
                 <h3 style="margin-top: 0">Heathrow Ground Endorsement - S1</h3>
                 <p>

--- a/resources/views/site/atc/heathrow.blade.php
+++ b/resources/views/site/atc/heathrow.blade.php
@@ -1,8 +1,16 @@
 @extends('layout')
 
 @section('content')
-    <div class="row">
+    @if($account->qualification_atc->isS1)
+            <div class="alert alert-danger">
+                <h3 style="margin-top: 0">Heathrow Ground Endorsement - S1</h3>
+                <p>
+                    This page only applies to controllers with a S2+ controller rating. As an S1 controller, you can view information on the S1 Heathrow Ground Endorsement <a href="{{ route('controllers.endorsements.heathrow_ground_s1') }}">here</a>.
+                </p>
+            </div>
+        @endif
 
+    <div class="row">
         <div class="col-md-9">
             <div class="panel panel-ukblue">
                 <div class="panel-heading"><i class="glyphicon glyphicon-pencil"></i> &thinsp;Heathrow Endorsements

--- a/resources/views/site/atc/newcontroller.blade.php
+++ b/resources/views/site/atc/newcontroller.blade.php
@@ -50,7 +50,7 @@
                             <a href="https://docs.vatsim.uk/General/Software%20Downloads/Controller%20Pack%20%26%20Sector%20File/" rel="">UK Controller Pack</a>
                         </li>
 						<li>
-							<a href="https://github.com/pierr3/TrackAudio/releases/latest" rel="external nofollow">TrackAudio</a>
+							<a href="{{ route('api.trackaudio.latest') }}" rel="external nofollow">TrackAudio</a>
 						</li>
                         <li>
                             <a href="{{ route('site.community.teamspeak') }}" rel="">Teamspeak</a>


### PR DESCRIPTION
# Summary of changes
- Added a banner to the top of the Heathrow page only for S1s
- Updated some links in the FAQs section

# Screenshots (if necessary)
<img width="1070" height="145" alt="image" src="https://github.com/user-attachments/assets/0d84899b-f280-4bb0-a966-2f51c1ff72d8" />
