### PR TITLE
chore: add Thijs Schepman to Division Instructor role

### DIFF
--- a/resources/views/site/staff.blade.php
+++ b/resources/views/site/staff.blade.php
@@ -169,6 +169,10 @@
                                 <td>Charlie Watson</td>
                             </tr>
                             <tr>
+                                <td>Division Instructor</td>
+                                <td>Thijs Schepman</td>
+                            </tr>
+                            <tr>
                                 <td>TG Instructor (New Controller)</td>
                                 <td>James Taylor</td>
                             </tr>


### PR DESCRIPTION
# Summary of changes
- adds Thijs Schepman to Division Instructor role per https://discord.com/channels/705488311346790471/1500889261916819649/1500889350500516002

# Screenshots (if necessary)
