### PR TITLE
fix: resolve bugs in the My Availability page

### DIFF
--- a/app/Filament/Training/Pages/MyTraining/MyAvailability.php
+++ b/app/Filament/Training/Pages/MyTraining/MyAvailability.php
@@ -153,14 +153,18 @@ class MyAvailability extends Page implements HasForms, HasTable
                     ->required()
                     ->searchable()
                     ->allowHtml(false)
-                    ->options($this->generateTimeOptions()),
+                    ->searchPrompt('Type a time (e.g. 18:30) to filter the list')
+                    ->options($this->generateTimeOptions())
+                    ->optionsLimit(100),
 
                 Select::make('to')
                     ->label('To')
                     ->required()
                     ->searchable()
                     ->allowHtml(false)
-                    ->options($this->generateTimeOptions()),
+                    ->searchPrompt('Type a time (e.g. 18:30) to filter the list')
+                    ->options($this->generateTimeOptions())
+                    ->optionsLimit(100),
             ])
             ->statePath('data');
     }

--- a/app/Filament/Training/Pages/MyTraining/Widgets/MyAvailabilityStats.php
+++ b/app/Filament/Training/Pages/MyTraining/Widgets/MyAvailabilityStats.php
@@ -20,18 +20,22 @@ class MyAvailabilityStats extends BaseWidget
 
         $query = Availability::query()
             ->where('student_id', $studentId)
-            ->where('type', 'S');
-
-        $futureSlotsCount = (clone $query)
-            ->where('date', '>=', now()->toDateString())
-            ->count();
-
-        $totalMinutes = (clone $query)
-            ->where('date', '>=', now()->toDateString())
-            ->get()
-            ->sum(function ($availability) {
-                return Carbon::parse($availability->from)->diffInMinutes(Carbon::parse($availability->to));
+            ->where('type', 'S')
+            ->where(function ($q) {
+                $q->where('date', '>', now()->toDateString())
+                    ->orWhere(function ($q) {
+                        $q->where('date', now()->toDateString())
+                            ->where('to', '>', now()->toTimeString());
+                    });
             });
+
+        $futureAvailability = $query->get();
+
+        $futureSlotsCount = $futureAvailability->count();
+
+        $totalMinutes = $futureAvailability->sum(function ($availability) {
+            return Carbon::parse($availability->from)->diffInMinutes(Carbon::parse($availability->to));
+        });
 
         $hours = round($totalMinutes / 60, 1);
 

--- a/app/Services/Training/AvailabilityService.php
+++ b/app/Services/Training/AvailabilityService.php
@@ -24,7 +24,7 @@ class AvailabilityService
                 $query->whereDate('date', '>', $now->toDateString())
                     ->orWhere(function ($q) use ($now) {
                         $q->whereDate('date', $now->toDateString())
-                            ->whereTime('from', '>', $now->format('H:i:s'));
+                            ->whereTime('to', '>', $now->format('H:i:s'));
                     });
             });
     }

--- a/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityTest.php
@@ -24,6 +24,8 @@ class MyAvailabilityTest extends BaseTrainingPanelTestCase
     {
         parent::setUp();
 
+        $this->travelTo(Carbon::create(2026, 5, 10, 12, 0, 0));
+
         $this->studentAccount = Account::factory()->create();
         $this->studentMember = Member::factory()->recycle($this->studentAccount)->create([
             'cid' => $this->studentAccount->id,
@@ -90,8 +92,8 @@ class MyAvailabilityTest extends BaseTrainingPanelTestCase
 
         Availability::factory()->forStudent($this->studentMember->id)->create([
             'date' => now()->toDateString(),
-            'from' => now()->subHour()->format('H:i:s'),
-            'to' => now()->addHour()->format('H:i:s'),
+            'from' => '09:00:00',
+            'to' => '11:00:00',
             'type' => 'S',
         ]);
 

--- a/tests/Feature/TrainingPanel/MyTraining/Widgets/MyAvailabilityStatsTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/Widgets/MyAvailabilityStatsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\MyTraining\Widgets;
+
+use App\Filament\Training\Pages\MyTraining\Widgets\MyAvailabilityStats;
+use App\Models\Cts\Availability;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MyAvailabilityStatsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected Account $user;
+
+    protected Member $member;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = Account::factory()->create();
+        $this->member = Member::factory()->create(['cid' => $this->user->id]);
+
+        Carbon::setTestNow(Carbon::create(2026, 5, 10, 12, 0, 0));
+    }
+
+    #[Test]
+    public function it_shows_zero_stats_when_no_availability_exists(): void
+    {
+        Livewire::actingAs($this->user)
+            ->test(MyAvailabilityStats::class)
+            ->assertSee('Upcoming Slots')
+            ->assertSee('0')
+            ->assertSee('Total Availability')
+            ->assertSee('0 Hours');
+    }
+
+    #[Test]
+    public function it_calculates_stats_for_future_slots_correctly(): void
+    {
+        Availability::factory()->create([
+            'student_id' => $this->member->id,
+            'type' => 'S',
+            'date' => '2026-05-11',
+            'from' => '18:00:00',
+            'to' => '20:00:00',
+        ]);
+
+        Availability::factory()->create([
+            'student_id' => $this->member->id,
+            'type' => 'S',
+            'date' => '2026-05-12',
+            'from' => '10:00:00',
+            'to' => '11:30:00',
+        ]);
+
+        Livewire::actingAs($this->user)
+            ->test(MyAvailabilityStats::class)
+            ->assertSee('Upcoming Slots')
+            ->assertSee('2')
+            ->assertSee('Total Availability')
+            ->assertSee('3.5 Hours');
+    }
+
+    #[Test]
+    public function it_includes_slots_happening_later_today_but_excludes_past_slots(): void
+    {
+        Availability::factory()->create([
+            'student_id' => $this->member->id,
+            'type' => 'S',
+            'date' => '2026-05-10',
+            'from' => '08:00:00',
+            'to' => '10:00:00',
+        ]);
+
+        Availability::factory()->create([
+            'student_id' => $this->member->id,
+            'type' => 'S',
+            'date' => '2026-05-10',
+            'from' => '14:00:00',
+            'to' => '16:00:00',
+        ]);
+
+        Livewire::actingAs($this->user)
+            ->test(MyAvailabilityStats::class)
+            ->assertSee('Upcoming Slots')
+            ->assertSee('1')
+            ->assertSee('Total Availability')
+            ->assertSee('2 Hours');
+    }
+
+    #[Test]
+    public function it_ignores_availability_for_other_members(): void
+    {
+        $otherMember = Member::factory()->create();
+
+        Availability::factory()->create([
+            'student_id' => $otherMember->id,
+            'type' => 'S',
+            'date' => '2026-06-01',
+            'from' => '12:00:00',
+            'to' => '15:00:00',
+        ]);
+
+        Livewire::actingAs($this->user)
+            ->test(MyAvailabilityStats::class)
+            ->assertSee('0 Hours');
+    }
+}


### PR DESCRIPTION
# Summary of changes
- Ensure stats widgets don't include historical slots
- Ensure the From and To lists include ALL times + added a prompt to tell the user they can also type
- Now an availability slot will show in the list until the end time
- Adds tests for the widgets

Thanks @WillShaw1100 for all the reports!

# Screenshots (if necessary)
<img width="490" height="349" alt="image" src="https://github.com/user-attachments/assets/257fe627-75dc-457e-aecf-875c82a91aa0" />
