### PR TITLE
feat: have 'Availability Checks' collapsed by default

### DIFF
--- a/app/Livewire/Training/AvailabilityChecksTable.php
+++ b/app/Livewire/Training/AvailabilityChecksTable.php
@@ -29,7 +29,6 @@ class AvailabilityChecksTable extends Component implements HasActions, HasForms,
     public function table(Table $table): Table
     {
         return $table
-            ->heading('Availability checks')
             ->queryStringIdentifier('availability-checks')
             ->query(
                 AvailabilityCheck::query()

--- a/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
+++ b/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
@@ -48,14 +48,9 @@ class TrainingPlaceExamCancellationsTable extends Component implements HasForms,
         return view('livewire.training.training-place-exam-cancellations-table');
     }
 
-    public function hasExamCancellations(): bool
-    {
-        return $this->cancellationsQuery()->exists();
-    }
-
     private function cancellationsQuery()
     {
-        $position = $this->trainingPlace->trainingPosition->exam_callsign;
+        $position = $this->trainingPlace->trainingPosition?->exam_callsign ?? $this->trainingPlace->trainingPosition?->position?->callsign;
 
         return CancelReason::query()
             ->select('cancel_reason.*')

--- a/app/Models/Training/TrainingPlace/TrainingPlace.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlace.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Training\TrainingPlace;
 
+use App\Models\Cts\CancelReason;
 use App\Models\Cts\Session as CtsSession;
 use App\Models\Mship\Account;
 use App\Models\Training\TrainingPosition\TrainingPosition;
@@ -81,6 +82,21 @@ class TrainingPlace extends Model
     public function currentLeaveOfAbsence()
     {
         return $this->leaveOfAbsences()->current()->first();
+    }
+
+    public function hasExamCancellations(): bool
+    {
+        $position = $this->trainingPosition?->exam_callsign ?? $this->trainingPosition?->position?->callsign;
+
+        if (! $position) {
+            return false;
+        }
+
+        return CancelReason::query()
+            ->join('exam_book', 'cancel_reason.sesh_id', '=', 'exam_book.id')
+            ->where('cancel_reason.sesh_type', 'EX')
+            ->where('exam_book.position_1', $position)
+            ->exists();
     }
 
     public function deletePendingSessionRequests(): void

--- a/resources/views/filament/training/pages/view-training-place.blade.php
+++ b/resources/views/filament/training/pages/view-training-place.blade.php
@@ -9,8 +9,6 @@
 
     @livewire(\App\Livewire\Training\AvailabilityWarningsTable::class, ['trainingPlace' => $this->trainingPlace], key('availability-warnings-table'))
 
-    @livewire(\App\Livewire\Training\AvailabilityChecksTable::class, ['trainingPlace' => $this->trainingPlace], key('availability-checks-table'))
-
     @if($this->trainingPlace->trainingPosition->should_show_solo_endorsement ?? true)
         @livewire(\App\Livewire\Training\TrainingPlaceSoloEndorsement::class, ['trainingPlace' => $this->trainingPlace], key('training-place-solo-endorsement'))
     @endif
@@ -21,5 +19,13 @@
 
     @livewire(\App\Livewire\Training\LeaveOfAbsencesTable::class, ['trainingPlace' => $this->trainingPlace], key('leave-of-absences-table'))
 
-    @livewire(\App\Livewire\Training\TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace], key('exam-cancellations-table'))
+    @if($this->trainingPlace->hasExamCancellations())
+        @livewire(\App\Livewire\Training\TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace], key('exam-cancellations-table'))
+    @endif
+
+    <x-filament::section collapsible collapsed>
+        <x-slot name="heading">Availability checks</x-slot>
+        @livewire(\App\Livewire\Training\AvailabilityChecksTable::class, ['trainingPlace' => $this->trainingPlace], key('availability-checks-table'))
+    </x-filament::section>
+
 </x-filament-panels::page>

--- a/resources/views/livewire/training/training-place-exam-cancellations-table.blade.php
+++ b/resources/views/livewire/training/training-place-exam-cancellations-table.blade.php
@@ -1,5 +1,3 @@
 <div>
-    @if($this->hasExamCancellations())
-        {{ $this->table }}
-    @endif
+    {{ $this->table }}
 </div>


### PR DESCRIPTION
# Summary of changes
- By default collapse availability checks
- Ensure `TrainingPlaceExamCancellationsTable` isn't created with an empty div
- Ensure `TrainingPlaceExamCancellationsTable` uses `exam_callsign` overide

The reason for the changes to `TrainingPlaceExamCancellationsTable` is the empty div was leaving weird spacing on the screen

# Screenshots (if necessary)
<img width="830" height="537" alt="image" src="https://github.com/user-attachments/assets/ae7cf49e-fbf6-4f80-a537-cd8b546d968a" />
<img width="792" height="422" alt="image" src="https://github.com/user-attachments/assets/28e878fc-3649-41a0-a60a-811d003ea7b0" />
<img width="760" height="519" alt="image" src="https://github.com/user-attachments/assets/69f3bdfd-5a91-4976-9d13-25f0bd8a346a" />
