### PR TITLE
feat: Allow clicking on student or mentor name to filter the mentoring history table

### DIFF
--- a/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
+++ b/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
@@ -49,12 +49,28 @@ abstract class BaseMentoringHistoryPage extends Page implements HasTable
                 TextColumn::make('student_name')
                     ->label('Student')
                     ->getStateUsing(fn ($record) => $record->student->name)
-                    ->description(fn ($record) => $record->student->cid),
+                    ->description(fn ($record) => $record->student->cid)
+                    ->action(function ($record, $livewire) {
+                        if (! $this->showStudentFilter()) {
+                            return;
+                        }
+
+                        $livewire->tableFilters['student']['value'] = $record->student->cid;
+                        $livewire->updatedTableFilters();
+                    }),
 
                 TextColumn::make('mentor_name')
                     ->label('Mentor')
                     ->getStateUsing(fn ($record) => $record->mentor->name)
-                    ->description(fn ($record) => $record->mentor->cid),
+                    ->description(fn ($record) => $record->mentor->cid)
+                    ->action(function ($record, $livewire) {
+                        if (! $this->showMentorFilter()) {
+                            return;
+                        }
+
+                        $livewire->tableFilters['mentor']['value'] = $record->mentor->cid;
+                        $livewire->updatedTableFilters();
+                    }),
 
                 TextColumn::make('position')
                     ->label('Position')


### PR DESCRIPTION
# Summary of changes
- Clicking on the student or mentor name will now automatically filter the table by that account

# Screenshots (if necessary)

https://github.com/user-attachments/assets/bdaf4349-8979-4926-b8cf-1b160a12bff3
