### PR TITLE
fix: update current staff page

### DIFF
--- a/resources/views/site/staff.blade.php
+++ b/resources/views/site/staff.blade.php
@@ -149,6 +149,10 @@
                                 <td>Craig Stewart</td>
                             </tr>
                             <tr>
+                                <td>Training Department Assistant</td>
+                                <td>Alex Anderson</td>
+                            </tr>
+                            <tr>
                                 <td>Division Instructor</td>
                                 <td>Adam Arkley</td>
                             </tr>
@@ -255,10 +259,6 @@
                         <tr>
                             <td>Developer</td>
                             <td>Kristián Kunc</td>
-                        </tr>
-                        <tr>
-                            <td>Developer</td>
-                            <td>Max Brokman</td>
                         </tr>
                         <tr>
                             <td>Developer</td>


### PR DESCRIPTION
# Summary of changes
- Adds Alex Anderson as Training Department Assistant per https://discord.com/channels/705488311346790471/705813598580244532/1487375229360537722
- Removes Max Brokman from Tech following his departure

# Screenshots (if necessary)
