### PR TITLE
fix: rename sync button to be more descriptive

### DIFF
--- a/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
+++ b/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
@@ -43,6 +43,7 @@ class ViewAccount extends BaseViewRecordPage
             Action::make('request_central_update')
                 ->color('gray')
                 ->icon('heroicon-o-cloud-arrow-down')
+                ->label('Sync Member')
                 ->action(function ($action) {
                     UpdateMember::dispatch($this->record->id);
                     $action->success();


### PR DESCRIPTION
# Summary of changes
- The sync button on the member page now does more than just requesting a central update, updated the member facing label accordingly

# Screenshots (if necessary)
<img width="190" height="71" alt="image" src="https://github.com/user-attachments/assets/0ddf6726-d123-4c1b-b629-18bb45d41bd0" />
