### PR TITLE
Change some filters and fix some bugs on the VT system

### DIFF
--- a/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ListVisitTransferApplications.php
+++ b/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ListVisitTransferApplications.php
@@ -19,7 +19,8 @@ class ListVisitTransferApplications extends ListRecords
 
     protected function getTableQuery(): Builder
     {
-        return parent::getTableQuery()->where('type', $this->type);
+        return parent::getTableQuery()->where('type', $this->type)
+            ->whereNotIn('status', [Application::STATUS_WITHDRAWN, Application::STATUS_LAPSED, Application::STATUS_EXPIRED]);
     }
 
     protected function getHeaderActions(): array
@@ -39,22 +40,27 @@ class ListVisitTransferApplications extends ListRecords
 
                 Action::make('all')
                     ->label('All Applications')
-                    ->url(fn () => static::getResource()::getUrl('index', ['type' => $this->type])),
-
-                Action::make('open')
-                    ->label('Open Applications')
-                    ->url(fn () => static::getResource()::getUrl('index', ['type' => $this->type, 'tableFilters' => ['status' => ['values' => [0 => Application::STATUS_SUBMITTED]]]])),
+                    ->action(function () {
+                        $this->tableFilters['status'] = null;
+                    }),
 
                 Action::make('review')
                     ->label('Review Applications')
-                    ->url(fn () => static::getResource()::getUrl('index', ['type' => $this->type, 'tableFilters' => ['status' => ['values' => [0 => Application::STATUS_UNDER_REVIEW]]]])),
+                    ->action(function () {
+                        $this->tableFilters['status'] = ['values' => [Application::STATUS_UNDER_REVIEW, Application::STATUS_SUBMITTED]];
+                    }),
+
                 Action::make('accepted')
                     ->label('Accepted Applications')
-                    ->url(fn () => static::getResource()::getUrl('index', ['type' => $this->type, 'tableFilters' => ['status' => ['values' => [0 => Application::STATUS_ACCEPTED, 1 => Application::STATUS_IN_PROGRESS]]]])),
+                    ->action(function () {
+                        $this->tableFilters['status'] = ['values' => [0 => Application::STATUS_ACCEPTED, 1 => Application::STATUS_IN_PROGRESS]];
+                    }),
 
                 Action::make('closed')
                     ->label('Closed Applications')
-                    ->url(fn () => static::getResource()::getUrl('index', ['type' => $this->type, 'tableFilters' => ['status' => ['values' => [0 => Application::STATUS_COMPLETED, 1 => Application::STATUS_REJECTED, 2 => Application::STATUS_WITHDRAWN, 3 => Application::STATUS_EXPIRED, 4 => Application::STATUS_CANCELLED, 5 => Application::STATUS_LAPSED]]]])),
+                    ->action(function () {
+                        $this->tableFilters['status'] = ['values' => [0 => Application::STATUS_COMPLETED, 1 => Application::STATUS_REJECTED,  2 => Application::STATUS_CANCELLED]];
+                    }),
 
             ])->label('Status')->button()->icon('heroicon-o-flag')->color('gray'),
         ];

--- a/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ViewVisitTransferApplication.php
+++ b/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ViewVisitTransferApplication.php
@@ -47,6 +47,9 @@ class ViewVisitTransferApplication extends ViewRecord
                         ->visible(fn ($record) => $record->facility?->waitingList !== null)
                         ->default(true)
                         ->helperText('If checked, the applicant will be added to the waiting list associated with this facility.'),
+                    Checkbox::make('staff_acknoledgement')
+                        ->label('I have checked and added a note to terminal before accepting this application.')
+                        ->required(),
                 ])->authorize(fn ($record) => auth()->user()->can('accept', $record)),
 
             Action::make('override_checks')
@@ -71,7 +74,7 @@ class ViewVisitTransferApplication extends ViewRecord
                 ->color('danger')
                 ->modalHeading(fn ($record) => "Reject Application #{$record->public_id}")
                 ->modalDescription('This action cannot be undone. If you reject this application the applicant will be notified.')
-                ->action(fn ($record, array $data) => $record->reject($data['reason'], $data['staff_note']))
+                ->action(fn ($record, array $data) => $record->reject($data['reason'], $data['staff_note'], auth()->user()))
                 ->schema([
                     Select::make('reason')
                         ->label('Reason for Rejection (required)')
@@ -90,6 +93,9 @@ class ViewVisitTransferApplication extends ViewRecord
                     Textarea::make('staff_note')
                         ->label('Staff Note (required)')
                         ->required(),
+                    Checkbox::make('staff_acknoledgement')
+                        ->label('I have added a note to terminal before rejecting this application.')
+                        ->required(),
                 ])->authorize(fn ($record) => auth()->user()->can('reject', $record)),
 
             Action::make('complete')
@@ -97,7 +103,7 @@ class ViewVisitTransferApplication extends ViewRecord
                 ->color('primary')
                 ->modalHeading(fn ($record) => "Mark Application #{$record->public_id} as Completed")
                 ->modalDescription('This action cannot be undone. This will mark the application as completed.')
-                ->action(fn ($record, array $data) => $record->complete($data['staff_note']))
+                ->action(fn ($record, array $data) => $record->complete($data['staff_note'], auth()->user()))
                 ->schema([
                     Textarea::make('staff_note')
                         ->label('Staff Note (required)')
@@ -109,7 +115,7 @@ class ViewVisitTransferApplication extends ViewRecord
                 ->color('danger')
                 ->modalHeading(fn ($record) => "Cancel Application #{$record->public_id}")
                 ->modalDescription('This action cannot be undone. This will cancel the application.')
-                ->action(fn ($record, array $data) => $record->cancel($data['cancel_reason'], $data['staff_note']))
+                ->action(fn ($record, array $data) => $record->cancel($data['cancel_reason'], $data['staff_note'], auth()->user()))
                 ->schema([
                     Textarea::make('cancel_reason')
                         ->label('Reason for Cancellation (required)')
@@ -195,7 +201,7 @@ class ViewVisitTransferApplication extends ViewRecord
                                     ($application->account?->notes ?? collect())
                                         ->map(function ($note) {
                                             return TextEntry::make("note_{$note->id}")
-                                                ->label("Note by {$note->writer?->full_name} on {$note->created_at->toFormattedDateString()}")
+                                                ->label('Note by '.($note->writer?->full_name ?? 'System').' on '.$note->created_at->toFormattedDateString())
                                                 ->getStateUsing(fn () => $note->content);
                                         })->toArray()
                                 ),

--- a/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/VisitTransferApplicationResource.php
+++ b/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/VisitTransferApplicationResource.php
@@ -6,11 +6,15 @@ use App\Filament\Admin\Resources\VisitTransfer\VisitTransferApplications\Pages\L
 use App\Filament\Admin\Resources\VisitTransfer\VisitTransferApplications\Pages\ViewVisitTransferApplication;
 use App\Models\VisitTransfer\Application;
 use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DatePicker;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\Indicator;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class VisitTransferApplicationResource extends Resource
 {
@@ -41,35 +45,71 @@ class VisitTransferApplicationResource extends Resource
 
         return $table
             ->columns([
-                TextColumn::make('public_id')->label('ID'),
-                TextColumn::make('account_id')->label('Account ID')->searchable(),
-                TextColumn::make('account.name')->label('Full Name')->searchable(['name_first', 'name_last']),
+                TextColumn::make('public_id')->label('Public ID')->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('account_id')->label('CID')->searchable(),
+                TextColumn::make('account.name')->label('Name')->searchable(['name_first', 'name_last']),
                 TextColumn::make('facility.name')->label('Facility Name'),
                 TextColumn::make('status')->label('Status')
                     ->badge()
                     ->formatStateUsing(fn ($state, $record) => $record->status_string)
                     ->color(fn ($record) => $record->status_color),
-                TextColumn::make('created_at')->label('Created At')->dateTime(),
+                TextColumn::make('created_at')->label('Created At')->dateTime()->sortable(),
+                TextColumn::make('updated_at')->label('Updated At')->dateTime()->sortable(),
             ])->defaultSort('created_at', 'desc')
             ->filters([
                 SelectFilter::make('status')
                     ->options([
                         Application::STATUS_IN_PROGRESS => 'In Progress',
-                        Application::STATUS_WITHDRAWN => 'Withdrawn',
-                        Application::STATUS_EXPIRED => 'Expired Automatically',
                         Application::STATUS_SUBMITTED => 'Submitted',
                         Application::STATUS_UNDER_REVIEW => 'Under Review',
                         Application::STATUS_ACCEPTED => 'Accepted',
                         Application::STATUS_COMPLETED => 'Completed',
-                        Application::STATUS_LAPSED => 'Lapsed',
                         Application::STATUS_CANCELLED => 'Cancelled',
                         Application::STATUS_REJECTED => 'Rejected',
                     ])->searchable()->preload()->multiple(),
                 SelectFilter::make('facility_id')
                     ->label('Facility')
-                    ->relationship('facility', 'name')
+                    ->relationship('facility', 'name', function ($query, $livewire) {
+                        $type = $livewire->type;
+
+                        return $query
+                            ->when($type === Application::TYPE_TRANSFER, function ($query) {
+                                $query->where('can_transfer', true);
+                            }
+                            )->when($type === Application::TYPE_VISIT, function ($query) {
+                                $query->where('can_visit', true);
+                            });
+                    })
                     ->searchable()
                     ->preload(),
+
+                Filter::make('updated_at')
+                    ->schema([
+                        DatePicker::make('from')
+                            ->label('Updated from'),
+                        DatePicker::make('until')
+                            ->label('Updated until'),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when($data['from'], fn (Builder $q) => $q->whereDate('updated_at', '>=', $data['from']))
+                            ->when($data['until'], fn (Builder $q) => $q->whereDate('updated_at', '<=', $data['until']));
+                    })
+                    ->indicateUsing(function (array $data): array {
+                        $indicators = [];
+
+                        if ($data['from'] ?? null) {
+                            $indicators[] = Indicator::make('updated from '.date('d/m/Y', strtotime($data['from'])))
+                                ->removeField('from');
+                        }
+
+                        if ($data['until'] ?? null) {
+                            $indicators[] = Indicator::make('updated until '.date('d/m/Y', strtotime($data['until'])))
+                                ->removeField('until');
+                        }
+
+                        return $indicators;
+                    }),
             ])
             ->recordActions([
                 ViewAction::make(),

--- a/tests/Feature/VisitTransfer/Application/ApplicationTableTest.php
+++ b/tests/Feature/VisitTransfer/Application/ApplicationTableTest.php
@@ -49,7 +49,7 @@ class ApplicationTableTest extends BaseAdminTestCase
         $applications = Application::where('type', Application::TYPE_TRANSFER)->get();
 
         foreach ($applications as $application) {
-            $component->assertSee($application->public_id);
+            $component->assertSee($application->cid);
         }
     }
 
@@ -64,7 +64,7 @@ class ApplicationTableTest extends BaseAdminTestCase
         $applications = Application::where('type', Application::TYPE_VISIT)->get();
 
         foreach ($applications as $application) {
-            $component->assertSee($application->public_id);
+            $component->assertSee($application->cid);
         }
     }
 


### PR DESCRIPTION
# Summary of changes

All changed relate to the VT Applications Page
- Update how filters work and what filters are available (including fixing them to work with most recent Laravel version)
- Fix notes so they record the person performing an action
- Hide Withdrawn, Expired and Elapsed applications from the table (these are still accessible by the accounts and application view pages)
- A few other minor style changes