### PR TITLE
feat: Conditionally append (BST) to "Europe/London" time zone when BST is active

### DIFF
--- a/app/Filament/Training/Pages/MyTraining/MyAvailability.php
+++ b/app/Filament/Training/Pages/MyTraining/MyAvailability.php
@@ -82,7 +82,7 @@ class MyAvailability extends Page implements HasForms, HasTable
     {
         return [
             Action::make('changeTimezone')
-                ->label(fn () => "Timezone: {$this->timezone}")
+                ->label(fn () => 'Timezone: '.$this->getTimezoneLabel($this->timezone))
                 ->icon('heroicon-o-globe-alt')
                 ->form([
                     Select::make('timezone')
@@ -91,10 +91,15 @@ class MyAvailability extends Page implements HasForms, HasTable
                             $zones = timezone_identifiers_list();
                             $options = array_combine($zones, $zones);
 
+                            // Append (BST) suffix for Europe/London option during British Summer Time
+                            if (isset($options['Europe/London'])) {
+                                $options['Europe/London'] = $this->getTimezoneLabel('Europe/London');
+                            }
+
                             $topZones = [];
 
                             if ($this->browserTimezone && isset($options[$this->browserTimezone])) {
-                                $topZones[$this->browserTimezone] = "Detected: {$this->browserTimezone}";
+                                $topZones[$this->browserTimezone] = 'Detected: '.$this->getTimezoneLabel($this->browserTimezone);
                                 unset($options[$this->browserTimezone]);
                             }
 
@@ -312,6 +317,18 @@ class MyAvailability extends Page implements HasForms, HasTable
         }
 
         return $options;
+    }
+
+    protected function getTimezoneLabel(string $timezone, ?string $prefix = null): string
+    {
+        $label = $prefix ?? $timezone;
+
+        // Add (BST) suffix for Europe/London during British Summer Time
+        if ($timezone === 'Europe/London' && now()->setTimezone('Europe/London')->offsetHours === 1) {
+            $label .= ' (BST)';
+        }
+
+        return $label;
     }
 
     protected function resolveStudentId(): ?int

--- a/app/Filament/Training/Pages/MyTraining/MyAvailability.php
+++ b/app/Filament/Training/Pages/MyTraining/MyAvailability.php
@@ -91,7 +91,7 @@ class MyAvailability extends Page implements HasForms, HasTable
                             $zones = timezone_identifiers_list();
                             $options = array_combine($zones, $zones);
 
-                            // Append (BST) suffix for Europe/London option during British Summer Time
+                            // Append (not ZULU) suffix for Europe/London option during British Summer Time
                             if (isset($options['Europe/London'])) {
                                 $options['Europe/London'] = $this->getTimezoneLabel('Europe/London');
                             }
@@ -323,9 +323,9 @@ class MyAvailability extends Page implements HasForms, HasTable
     {
         $label = $prefix ?? $timezone;
 
-        // Add (BST) suffix for Europe/London during British Summer Time
+        // Add (not ZULU) suffix for Europe/London during British Summer Time
         if ($timezone === 'Europe/London' && now()->setTimezone('Europe/London')->offsetHours === 1) {
-            $label .= ' (BST)';
+            $label .= ' (not ZULU)';
         }
 
         return $label;

--- a/resources/views/filament/training/pages/my-training/my-availability.blade.php
+++ b/resources/views/filament/training/pages/my-training/my-availability.blade.php
@@ -28,7 +28,7 @@
             <x-filament::section>
                 <x-slot name="heading">Add Availability</x-slot>
                 <x-slot name="description">
-                    All times are currently entered and shown in <strong>{{ $this->timezone }}</strong>.
+                    All times are currently entered and shown in <strong>{{ $this->getTimezoneLabel($this->timezone) }}</strong>.
                 </x-slot>
 
                 {{ $this->form }}
@@ -51,7 +51,7 @@
             <x-filament::section>
                 <x-slot name="heading">My Availability</x-slot>
                 <x-slot name="description">
-                    Future slots adjusted to <strong>{{ $this->timezone }}</strong>.
+                    Future slots adjusted to <strong>{{ $this->getTimezoneLabel($this->timezone) }}</strong>.
                 </x-slot>
 
                 {{ $this->table }}


### PR DESCRIPTION
# Summary of changes
- In order to ensure there is no confusion, during BST "Europe/London" will have a "(BST)" suffix

# Screenshots (if necessary)
<img width="317" height="57" alt="image" src="https://github.com/user-attachments/assets/2347902f-6370-417a-9f1a-a20f0cefa4d4" />
<img width="289" height="67" alt="image" src="https://github.com/user-attachments/assets/89b64e86-773a-43a7-8010-9c823e1ff105" />
