### PR TITLE
feat: Display indication member has waiting list notes

### DIFF
--- a/app/Filament/Training/Resources/WaitingLists/RelationManagers/AccountsRelationManager.php
+++ b/app/Filament/Training/Resources/WaitingLists/RelationManagers/AccountsRelationManager.php
@@ -116,6 +116,7 @@ class AccountsRelationManager extends RelationManager
                 TextColumn::make('created_at')->label('Added On')->dateTime('d/m/Y H:i:s'),
                 IconColumn::make('cts_theory_exam')->boolean()->label('CTS Theory Exam')->getStateUsing(fn (WaitingListAccount $record) => $record->theory_exam_passed)->visible(fn () => $this->ownerRecord->feature_toggles['check_cts_theory_exam'] ?? true),
                 ...$this->getFlagColumns(),
+                IconColumn::make('has_notes')->label('')->getStateUsing(fn (WaitingListAccount $record) => filled($record->notes))->icon(fn (WaitingListAccount $record) => filled($record->notes) ? 'heroicon-o-exclamation-triangle' : null)->color('warning')->tooltip('This user has notes on their waiting list account'),
             ])
             ->recordActions([
                 Action::make('offerTrainingPlace')
@@ -303,6 +304,9 @@ class AccountsRelationManager extends RelationManager
                                                 $this->ownerRecord->waitingListAccounts->count()
                                             );
                                         }),
+                                    TextEntry::make('notes')
+                                        ->label('Notes')
+                                        ->placeholder('No notes'),
                                 ]),
 
                             ...$offerFields,


### PR DESCRIPTION
# Summary of changes
Adds visual indication their are notes on a members waiting list account. Only displays if notes are available.
Also added the notes to the view action.

# Screenshots

<img width="1236" height="348" alt="image" src="https://github.com/user-attachments/assets/3ef030a9-25bb-4407-8236-6e762fe1e609" />