### PR TITLE
fix: allow rich editor text boxes to expand vertically

### DIFF
--- a/app/Filament/Training/Pages/Exam/ConductExam.php
+++ b/app/Filament/Training/Pages/Exam/ConductExam.php
@@ -184,7 +184,7 @@ class ConductExam extends Page implements HasForms, HasInfolists
                             ->disableToolbarButtons(['attachFiles', 'blockquote'])
                             ->live(debounce: 500)
                             ->extraInputAttributes([
-                                'style' => 'height: 200px;',
+                                'style' => 'min-height: 200px;',
                             ])
                             ->afterStateUpdated(fn () => $this->markDirty()),
                         Select::make("form.{$criteria->id}.grade")
@@ -219,7 +219,7 @@ class ConductExam extends Page implements HasForms, HasInfolists
                     ->live(debounce: 1000)
                     // save additional comments in session to persist in session in case navigation occurs
                     ->extraInputAttributes([
-                        'style' => 'height: 200px;',
+                        'style' => 'min-height: 200px;',
                     ])
                     ->afterStateHydrated(fn ($component) => $component->state(
                         $this->richEditorHtmlForHydration($this->additionalComments)


### PR DESCRIPTION
# Summary of changes
- Stops vertical text overflow

# Screenshots (if necessary)
Before:
<img width="948" height="653" alt="image" src="https://github.com/user-attachments/assets/432a7fd6-5b81-4654-b9fb-854beac031c2" />

After:
<img width="923" height="603" alt="image" src="https://github.com/user-attachments/assets/6d7a27c7-16bc-4cb2-8b25-0b1f1e8a41cd" />
