### PR TITLE
fix: show datetime correctly on mentoring history page

### DIFF
--- a/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
+++ b/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
@@ -4,6 +4,7 @@ namespace App\Filament\Training\Pages\Mentor\Base;
 
 use App\Filament\Training\Support\TrainingMemberAccountSearch;
 use App\Models\Cts\Member;
+use Carbon\Carbon;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Pages\Page;
@@ -62,8 +63,16 @@ abstract class BaseMentoringHistoryPage extends Page implements HasTable
 
                 TextColumn::make('taken_date')
                     ->label('Date & Time')
-                    ->dateTime('d/m/Y H:i')
-                    ->sortable(),
+                    ->getStateUsing(function ($record) {
+                        $date = Carbon::parse($record->taken_date)->format('d/m/Y');
+                        $time = Carbon::parse($record->taken_from)->format('H:i');
+
+                        return trim("{$date} {$time}");
+                    })
+                    ->sortable(query: fn (Builder $query, string $direction) => $query
+                        ->orderBy('taken_date', $direction)
+                        ->orderBy('taken_from', $direction)
+                    ),
 
                 TextColumn::make('status')
                     ->label('Status')


### PR DESCRIPTION
# Summary of changes
- Fixes error where time would not show on mentoring history page

# Screenshots (if necessary)
<img width="783" height="321" alt="image" src="https://github.com/user-attachments/assets/eb4e98a2-65b2-4796-8441-154f4aacfb55" />
