### PR TITLE
feat: add a mentoring history page

### DIFF
--- a/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
+++ b/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
@@ -88,7 +88,7 @@ abstract class BaseMentoringHistoryPage extends Page implements HasTable
                     ->visible(fn ($record) => $record->filed !== null)
                     ->openUrlInNewTab(),
             ])
-            ->emptyStateHeading('No mentoring sessions found');
+            ->emptyStateHeading('No mentoring sessions found in this training group');
     }
 
     private function getTableFilters(): array

--- a/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
+++ b/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Filament\Training\Pages\Mentor\Base;
+
+use App\Filament\Training\Support\TrainingMemberAccountSearch;
+use App\Models\Cts\Member;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Pages\Page;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+abstract class BaseMentoringHistoryPage extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    abstract protected function getSessionQuery(): Builder;
+
+    protected function getPositionFilterOptions(): array
+    {
+        return [];
+    }
+
+    protected function showStudentFilter(): bool
+    {
+        return true;
+    }
+
+    protected function showMentorFilter(): bool
+    {
+        return true;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query($this->getSessionQuery())
+            ->defaultSort('taken_date', 'desc')
+            ->striped()
+            ->paginated([10, 25, 50, 100])
+            ->defaultPaginationPageOption(25)
+            ->columns([
+                TextColumn::make('student_name')
+                    ->label('Student')
+                    ->getStateUsing(fn ($record) => $record->student->name)
+                    ->description(fn ($record) => $record->student->cid),
+
+                TextColumn::make('mentor_name')
+                    ->label('Mentor')
+                    ->getStateUsing(fn ($record) => $record->mentor->name)
+                    ->description(fn ($record) => $record->mentor->cid),
+
+                TextColumn::make('position')
+                    ->label('Position')
+                    ->badge()
+                    ->color('gray'),
+
+                TextColumn::make('taken_date')
+                    ->label('Date & Time')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->getStateUsing(fn ($record) => match (true) {
+                        $record->noShow == 1 => 'No Show',
+                        $record->cancelled_datetime !== null => 'Cancelled',
+                        $record->filed !== null => 'Completed',
+                        default => 'Pending',
+                    })
+                    ->color(fn ($state) => match ($state) {
+                        'Pending' => 'primary',
+                        'No Show' => 'danger',
+                        'Cancelled' => 'warning',
+                        'Completed' => 'success',
+                    }),
+            ])
+            ->filters($this->getTableFilters())
+            ->recordActions([
+                ViewAction::make()
+                    ->url(fn ($record) => "https://cts.vatsim.uk/mentors/report.php?id={$record->id}&view=report")
+                    ->visible(fn ($record) => $record->filed !== null)
+                    ->openUrlInNewTab(),
+            ])
+            ->emptyStateHeading('No mentoring sessions found');
+    }
+
+    private function getTableFilters(): array
+    {
+        $filters = [];
+
+        if (! empty($this->getPositionFilterOptions())) {
+            $filters[] = SelectFilter::make('position')
+                ->label('Position')
+                ->options($this->getPositionFilterOptions())
+                ->searchable()
+                ->multiple();
+        }
+
+        if ($this->showStudentFilter()) {
+            $filters[] = SelectFilter::make('student')
+                ->label('Student')
+                ->searchable()
+                ->getSearchResultsUsing(fn (string $search) => TrainingMemberAccountSearch::searchAccountsForSelect($search))
+                ->getOptionLabelUsing(fn ($value) => Member::where('cid', $value)->first()?->name." ({$value})")
+                ->query(fn (Builder $query, array $data): Builder => $query->when(
+                    $data['value'],
+                    fn ($q, $value) => $q->whereHas('student', fn ($q) => $q->where('cid', $value))
+                ));
+        }
+
+        if ($this->showMentorFilter()) {
+            $filters[] = SelectFilter::make('mentor')
+                ->label('Mentor')
+                ->searchable()
+                ->getSearchResultsUsing(fn (string $search) => TrainingMemberAccountSearch::searchAccountsForSelect($search))
+                ->getOptionLabelUsing(fn ($value) => Member::where('cid', $value)->first()?->name." ({$value})")
+                ->query(fn (Builder $query, array $data): Builder => $query->when(
+                    $data['value'],
+                    fn ($q, $value) => $q->whereHas('mentor', fn ($q) => $q->where('cid', $value))
+                ));
+        }
+
+        $filters[] = $this->statusFilter();
+        $filters[] = $this->dateRangeFilter();
+
+        return $filters;
+    }
+
+    private function statusFilter(): SelectFilter
+    {
+        return SelectFilter::make('status')
+            ->label('Status')
+            ->multiple()
+            ->options([
+                'completed' => 'Completed',
+                'cancelled' => 'Cancelled',
+                'no_show' => 'No Show',
+                'pending' => 'Pending',
+            ])
+            ->query(function (Builder $query, array $data): Builder {
+                $values = array_filter($data['values'] ?? []);
+
+                if (empty($values)) {
+                    return $query;
+                }
+
+                return $query->where(function (Builder $q) use ($values): void {
+                    foreach ($values as $value) {
+                        $q->orWhere(function (Builder $inner) use ($value): void {
+                            match ($value) {
+                                'completed' => $inner->whereNotNull('filed'),
+                                'cancelled' => $inner->whereNotNull('cancelled_datetime'),
+                                'no_show' => $inner->where('noShow', 1),
+                                'pending' => $inner->whereNull('filed')
+                                    ->whereNull('cancelled_datetime')
+                                    ->where('noShow', 0),
+                            };
+                        });
+                    }
+                });
+            });
+    }
+
+    private function dateRangeFilter(): Filter
+    {
+        return Filter::make('taken_date')
+            ->form([
+                DatePicker::make('from')->label('From Date'),
+                DatePicker::make('until')->label('To Date'),
+            ])
+            ->query(fn (Builder $query, array $data): Builder => $query
+                ->when($data['from'], fn ($q, $date) => $q->whereDate('taken_date', '>=', $date))
+                ->when($data['until'], fn ($q, $date) => $q->whereDate('taken_date', '<=', $date))
+            );
+    }
+}

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -4,28 +4,16 @@ declare(strict_types=1);
 
 namespace App\Filament\Training\Pages\Mentor;
 
-use App\Filament\Training\Support\TrainingMemberAccountSearch;
-use App\Models\Cts\Member;
+use App\Filament\Training\Pages\Mentor\Base\BaseMentoringHistoryPage;
 use App\Repositories\Cts\SessionRepository;
 use App\Services\Training\MentorPermissionService;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
-use Filament\Actions\ViewAction;
-use Filament\Forms\Components\DatePicker;
-use Filament\Pages\Page;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Concerns\InteractsWithTable;
-use Filament\Tables\Contracts\HasTable;
-use Filament\Tables\Filters\Filter;
-use Filament\Tables\Filters\SelectFilter;
-use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Livewire\Attributes\Url;
 
-class MentoringHistory extends Page implements HasTable
+class MentoringHistory extends BaseMentoringHistoryPage
 {
-    use InteractsWithTable;
-
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
 
     protected string $view = 'filament.training.pages.mentoring-history';
@@ -74,133 +62,18 @@ class MentoringHistory extends Page implements HasTable
         ];
     }
 
-    public function table(Table $table): Table
+    protected function getSessionQuery(): Builder
     {
-        return $table
-            ->heading("{$this->category} Session History")
-            ->queryStringIdentifier('mentoring_history')
-            ->query((new SessionRepository)->getAllAcceptedSessionsForPositionsQuery($this->getVisibleCtsPositions())->where('taken_date', '<', now()))
-            ->defaultSort('taken_date', 'desc')
-            ->striped()
-            ->paginated([10, 25, 50, 100])
-            ->defaultPaginationPageOption(25)
-            ->columns([
-                TextColumn::make('student_name')
-                    ->label('Student')
-                    ->getStateUsing(fn ($record) => $record->student->name)
-                    ->description(fn ($record) => $record->student->cid),
+        return (new SessionRepository)
+            ->getAllAcceptedSessionsForPositionsQuery($this->getVisibleCtsPositions())
+            ->where('taken_date', '<', now());
+    }
 
-                TextColumn::make('mentor_name')
-                    ->label('Mentor')
-                    ->getStateUsing(fn ($record) => $record->mentor->name)
-                    ->description(fn ($record) => $record->mentor->cid),
+    protected function getPositionFilterOptions(): array
+    {
+        $positions = $this->getVisibleCtsPositions();
 
-                TextColumn::make('position')
-                    ->label('Position')
-                    ->badge()
-                    ->color('gray'),
-
-                TextColumn::make('taken_date')
-                    ->label('Date & Time')
-                    ->dateTime('d/m/Y H:i')
-                    ->sortable(),
-
-                TextColumn::make('status')
-                    ->label('Status')
-                    ->badge()
-                    ->getStateUsing(fn ($record) => match (true) {
-                        $record->noShow == 1 => 'No Show',
-                        $record->cancelled_datetime != null => 'Cancelled',
-                        $record->filed != null => 'Completed',
-                        default => 'Pending',
-                    })
-                    ->color(fn ($state) => match ($state) {
-                        'Pending' => 'primary',
-                        'No Show' => 'danger',
-                        'Cancelled' => 'warning',
-                        'Completed' => 'success',
-                    })
-                    ->wrap(),
-            ])
-            ->filters([
-                SelectFilter::make('position')
-                    ->label('Position')
-                    ->options(function () {
-                        $positions = $this->getVisibleCtsPositions();
-
-                        return array_combine($positions, $positions);
-                    })
-                    ->searchable()
-                    ->multiple(),
-
-                SelectFilter::make('student')
-                    ->label('Student')
-                    ->searchable()
-                    ->getSearchResultsUsing(fn (string $search) => TrainingMemberAccountSearch::searchAccountsForSelect($search))
-                    ->getOptionLabelUsing(fn ($value) => Member::where('cid', $value)->first()?->name." ({$value})")
-                    ->query(function (Builder $query, array $data): Builder {
-                        return $query->when(
-                            $data['value'],
-                            fn (Builder $query, $value) => $query->whereHas('student', fn ($q) => $q->where('cid', $value))
-                        );
-                    }),
-
-                SelectFilter::make('mentor')
-                    ->label('Mentor')
-                    ->searchable()
-                    ->getSearchResultsUsing(fn (string $search) => TrainingMemberAccountSearch::searchAccountsForSelect($search))
-                    ->getOptionLabelUsing(fn ($value) => Member::where('cid', $value)->first()?->name." ({$value})")
-                    ->query(function (Builder $query, array $data): Builder {
-                        return $query->when(
-                            $data['value'],
-                            fn (Builder $query, $value) => $query->whereHas('mentor', fn ($q) => $q->where('cid', $value))
-                        );
-                    }),
-
-                SelectFilter::make('status')
-                    ->label('Status')
-                    ->options([
-                        'completed' => 'Completed',
-                        'cancelled' => 'Cancelled',
-                        'no_show' => 'No Show',
-                        'pending' => 'Pending',
-                    ])
-                    ->query(function (Builder $query, array $data) {
-                        return match ($data['value']) {
-                            'completed' => $query->whereNotNull('filed'),
-                            'cancelled' => $query->whereNotNull('cancelled_datetime'),
-                            'no_show' => $query->where('noShow', 1),
-                            'pending' => $query->whereNull('filed')
-                                ->whereNull('cancelled_datetime')
-                                ->where('noShow', 0),
-                            default => $query,
-                        };
-                    }),
-
-                Filter::make('taken_date')
-                    ->form([
-                        DatePicker::make('from')->label('From Date'),
-                        DatePicker::make('until')->label('To Date'),
-                    ])
-                    ->query(function (Builder $query, array $data): Builder {
-                        return $query
-                            ->when(
-                                $data['from'],
-                                fn (Builder $query, $date): Builder => $query->whereDate('taken_date', '>=', $date),
-                            )
-                            ->when(
-                                $data['until'],
-                                fn (Builder $query, $date): Builder => $query->whereDate('taken_date', '<=', $date),
-                            );
-                    }),
-            ])
-            ->recordActions([
-                ViewAction::make()
-                    ->url(fn ($record) => "https://cts.vatsim.uk/mentors/report.php?id={$record->id}&view=report")
-                    ->visible(fn ($record) => $record->filed != null)
-                    ->openUrlInNewTab(),
-            ])
-            ->emptyStateHeading('No mentoring sessions found in this group');
+        return array_combine($positions, $positions);
     }
 
     private function getVisibleCtsPositions(): array

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -15,6 +15,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Livewire\Attributes\Url;
@@ -78,34 +79,33 @@ class MentoringHistory extends Page implements HasTable
             ->queryStringIdentifier('mentoring_history')
             ->query((new SessionRepository)->getAllAcceptedSessionsForPositionsQuery($this->getVisibleCtsPositions()))
             ->defaultSort('taken_date', 'desc')
+            ->striped()
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(25)
             ->columns([
-                TextColumn::make('student.cid')
-                    ->label('Student CID')
+                TextColumn::make('student_name')
+                    ->label('Student')
+                    ->getStateUsing(fn ($record) => $record->student->name)
+                    ->description(fn ($record) => $record->student->cid)
                     ->searchable(),
 
-                TextColumn::make('student.name')
-                    ->label('Student Name')
+                TextColumn::make('mentor_name')
+                    ->label('Mentor')
+                    ->getStateUsing(fn ($record) => $record->mentor?->name ?? 'Unknown')
+                    ->description(fn ($record) => $record->mentor?->cid ?? 'Unknown')
                     ->searchable(),
 
                 TextColumn::make('position')
                     ->label('Position')
+                    ->badge()
+                    ->color('gray')
                     ->searchable()
                     ->sortable(),
 
                 TextColumn::make('taken_date')
-                    ->label('Date')
-                    ->date('d/m/Y H:i')
+                    ->label('Date & Time')
+                    ->dateTime('d/m/Y H:i')
                     ->sortable(),
-
-                TextColumn::make('mentor.cid')
-                    ->label('Mentor CID')
-                    ->searchable(),
-
-                TextColumn::make('mentor.name')
-                    ->label('Mentor')
-                    ->searchable(),
 
                 TextColumn::make('status')
                     ->label('Status')
@@ -125,6 +125,36 @@ class MentoringHistory extends Page implements HasTable
                     ->wrap(),
             ])
             ->filters([
+                SelectFilter::make('position')
+                    ->label('Position')
+                    ->options(function () {
+                        $positions = $this->getVisibleCtsPositions();
+
+                        return array_combine($positions, $positions);
+                    })
+                    ->searchable()
+                    ->multiple(),
+
+                SelectFilter::make('status')
+                    ->label('Status')
+                    ->options([
+                        'completed' => 'Completed',
+                        'cancelled' => 'Cancelled',
+                        'no_show' => 'No Show',
+                        'pending' => 'Pending',
+                    ])
+                    ->query(function (Builder $query, array $data) {
+                        return match ($data['value']) {
+                            'completed' => $query->whereNotNull('filed'),
+                            'cancelled' => $query->whereNotNull('cancelled_datetime'),
+                            'no_show' => $query->where('noShow', 1),
+                            'pending' => $query->whereNull('filed')
+                                ->whereNull('cancelled_datetime')
+                                ->where('noShow', 0),
+                            default => $query,
+                        };
+                    }),
+
                 Filter::make('taken_date')
                     ->form([
                         DatePicker::make('from')->label('From Date'),
@@ -158,7 +188,6 @@ class MentoringHistory extends Page implements HasTable
 
     private function canViewCategory(string $category): bool
     {
-        // Mentors should be allowed to view any category they hold at least one mentoring permission in
         $assignedCallsigns = app(MentorPermissionService::class)->getAssignedCtsCallsigns(auth()->user(), $category);
 
         return count($assignedCallsigns) > 0;

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Pages\Mentor;
+
+use App\Repositories\Cts\SessionRepository;
+use App\Services\Training\MentorPermissionService;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Pages\Page;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Attributes\Url;
+
+class MentoringHistory extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected string $view = 'filament.training.pages.mentoring-history';
+
+    protected static ?int $navigationSort = 30;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Mentoring';
+
+    protected static ?string $title = 'Mentoring History';
+
+    #[Url]
+    public string $category = '';
+
+    public static function canAccess(): bool
+    {
+        // If a user has any mentoring permissions they are allowed to view this page
+        return auth()->user()->mentorTrainingPositions()->exists();
+    }
+
+    public function mount(): void
+    {
+        if (empty($this->category) || ! $this->canViewCategory($this->category)) {
+            $this->category = $this->firstVisibleCategory() ?? '';
+        }
+    }
+
+    protected function getHeaderActions(): array
+    {
+        $allCategories = collect(MentorPermissionService::atcCategories())->merge(MentorPermissionService::pilotCategories());
+
+        return [
+            ActionGroup::make(
+                $allCategories
+                    ->filter(fn (string $cat) => $this->canViewCategory($cat))
+                    ->map(fn (string $cat) => Action::make('cat_'.str($cat)->slug('_'))
+                        ->label($cat)
+                        ->url(static::getUrl(['category' => $cat]))
+                        ->icon($this->category === $cat ? 'heroicon-m-check' : null)
+                    )
+                    ->all()
+            )
+                ->label("Training Group: {$this->category}")
+                ->icon('heroicon-m-chevron-down')
+                ->color('gray')
+                ->button(),
+        ];
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->heading("{$this->category} Session History")
+            ->queryStringIdentifier('mentoring_history')
+            ->query((new SessionRepository)->getAllAcceptedSessionsForPositionsQuery($this->getVisibleCtsPositions()))
+            ->defaultSort('taken_date', 'desc')
+            ->paginated([10, 25, 50, 100])
+            ->defaultPaginationPageOption(25)
+            ->columns([
+                TextColumn::make('student.cid')
+                    ->label('Student CID')
+                    ->searchable(),
+
+                TextColumn::make('student.name')
+                    ->label('Student Name')
+                    ->searchable(),
+
+                TextColumn::make('position')
+                    ->label('Position')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('taken_date')
+                    ->label('Date')
+                    ->date('d/m/Y H:i')
+                    ->sortable(),
+
+                TextColumn::make('mentor.cid')
+                    ->label('Mentor CID')
+                    ->searchable(),
+
+                TextColumn::make('mentor.name')
+                    ->label('Mentor')
+                    ->searchable(),
+
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->getStateUsing(fn ($record) => match (true) {
+                        $record->noShow == 1 => 'No Show',
+                        $record->cancelled_datetime != null => 'Cancelled',
+                        $record->filed != null => 'Completed',
+                        default => 'Pending',
+                    })
+                    ->color(fn ($state) => match ($state) {
+                        'Pending' => 'primary',
+                        'No Show' => 'danger',
+                        'Cancelled' => 'warning',
+                        'Completed' => 'success',
+                    })
+                    ->wrap(),
+            ])
+            ->filters([
+                Filter::make('taken_date')
+                    ->form([
+                        DatePicker::make('from')->label('From Date'),
+                        DatePicker::make('until')->label('To Date'),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when(
+                                $data['from'],
+                                fn (Builder $query, $date): Builder => $query->whereDate('taken_date', '>=', $date),
+                            )
+                            ->when(
+                                $data['until'],
+                                fn (Builder $query, $date): Builder => $query->whereDate('taken_date', '<=', $date),
+                            );
+                    }),
+            ])
+            ->recordActions([
+                ViewAction::make()
+                    ->url(fn ($record) => "https://cts.vatsim.uk/mentors/report.php?id={$record->id}&view=report")
+                    ->visible(fn ($record) => $record->filed != null)
+                    ->openUrlInNewTab(),
+            ])
+            ->emptyStateHeading('No mentoring sessions found in this group');
+    }
+
+    private function getVisibleCtsPositions(): array
+    {
+        return app(MentorPermissionService::class)->getAssignedCtsCallsigns(auth()->user(), $this->category);
+    }
+
+    private function canViewCategory(string $category): bool
+    {
+        // Mentors should be allowed to view any category they hold at least one mentoring permission in
+        $assignedCallsigns = app(MentorPermissionService::class)->getAssignedCtsCallsigns(auth()->user(), $category);
+
+        return count($assignedCallsigns) > 0;
+    }
+
+    private function firstVisibleCategory(): ?string
+    {
+        return collect(MentorPermissionService::atcCategories())->merge(MentorPermissionService::pilotCategories())->first(fn (string $cat) => $this->canViewCategory($cat));
+    }
+}

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -79,7 +79,7 @@ class MentoringHistory extends Page implements HasTable
         return $table
             ->heading("{$this->category} Session History")
             ->queryStringIdentifier('mentoring_history')
-            ->query((new SessionRepository)->getAllAcceptedSessionsForPositionsQuery($this->getVisibleCtsPositions()))
+            ->query((new SessionRepository)->getAllAcceptedSessionsForPositionsQuery($this->getVisibleCtsPositions())->where('taken_date', '<', now()))
             ->defaultSort('taken_date', 'desc')
             ->striped()
             ->paginated([10, 25, 50, 100])

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Filament\Training\Pages\Mentor;
 
+use App\Filament\Training\Support\TrainingMemberAccountSearch;
+use App\Models\Cts\Member;
 use App\Repositories\Cts\SessionRepository;
 use App\Services\Training\MentorPermissionService;
 use Filament\Actions\Action;
@@ -86,21 +88,17 @@ class MentoringHistory extends Page implements HasTable
                 TextColumn::make('student_name')
                     ->label('Student')
                     ->getStateUsing(fn ($record) => $record->student->name)
-                    ->description(fn ($record) => $record->student->cid)
-                    ->searchable(),
+                    ->description(fn ($record) => $record->student->cid),
 
                 TextColumn::make('mentor_name')
                     ->label('Mentor')
-                    ->getStateUsing(fn ($record) => $record->mentor?->name ?? 'Unknown')
-                    ->description(fn ($record) => $record->mentor?->cid ?? 'Unknown')
-                    ->searchable(),
+                    ->getStateUsing(fn ($record) => $record->mentor->name)
+                    ->description(fn ($record) => $record->mentor->cid),
 
                 TextColumn::make('position')
                     ->label('Position')
                     ->badge()
-                    ->color('gray')
-                    ->searchable()
-                    ->sortable(),
+                    ->color('gray'),
 
                 TextColumn::make('taken_date')
                     ->label('Date & Time')
@@ -134,6 +132,30 @@ class MentoringHistory extends Page implements HasTable
                     })
                     ->searchable()
                     ->multiple(),
+
+                SelectFilter::make('student')
+                    ->label('Student')
+                    ->searchable()
+                    ->getSearchResultsUsing(fn (string $search) => TrainingMemberAccountSearch::searchAccountsForSelect($search))
+                    ->getOptionLabelUsing(fn ($value) => Member::where('cid', $value)->first()?->name." ({$value})")
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query->when(
+                            $data['value'],
+                            fn (Builder $query, $value) => $query->whereHas('student', fn ($q) => $q->where('cid', $value))
+                        );
+                    }),
+
+                SelectFilter::make('mentor')
+                    ->label('Mentor')
+                    ->searchable()
+                    ->getSearchResultsUsing(fn (string $search) => TrainingMemberAccountSearch::searchAccountsForSelect($search))
+                    ->getOptionLabelUsing(fn ($value) => Member::where('cid', $value)->first()?->name." ({$value})")
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query->when(
+                            $data['value'],
+                            fn (Builder $query, $value) => $query->whereHas('mentor', fn ($q) => $q->where('cid', $value))
+                        );
+                    }),
 
                 SelectFilter::make('status')
                     ->label('Status')

--- a/app/Repositories/Cts/SessionRepository.php
+++ b/app/Repositories/Cts/SessionRepository.php
@@ -17,11 +17,13 @@ class SessionRepository
 
     }
 
-    public function getAllAcceptedSessionsForPositionsQuery(array $positionCallsigns, int $studentId)
+    public function getAllAcceptedSessionsForPositionsQuery(array $positionCallsigns, ?int $studentId = null)
     {
         return Session::query()
             ->with(['student', 'mentor'])
-            ->where('student_id', $studentId)
+            ->when($studentId, function ($query, $studentId) {
+                return $query->where('student_id', $studentId);
+            })
             ->whereIn('position', $positionCallsigns)
             ->where('taken', 1);
     }

--- a/resources/views/filament/training/pages/mentoring-history.blade.php
+++ b/resources/views/filament/training/pages/mentoring-history.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/tests/Feature/TrainingPanel/Mentor/MentoringHistoryTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringHistoryTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\Mentor;
+
+use App\Filament\Training\Pages\Mentor\MentoringHistory;
+use App\Models\Cts\Member;
+use App\Models\Cts\Position as CtsPosition;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\MentorPermissionService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class MentoringHistoryTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_loads_when_user_has_at_least_one_mentoring_position(): void
+    {
+        $category = MentorPermissionService::atcCategories()[0];
+        $trainingPosition = $this->createTrainingPosition($category, 'EGLL_GND');
+
+        app(MentorPermissionService::class)->assignToMentorable($this->panelUser, $trainingPosition, $this->panelUser, $category);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(MentoringHistory::class)
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_is_forbidden_when_user_has_no_mentoring_positions(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(MentoringHistory::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_defaults_to_the_first_visible_category_when_category_is_empty(): void
+    {
+        $category = MentorPermissionService::atcCategories()[0];
+        $trainingPosition = $this->createTrainingPosition($category, 'EGLL_GND');
+
+        app(MentorPermissionService::class)->assignToMentorable($this->panelUser, $trainingPosition, $this->panelUser, $category);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(MentoringHistory::class)
+            ->assertSet('category', $category);
+    }
+
+    #[Test]
+    public function it_defaults_to_the_first_visible_category_when_category_is_invalid(): void
+    {
+        $category = MentorPermissionService::atcCategories()[0];
+        $trainingPosition = $this->createTrainingPosition($category, 'EGLL_GND');
+
+        app(MentorPermissionService::class)->assignToMentorable($this->panelUser, $trainingPosition, $this->panelUser, $category);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(MentoringHistory::class, ['category' => 'Not A Real Category'])
+            ->assertSet('category', $category);
+    }
+
+    #[Test]
+    public function it_shows_sessions_for_the_selected_atc_category_only(): void
+    {
+        $categoryOne = MentorPermissionService::atcCategories()[0];
+        $categoryTwo = MentorPermissionService::atcCategories()[1];
+
+        $positionOne = $this->createTrainingPosition($categoryOne, 'EGKK_GND');
+        $positionTwo = $this->createTrainingPosition($categoryTwo, 'EGKK_TWR');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+
+        app(MentorPermissionService::class)->assignToMentorable($this->panelUser, $positionOne, $this->panelUser, $categoryOne);
+        app(MentorPermissionService::class)->assignToMentorable($this->panelUser, $positionTwo, $this->panelUser, $categoryTwo);
+
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionInCategory = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGKK_GND');
+        $sessionOutOfCategory = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGKK_TWR');
+
+        $sessionInRecord = Session::on('cts')->find($sessionInCategory);
+        $sessionOutRecord = Session::on('cts')->find($sessionOutOfCategory);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(MentoringHistory::class, ['category' => $categoryOne])
+            ->assertCanSeeTableRecords([$sessionInRecord])
+            ->assertCanNotSeeTableRecords([$sessionOutRecord]);
+    }
+
+    #[Test]
+    public function it_shows_view_action_only_for_filed_sessions(): void
+    {
+        $category = MentorPermissionService::atcCategories()[0];
+        $trainingPosition = $this->createTrainingPosition($category, 'EGNM_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        app(MentorPermissionService::class)->assignToMentorable($this->panelUser, $trainingPosition, $this->panelUser, $category);
+
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $filedId = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGNM_GND', filed: now()->toDateTimeString());
+        $unfiledId = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGNM_GND', filed: null);
+
+        $filedSession = Session::on('cts')->find($filedId);
+        $unfiledSession = Session::on('cts')->find($unfiledId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(MentoringHistory::class, ['category' => $category])
+            ->assertTableActionVisible('view', $filedSession)
+            ->assertTableActionHidden('view', $unfiledSession);
+    }
+
+    #[Test]
+    public function it_displays_the_correct_status_badge_for_completed_sessions(): void
+    {
+        $category = MentorPermissionService::atcCategories()[0];
+        $trainingPosition = $this->createTrainingPosition($category, 'EGNT_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        app(MentorPermissionService::class)->assignToMentorable($this->panelUser, $trainingPosition, $this->panelUser, $category);
+
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGNT_GND', filed: now()->toDateTimeString());
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(MentoringHistory::class, ['category' => $category])
+            ->assertTableColumnStateSet('status', 'Completed', record: $session);
+    }
+
+    #[Test]
+    public function it_displays_the_correct_status_badge_for_no_show_sessions(): void
+    {
+        $category = MentorPermissionService::atcCategories()[0];
+        $trainingPosition = $this->createTrainingPosition($category, 'EGNS_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        app(MentorPermissionService::class)->assignToMentorable($this->panelUser, $trainingPosition, $this->panelUser, $category);
+
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGNS_GND', noShow: 1, filed: null);
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(MentoringHistory::class, ['category' => $category])
+            ->assertTableColumnStateSet('status', 'No Show', record: $session);
+    }
+
+    #[Test]
+    public function it_displays_an_empty_state_when_no_sessions_exist_for_the_category(): void
+    {
+        $category = MentorPermissionService::atcCategories()[0];
+        $trainingPosition = $this->createTrainingPosition($category, 'EGPO_GND');
+
+        app(MentorPermissionService::class)->assignToMentorable($this->panelUser, $trainingPosition, $this->panelUser, $category);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(MentoringHistory::class, ['category' => $category])
+            ->assertSee('No mentoring sessions found in this group');
+    }
+
+    private function createTrainingPosition(string $category, string $callsign): TrainingPosition
+    {
+        CtsPosition::firstOrCreate(['callsign' => $callsign]);
+
+        return TrainingPosition::factory()->create([
+            'category' => $category,
+            'cts_positions' => [$callsign],
+        ]);
+    }
+
+    private function insertSession(
+        int $mentorId,
+        int $studentId,
+        string $position,
+        int $taken = 1,
+        int $noShow = 0,
+        ?string $filed = null,
+        ?string $cancelledDatetime = null,
+        ?string $takenDate = null,
+    ): int {
+        return DB::connection('cts')->table('sessions')->insertGetId([
+            'mentor_id' => $mentorId,
+            'student_id' => $studentId,
+            'position' => $position,
+            'progress_sheet_id' => 1,
+            'taken' => $taken,
+            'session_done' => $filed !== null ? 1 : 0,
+            'noShow' => $noShow,
+            'filed' => $filed,
+            'cancelled_datetime' => $cancelledDatetime,
+            'taken_date' => $takenDate ?? now()->format('Y-m-d H:i:s'),
+        ]);
+    }
+
+    private function getOrCreateCtsMember(Account $account): Member
+    {
+        return Member::on('cts')->firstOrCreate(
+            ['cid' => $account->id],
+            [
+                'id' => $account->id,
+                'old_rts_id' => 0,
+                'name' => $account->name,
+                'joined' => now(),
+                'joined_div' => now(),
+            ]
+        );
+    }
+}

--- a/tests/Feature/TrainingPanel/Mentor/MentoringHistoryTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringHistoryTest.php
@@ -171,7 +171,7 @@ class MentoringHistoryTest extends BaseTrainingPanelTestCase
 
         Livewire::actingAs($this->panelUser)
             ->test(MentoringHistory::class, ['category' => $category])
-            ->assertSee('No mentoring sessions found in this group');
+            ->assertSee('No mentoring sessions found in this training group');
     }
 
     private function createTrainingPosition(string $category, string $callsign): TrainingPosition


### PR DESCRIPTION
# Summary of changes
- Adds a mentoring history page
- You can view the page if you hold ANY mentoring permissions
- You can view TGs you hold ANY mentoring permission within
- You can only see sessions that you hold permission to mentor

# Screenshots (if necessary)
<img width="1390" height="870" alt="image" src="https://github.com/user-attachments/assets/3446452d-100b-43c0-908b-6a22afd97b0b" />
<img width="393" height="262" alt="image" src="https://github.com/user-attachments/assets/0b79b075-941f-48ec-ba38-a6527d25fb23" />
<img width="373" height="161" alt="image" src="https://github.com/user-attachments/assets/20606192-c894-473d-949b-50e7d973fa20" />
<img width="394" height="765" alt="image" src="https://github.com/user-attachments/assets/36b8032d-18df-473d-8f3b-311fae5a4910" />

Any feedback on the looks / styling of the page is greatly appreciated