### PR TITLE
feat: Show the 'last mentored' date within the manage mentors screen

### DIFF
--- a/app/Filament/Training/Pages/Mentor/ManageMentors.php
+++ b/app/Filament/Training/Pages/Mentor/ManageMentors.php
@@ -104,8 +104,6 @@ class ManageMentors extends Page implements HasTable
                     ->label('Last Mentored')
                     ->state(fn (Account $record) => app(MentorPermissionService::class)->getLastMentoredDate($record, $this->category)?->format('d/m/Y') ?? 'Never')
                     ->description(fn (string $state) => $state !== 'Never' ? Carbon::createFromFormat('d/m/Y', $state)->diffForHumans() : null),
-
-                // ->color(fn (string $state): string => $state === 'warning' ? 'danger' : 'success'),
             ])
             ->headerActions([
                 Action::make('addMentor')

--- a/app/Filament/Training/Pages/Mentor/ManageMentors.php
+++ b/app/Filament/Training/Pages/Mentor/ManageMentors.php
@@ -9,6 +9,7 @@ use App\Filament\Training\Support\TrainingMemberAccountSearch;
 use App\Models\Mship\Account;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Services\Training\MentorPermissionService;
+use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\CheckboxList;
@@ -99,6 +100,12 @@ class ManageMentors extends Page implements HasTable
                     ->separator(',')
                     ->limitList(7)
                     ->wrap(),
+                TextColumn::make('last_mentored')
+                    ->label('Last Mentored')
+                    ->state(fn (Account $record) => app(MentorPermissionService::class)->getLastMentoredDate($record, $this->category)?->format('d/m/Y') ?? 'Never')
+                    ->description(fn (string $state) => $state !== 'Never' ? Carbon::createFromFormat('d/m/Y', $state)->diffForHumans() : null),
+
+                // ->color(fn (string $state): string => $state === 'warning' ? 'danger' : 'success'),
             ])
             ->headerActions([
                 Action::make('addMentor')

--- a/app/Services/Training/MentorPermissionService.php
+++ b/app/Services/Training/MentorPermissionService.php
@@ -12,8 +12,11 @@ use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
 use App\Models\Training\Mentoring\MentorTrainingPosition;
 use App\Models\Training\TrainingPosition\TrainingPosition;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class MentorPermissionService
@@ -275,5 +278,59 @@ class MentorPermissionService
                 ->where('status', PositionValidationStatusEnum::Mentor->value)
                 ->delete();
         }
+    }
+
+    public function getLastMentoredDate(Account $account, string $category)
+    {
+        $ctsMemberId = DB::connection('cts')
+            ->table('members')
+            ->where('cid', $account->id)
+            ->value('id');
+
+        $callsigns = $this->getAssignedCtsCallsigns($account, $category);
+
+        if (empty($callsigns)) {
+            return null;
+        }
+
+        $lastMentoredDate = DB::connection('cts')
+            ->table('sessions')
+            ->where('mentor_id', $account->id)
+            ->whereIn('position', $callsigns)
+            ->where('taken', 1)
+            ->where('session_done', 1)
+            ->whereNull('cancelled_datetime')
+            ->max('taken_date');
+
+        if (! $lastMentoredDate) {
+            return null;
+        }
+
+        return Carbon::parse($lastMentoredDate);
+    }
+
+    public function getAssignedCtsCallsigns(Account $account, string $category): array
+    {
+        $callsigns = collect();
+
+        $account->mentorTrainingPositions
+            ->filter(fn ($mtp) => $mtp->mentorable && $this->mentorableBelongsToCategory($mtp->mentorable, $category))
+            ->each(function ($mtp) use ($callsigns) {
+                if ($mtp->mentorable instanceof TrainingPosition) {
+                    $ctsPositions = $mtp->mentorable->cts_positions;
+                    if (is_array($ctsPositions)) {
+                        $callsigns->push(...$ctsPositions);
+                    }
+                } elseif ($mtp->mentorable instanceof Qualification) {
+                    $map = self::QUALIFICATION_CTS_POSITION_MAP;
+
+                    if (array_key_exists($mtp->mentorable->code, $map)) {
+                        $mappedCallsigns = Arr::wrap($map[$mtp->mentorable->code]);
+                        $callsigns->push(...$mappedCallsigns);
+                    }
+                }
+            });
+
+        return $callsigns->unique()->filter()->values()->toArray();
     }
 }

--- a/tests/Feature/TrainingPanel/Mentor/ManageMentorsTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ManageMentorsTest.php
@@ -14,6 +14,7 @@ use App\Models\Training\Mentoring\MentorTrainingPosition;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Services\Training\MentorPermissionService;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
@@ -303,6 +304,108 @@ class ManageMentorsTest extends BaseTrainingPanelTestCase
             'member_id' => $mentor->member->id,
             'position_id' => $ctsPosition->id,
         ], 'cts');
+    }
+
+    #[Test]
+    public function it_displays_never_if_the_mentor_has_no_valid_sessions_in_the_category(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+        $category = MentorPermissionService::atcCategories()[0];
+
+        $mentor = Account::factory()->create();
+        Member::factory()->create(['cid' => $mentor->id]);
+
+        $callsign = 'EGLL_GND';
+        $trainingPosition = $this->createTrainingPosition($category, $callsign);
+
+        app(MentorPermissionService::class)->assignToMentorable($mentor, $trainingPosition, $this->panelUser, $category);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ManageMentors::class, ['category' => $category])
+            ->assertTableColumnStateSet('last_mentored', 'Never', record: $mentor);
+    }
+
+    #[Test]
+    public function it_displays_the_correct_last_mentored_date_for_a_mentor(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+        $category = MentorPermissionService::atcCategories()[0];
+
+        $mentor = Account::factory()->create();
+        Member::factory()->create(['cid' => $mentor->id]);
+
+        $callsign = 'EGKK_GND';
+        $trainingPosition = $this->createTrainingPosition($category, $callsign);
+
+        app(MentorPermissionService::class)->assignToMentorable($mentor, $trainingPosition, $this->panelUser, $category);
+
+        $date = now()->subDays(5);
+
+        DB::connection('cts')->table('sessions')->insert([
+            'mentor_id' => $mentor->id,
+            'position' => $callsign,
+            'progress_sheet_id' => 1,
+            'taken' => 1,
+            'session_done' => 1,
+            'cancelled_datetime' => null,
+            'taken_date' => $date->format('Y-m-d H:i:s'),
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ManageMentors::class, ['category' => $category])
+            ->assertTableColumnStateSet('last_mentored', $date->format('d/m/Y'), record: $mentor);
+    }
+
+    #[Test]
+    public function it_ignores_cancelled_or_incomplete_sessions_when_calculating_last_mentored(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+        $category = MentorPermissionService::atcCategories()[0];
+
+        $mentor = Account::factory()->create();
+        Member::factory()->create(['cid' => $mentor->id]);
+
+        $callsign = 'EGKK_GND';
+        $trainingPosition = $this->createTrainingPosition($category, $callsign);
+
+        app(MentorPermissionService::class)->assignToMentorable($mentor, $trainingPosition, $this->panelUser, $category);
+
+        $validDate = now()->subDays(10);
+        $invalidDate = now()->subDays(2);
+
+        DB::connection('cts')->table('sessions')->insert([
+            'mentor_id' => $mentor->id,
+            'position' => $callsign,
+            'progress_sheet_id' => 1,
+            'taken' => 1,
+            'session_done' => 1,
+            'cancelled_datetime' => null,
+            'taken_date' => $validDate->format('Y-m-d H:i:s'),
+        ]);
+
+        DB::connection('cts')->table('sessions')->insert([
+            'mentor_id' => $mentor->id,
+            'position' => $callsign,
+            'progress_sheet_id' => 1,
+            'taken' => 1,
+            'session_done' => 1,
+            'cancelled_datetime' => $invalidDate->format('Y-m-d H:i:s'),
+            'taken_date' => $invalidDate->format('Y-m-d H:i:s'),
+        ]);
+
+        DB::connection('cts')->table('sessions')->insert([
+            'mentor_id' => $mentor->id,
+            'position' => $callsign,
+            'progress_sheet_id' => 1,
+            'taken' => 1,
+            'session_done' => 0,
+            'cancelled_datetime' => null,
+            'taken_date' => $invalidDate->format('Y-m-d H:i:s'),
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ManageMentors::class, ['category' => $category])
+            ->assertTableColumnStateSet('last_mentored', $validDate->format('d/m/Y'), record: $mentor);
     }
 
     private function createTrainingPosition(string $category, string $callsign): TrainingPosition


### PR DESCRIPTION
# Summary of changes
- Shows the date of the latest mentoring session conducted by a mentor in a given category

# Screenshots (if necessary)

<img width="773" height="156" alt="image" src="https://github.com/user-attachments/assets/51d33b25-48c5-4559-b7b7-1f3c6f98709c" />
<img width="764" height="170" alt="image" src="https://github.com/user-attachments/assets/551fd812-7ad3-4c0b-8116-3f4d5ac19b3c" />
