### PR TITLE
Decrease discord lock TTL

### DIFF
--- a/app/Jobs/Mship/SyncToDiscord.php
+++ b/app/Jobs/Mship/SyncToDiscord.php
@@ -40,6 +40,10 @@ class SyncToDiscord extends Job implements ShouldQueue
 
     public function middleware(): array
     {
-        return [new RateLimitedWithRedis('discord-sync'), new WithoutOverlapping($this->getAccountId())];
+        return [
+            new RateLimitedWithRedis('discord-sync'),
+            // free lock after 90 seconds
+            new WithoutOverlapping($this->getAccountId(), null, 90),
+        ];
     }
 }


### PR DESCRIPTION
From zero to 90 seconds maximum TTL