### PR TITLE
fix: Only show PositionGroup endorsements and better display wildcard permission on dashboard widget

### DIFF
--- a/app/Filament/Widgets/AccountInfoWidget.php
+++ b/app/Filament/Widgets/AccountInfoWidget.php
@@ -72,6 +72,14 @@ class AccountInfoWidget extends Widget
                 $level = Str::upper(Str::after($perm->name, 'training.exams.conduct.'));
                 $atcLevels = ['OBS', 'TWR', 'APP', 'CTR'];
 
+                if ($level === '*') {
+                    return [
+                        'level' => '*',
+                        'label' => 'All Positions',
+                        'type' => 'all',
+                    ];
+                }
+
                 return [
                     'level' => $level,
                     'label' => array_key_exists($level, $atcMap) ? $atcMap[$level] : $pilotMap[$level] ?? $level,
@@ -92,6 +100,9 @@ class AccountInfoWidget extends Widget
         ])->filter()->values();
 
         $endorsements = $user->endorsements
+            ->filter(function ($endorsement) {
+                return $endorsement->endorsable_type === 'App\Models\Atc\PositionGroup';
+            })
             ->map(fn ($e) => $e->endorsable->name)
             ->filter()
             ->values();

--- a/resources/views/filament/widgets/account-info-widget.blade.php
+++ b/resources/views/filament/widgets/account-info-widget.blade.php
@@ -87,9 +87,14 @@
                             @foreach ($examinerGroups as $group)
                                 <span class="
                                     px-2.5 py-1 text-xs rounded-md shadow-sm
-                                    {{ $group['type'] === 'atc'
+                                    {{  $group['type'] === 'all'
+                                        ? 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-200'
+                                         : (
+                                    
+                                    $group['type'] === 'atc'
                                         ? 'bg-rose-100 text-rose-700 dark:bg-rose-900 dark:text-rose-200'
                                         : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-200'
+                                        )
                                     }}
                                     ">
                                     {{ $group['label'] }}


### PR DESCRIPTION
# Summary of changes

per title

# Screenshots
<img width="1266" height="587" alt="image" src="https://github.com/user-attachments/assets/3384136b-4588-4a03-a263-4b8c06317c2a" />

<img width="1469" height="24" alt="image" src="https://github.com/user-attachments/assets/a16abd5c-e629-4a1c-9774-bc809aa0650d" />
