### PR TITLE
fix: ensure roster status is aligned on mobile displays

### DIFF
--- a/resources/views/filament/widgets/account-info-widget.blade.php
+++ b/resources/views/filament/widgets/account-info-widget.blade.php
@@ -1,21 +1,20 @@
 <x-filament-widgets::widget>
     <x-filament::section>
         <div class="relative">
-
-            {{-- Active / Inactive badge --}}
-            <span class="px-4 py-1.5 text-xs font-semibold rounded-full absolute sm:right-6 sm:top-1 top-10 right-3
-                {{ $rosterStatus
-                    ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200'
-                    : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200'
-                }}" title="Roster Status">
-                {{ $rosterStatus ? 'Active' : 'Inactive' }}
-            </span>
-
             {{-- Header --}}
-            <div class="flex flex-col">
+            <div class="flex items-center justify-between gap-4">
                 <h2 class="text-xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
-                    Welcome back, {{ $user->name }}
+                        Welcome back, {{ $user->name }}
                 </h2>
+
+                {{-- Active / Inactive badge --}}
+                <span class="shrink-0 px-4 py-1.5 text-xs font-semibold rounded-full
+                    {{ $rosterStatus
+                        ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200'
+                        : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200'
+                    }}" title="Roster Status">
+                    {{ $rosterStatus ? 'Active' : 'Inactive' }}
+                </span>
             </div>
 
             <div class="space-y-3 mt-5">


### PR DESCRIPTION
# Summary of changes
- Align inactive + active

# Screenshots (if necessary)
Before:
<img width="478" height="150" alt="image" src="https://github.com/user-attachments/assets/55917b96-1486-4759-8b3e-7199b8d89eeb" />

After:
<img width="477" height="219" alt="image" src="https://github.com/user-attachments/assets/fdf11e34-11a4-4a90-b1a3-a5272407ccc1" />
