### PR TITLE
Fix missing discord role sync permission

### DIFF
--- a/app/Filament/Admin/Resources/Roles/RoleResource.php
+++ b/app/Filament/Admin/Resources/Roles/RoleResource.php
@@ -58,7 +58,7 @@ class RoleResource extends Resource
             ->recordActions([
                 Action::make('syncDiscord')
                     ->label('Sync Discord')
-                    ->visible(fn () => auth()->user()?->can('syncDiscord'))
+                    ->visible(fn () => auth()->user()?->can('role.sync-discord.*'))
                     ->action(function (Role $record) {
                         // Get all user IDs for this role
                         $userIds = DB::table('mship_account_role')

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -117,6 +117,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'role.edit.*',
             'role.delete.*',
             'role.manage-delegates.*',
+            'role.sync-discord.*',
 
             // Visit Transfer System Permissions
             'vt.access',

--- a/tests/Feature/Admin/Role/RoleResourceTest.php
+++ b/tests/Feature/Admin/Role/RoleResourceTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Feature\Admin\Role;
 
+use App\Filament\Admin\Resources\Roles\Pages\ListRoles;
 use App\Filament\Admin\Resources\Roles\RoleResource;
 use App\Policies\RolePolicy;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
 use Tests\Feature\Admin\BaseAdminResourceTestCase;
 
 class RoleResourceTest extends BaseAdminResourceTestCase
@@ -11,4 +15,28 @@ class RoleResourceTest extends BaseAdminResourceTestCase
     protected static ?string $resourceClass = RoleResource::class;
 
     protected ?string $policy = RolePolicy::class;
+
+    #[Test]
+    public function it_hides_sync_discord_table_action_without_role_sync_discord_permission(): void
+    {
+        $role = Role::create(['name' => 'Role For Sync Discord Visibility', 'guard_name' => 'web']);
+
+        $this->actingAsAdminUser(['role.view.*']);
+
+        Livewire::test(ListRoles::class)
+            ->assertSuccessful()
+            ->assertTableActionHidden('syncDiscord', $role);
+    }
+
+    #[Test]
+    public function it_shows_sync_discord_table_action_with_role_sync_discord_permission(): void
+    {
+        $role = Role::create(['name' => 'Role For Sync Discord Visible', 'guard_name' => 'web']);
+
+        $this->actingAsAdminUser(['role.view.*', 'role.sync-discord.*']);
+
+        Livewire::test(ListRoles::class)
+            ->assertSuccessful()
+            ->assertTableActionVisible('syncDiscord', $role);
+    }
 }


### PR DESCRIPTION
The permission did not exist in the seeder and couldn't be assigned.
