### PR TITLE
Allow examiners to cancel a pending exam

### DIFF
--- a/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
+++ b/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
@@ -97,7 +97,7 @@ class MyPendingExams extends Page implements HasTable
                                 ->rows(4),
                         ])
                         ->action(function (ExamBooking $record, array $data, CancelPendingExamService $service): void {
-                            $service->cancel($record, strip_tags($data['reason']), auth()->user());
+                            $service->cancelByStudent($record, strip_tags($data['reason']), auth()->user());
 
                             Notification::make()
                                 ->title('Exam cancelled')

--- a/app/Livewire/Training/AcceptedExamsTable.php
+++ b/app/Livewire/Training/AcceptedExamsTable.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Training;
 
 use App\Filament\Training\Pages\Exam\ConductExam;
 use App\Models\Cts\ExamBooking;
+use App\Services\Training\CancelPendingExamService;
 use App\Services\Training\ExamAnnouncementService;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
@@ -17,6 +18,8 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Str;
 use Livewire\Component;
 
 class AcceptedExamsTable extends Component implements HasActions, HasForms, HasTable
@@ -54,6 +57,49 @@ class AcceptedExamsTable extends Component implements HasActions, HasForms, HasT
                 Action::make('Conduct')
                     ->url(fn (ExamBooking $exam): string => ConductExam::getUrl(['examId' => $exam->id]))
                     ->visible(fn (ExamBooking $examBooking) => $examBooking->finished != ExamBooking::FINISHED_FLAG),
+                Action::make('CancelExam')
+                    ->label('Cancel exam')
+                    ->color('danger')
+                    ->icon('heroicon-o-x-circle')
+                    ->visible(function (ExamBooking $examBooking): bool {
+                        if ($examBooking->finished == ExamBooking::FINISHED_FLAG || ! $examBooking->exam) {
+                            return false;
+                        }
+
+                        return auth()->user()->can('training.exams.conduct.'.Str::lower($examBooking->exam));
+                    })
+                    ->requiresConfirmation()
+                    ->modalHeading('Cancel exam')
+                    ->modalDescription('This will release the exam slot, remove examiner assignments, and notify the student. Co-examiners can view the cancellation reason on the exam cancellations dashboard. This cannot be undone from here.')
+                    ->modalSubmitActionLabel('Yes, cancel exam')
+                    ->schema([
+                        Textarea::make('reason')
+                            ->label('Reason for cancellation')
+                            ->helperText('This will be sent to the student. Co-examiners can view it on the exam cancellations dashboard.')
+                            ->required()
+                            ->rows(4),
+                    ])
+                    ->action(function (ExamBooking $record, array $data, CancelPendingExamService $service): void {
+                        try {
+                            $service->cancelByExaminer($record, strip_tags($data['reason']), auth()->user());
+                        } catch (AuthorizationException $e) {
+                            Notification::make()
+                                ->title('Unable to cancel exam')
+                                ->body($e->getMessage())
+                                ->danger()
+                                ->send();
+
+                            return;
+                        }
+
+                        Notification::make()
+                            ->title('Exam cancelled')
+                            ->body('The student has been notified. Co-examiners can view the reason on the exam cancellations dashboard.')
+                            ->success()
+                            ->send();
+
+                        $this->dispatch('exam-accepted');
+                    }),
                 Action::make('postExamAnnouncement')
                     ->label('Post Exam Announcement')
                     ->icon('heroicon-o-megaphone')

--- a/app/Notifications/Training/Exams/ExamCancelledByExaminerStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamCancelledByExaminerStudentNotification.php
@@ -3,18 +3,23 @@
 namespace App\Notifications\Training\Exams;
 
 use App\Models\Cts\ExamBooking;
+use App\Models\Mship\Account;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExamCancelledStudentNotification extends Notification
+class ExamCancelledByExaminerStudentNotification extends Notification
 {
     use Queueable;
 
     public function __construct(
         private ExamBooking $examBooking,
+        private Account $cancelledByExaminer,
     ) {}
 
+    /**
+     * @return array<int, string>
+     */
     public function via(object $notifiable): array
     {
         return ['mail'];
@@ -24,10 +29,11 @@ class ExamCancelledStudentNotification extends Notification
     {
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
-            ->subject("{$this->examBooking->exam} Practical Exam Cancelled")
-            ->view('emails.training.exams.exam_cancelled_student', [
+            ->subject('Your practical exam has been cancelled')
+            ->view('emails.training.exams.exam_cancelled_by_examiner_student', [
                 'recipient' => $notifiable,
                 'examBooking' => $this->examBooking,
+                'cancelledByExaminer' => $this->cancelledByExaminer,
             ]);
     }
 }

--- a/app/Notifications/Training/Exams/ExamCancelledExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamCancelledExaminerNotification.php
@@ -26,24 +26,14 @@ class ExamCancelledExaminerNotification extends Notification
 
     public function toMail(object $notifiable): MailMessage
     {
-        $examBooking = $this->examBooking->load(['student']);
-
-        $studentName = $examBooking->student?->account?->name ?? 'Unknown';
-        $studentCid = $examBooking->student?->account?->id ?? 'Unknown';
+        $this->examBooking->loadMissing('student');
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
-            ->subject("{$examBooking->exam} Practical Exam Cancelled")
+            ->subject("{$this->examBooking->exam} Practical Exam Cancelled")
             ->view('emails.training.exams.exam_cancelled_examiner', [
                 'recipient' => $notifiable,
-                'examBooking' => $examBooking,
-                'examType' => $examBooking->exam,
-                'position' => $examBooking->position_1,
-                'takenDate' => $examBooking->taken_date,
-                'takenFrom' => $examBooking->taken_from,
-                'takenTo' => $examBooking->taken_to,
-                'studentName' => $studentName,
-                'studentCid' => $studentCid,
+                'examBooking' => $this->examBooking,
                 'reason' => $this->reason,
             ]);
     }

--- a/app/Notifications/Training/Exams/ExamSessionCancelledForCoExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamSessionCancelledForCoExaminerNotification.php
@@ -3,18 +3,23 @@
 namespace App\Notifications\Training\Exams;
 
 use App\Models\Cts\ExamBooking;
+use App\Models\Mship\Account;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExamCancelledStudentNotification extends Notification
+class ExamSessionCancelledForCoExaminerNotification extends Notification
 {
     use Queueable;
 
     public function __construct(
         private ExamBooking $examBooking,
+        private Account $cancelledByExaminer,
     ) {}
 
+    /**
+     * @return array<int, string>
+     */
     public function via(object $notifiable): array
     {
         return ['mail'];
@@ -22,12 +27,15 @@ class ExamCancelledStudentNotification extends Notification
 
     public function toMail(object $notifiable): MailMessage
     {
+        $this->examBooking->loadMissing('student');
+
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
-            ->subject("{$this->examBooking->exam} Practical Exam Cancelled")
-            ->view('emails.training.exams.exam_cancelled_student', [
+            ->subject("{$this->examBooking->exam} Practical Exam Session Cancelled")
+            ->view('emails.training.exams.exam_session_cancelled_for_co_examiner', [
                 'recipient' => $notifiable,
                 'examBooking' => $this->examBooking,
+                'cancelledByExaminer' => $this->cancelledByExaminer,
             ]);
     }
 }

--- a/app/Services/Training/CancelPendingExamService.php
+++ b/app/Services/Training/CancelPendingExamService.php
@@ -3,17 +3,71 @@
 namespace App\Services\Training;
 
 use App\Models\Cts\ExamBooking;
+use App\Models\Cts\Member;
 use App\Models\Cts\PracticalExaminers;
 use App\Models\Mship\Account;
+use App\Notifications\Training\Exams\ExamCancelledByExaminerStudentNotification;
 use App\Notifications\Training\Exams\ExamCancelledExaminerNotification;
 use App\Notifications\Training\Exams\ExamCancelledStudentNotification;
+use App\Notifications\Training\Exams\ExamSessionCancelledForCoExaminerNotification;
+use Closure;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class CancelPendingExamService
 {
-    public function cancel(ExamBooking $examBooking, string $reason, Account $cancelledBy): void
+    public function cancelByStudent(ExamBooking $examBooking, string $reason, Account $cancelledBy): void
     {
-        DB::transaction(function () use ($examBooking, $reason, $cancelledBy): void {
+        $this->prepareBooking($examBooking);
+        $this->assertStudentMayCancel($examBooking, $cancelledBy);
+
+        $bookingForNotifications = $this->snapshotBookingForNotifications($examBooking);
+
+        $this->executeCancellation($examBooking, $reason, $cancelledBy, function () use ($bookingForNotifications, $reason, $cancelledBy): void {
+            $this->notifyStudentInitiatedCancellation($bookingForNotifications, $reason, $cancelledBy);
+        });
+    }
+
+    public function cancelByExaminer(ExamBooking $examBooking, string $reason, Account $cancelledBy): void
+    {
+        $this->prepareBooking($examBooking);
+        $this->assertExaminerMayCancel($examBooking, $cancelledBy);
+
+        $bookingForNotifications = $this->snapshotBookingForNotifications($examBooking);
+
+        $this->executeCancellation($examBooking, $reason, $cancelledBy, function () use ($bookingForNotifications, $cancelledBy): void {
+            $this->notifyExaminerInitiatedCancellation($bookingForNotifications, $cancelledBy);
+        });
+    }
+
+    private function prepareBooking(ExamBooking $examBooking): void
+    {
+        $examBooking->loadMissing(['student', 'examiners.primaryExaminer', 'examiners.secondaryExaminer', 'examiners.traineeExaminer']);
+    }
+
+    private function assertStudentMayCancel(ExamBooking $examBooking, Account $cancelledBy): void
+    {
+        if ((int) $examBooking->student->cid !== (int) $cancelledBy->id) {
+            throw new AuthorizationException('You may not cancel this exam booking.');
+        }
+    }
+
+    private function assertExaminerMayCancel(ExamBooking $examBooking, Account $cancelledBy): void
+    {
+        if (! $this->isAssignedExaminer($examBooking, $cancelledBy)) {
+            throw new AuthorizationException('You may not cancel this exam booking.');
+        }
+
+        $exam = Str::lower((string) $examBooking->exam);
+        if ($exam === '' || ! $cancelledBy->can("training.exams.conduct.{$exam}")) {
+            throw new AuthorizationException('You do not have permission to cancel this exam.');
+        }
+    }
+
+    private function executeCancellation(ExamBooking $examBooking, string $reason, Account $cancelledBy, Closure $sendNotifications): void
+    {
+        DB::connection('cts')->transaction(function () use ($examBooking, $reason, $cancelledBy): void {
             DB::connection('cts')->table('cancel_reason')->insert([
                 'sesh_id' => $examBooking->id,
                 'sesh_type' => 'EX',
@@ -22,11 +76,6 @@ class CancelPendingExamService
                 'reason_by' => $cancelledBy->id,
                 'date' => now(),
             ]);
-
-            $examinerAccount = $examBooking->examiners?->primaryExaminer->account;
-
-            $cancelledBy->notify(new ExamCancelledStudentNotification($examBooking, $reason));
-            $examinerAccount?->notify(new ExamCancelledExaminerNotification($examBooking, $reason));
 
             $examBooking->update([
                 'taken' => 0,
@@ -44,5 +93,68 @@ class CancelPendingExamService
 
             PracticalExaminers::where('examid', $examBooking->id)->delete();
         });
+
+        DB::connection('cts')->afterCommit(fn () => $sendNotifications());
+    }
+
+    private function snapshotBookingForNotifications(ExamBooking $examBooking): ExamBooking
+    {
+        $snapshot = $examBooking->replicate();
+        $snapshot->id = $examBooking->id;
+        $snapshot->exists = true;
+        $snapshot->setRelation('student', $examBooking->student);
+        $snapshot->setRelation('examiners', $examBooking->examiners);
+
+        return $snapshot;
+    }
+
+    private function isAssignedExaminer(ExamBooking $examBooking, Account $cancelledBy): bool
+    {
+        $member = $cancelledBy->member;
+        if (! $member || ! $examBooking->examiners) {
+            return false;
+        }
+
+        $pe = $examBooking->examiners;
+
+        return collect([$pe->senior, $pe->other, $pe->trainee])
+            ->filter(fn ($id) => $id !== null && $id !== '')
+            ->contains($member->id);
+    }
+
+    private function notifyStudentInitiatedCancellation(ExamBooking $examBooking, string $reason, Account $cancelledBy): void
+    {
+        $examinerAccount = $examBooking->examiners?->primaryExaminer->account;
+
+        $cancelledBy->notify(new ExamCancelledStudentNotification($examBooking));
+        $examinerAccount?->notify(new ExamCancelledExaminerNotification($examBooking, $reason));
+    }
+
+    private function notifyExaminerInitiatedCancellation(ExamBooking $examBooking, Account $cancelledBy): void
+    {
+        $studentAccount = $examBooking->studentAccount();
+        if ($studentAccount) {
+            $studentAccount->notify(new ExamCancelledByExaminerStudentNotification($examBooking, $cancelledBy));
+        }
+
+        $pe = $examBooking->examiners;
+        if (! $pe) {
+            return;
+        }
+
+        $memberIds = collect([$pe->senior, $pe->other, $pe->trainee])
+            ->filter(fn ($id) => $id !== null && $id !== '')
+            ->unique()
+            ->values();
+
+        foreach ($memberIds as $memberId) {
+            $member = Member::find($memberId);
+            $account = $member?->account;
+            if (! $account || (int) $account->id === (int) $cancelledBy->id) {
+                continue;
+            }
+
+            $account->notify(new ExamSessionCancelledForCoExaminerNotification($examBooking, $cancelledBy));
+        }
     }
 }

--- a/resources/views/emails/training/exams/exam_cancelled_by_examiner_student.blade.php
+++ b/resources/views/emails/training/exams/exam_cancelled_by_examiner_student.blade.php
@@ -1,0 +1,24 @@
+@extends('emails.messages.post')
+
+@section('body')
+<p>
+{{ $cancelledByExaminer->name }} ({{ $cancelledByExaminer->id }}) has cancelled your {{ $examBooking->exam }} practical exam. Details are shown below.
+</p>
+
+<h4>Position</h4>
+<p>{{ $examBooking->position_1 }}</p>
+
+<h4>Exam date</h4>
+<p>
+{{ \Carbon\Carbon::parse($examBooking->taken_date)->format('l jS M y') }}<br>
+{{ \Carbon\Carbon::parse($examBooking->taken_from)->format('H:i') }}Z &ndash; {{ \Carbon\Carbon::parse($examBooking->taken_to)->format('H:i') }}Z
+</p>
+
+<p>
+However, your exam request will remain in the system so it may be picked up by another examiner.
+</p>
+@stop
+
+@section('signature')
+VATSIM UK Training Department
+@stop

--- a/resources/views/emails/training/exams/exam_cancelled_examiner.blade.php
+++ b/resources/views/emails/training/exams/exam_cancelled_examiner.blade.php
@@ -2,15 +2,15 @@
 
 @section('body')
 <p>
-{{ $studentName }} ({{ $studentCid }}) has cancelled their {{ $examType }} practical exam. The details are shown below.
+{{ $examBooking->student?->account?->name ?? 'Unknown' }} ({{ $examBooking->student?->account?->id ?? 'Unknown' }}) has cancelled their {{ $examBooking->exam }} practical exam. The details are shown below.
 </p>
 
 <h4>Exam Details:</h4>
 <ul>
-    <li><strong>Exam Type:</strong> {{ $examType }}</li>
-    <li><strong>Position:</strong> {{ $position }}</li>
-    <li><strong>Scheduled Date:</strong> {{ \Carbon\Carbon::parse($takenDate)->format('l jS M Y') }}</li>
-    <li><strong>Scheduled Time:</strong> {{ \Carbon\Carbon::parse($takenFrom)->format('H:i') }}Z &ndash; {{ \Carbon\Carbon::parse($takenTo)->format('H:i') }}Z</li>
+    <li><strong>Exam Type:</strong> {{ $examBooking->exam }}</li>
+    <li><strong>Position:</strong> {{ $examBooking->position_1 }}</li>
+    <li><strong>Scheduled Date:</strong> {{ \Carbon\Carbon::parse($examBooking->taken_date)->format('l jS M Y') }}</li>
+    <li><strong>Scheduled Time:</strong> {{ \Carbon\Carbon::parse($examBooking->taken_from)->format('H:i') }}Z &ndash; {{ \Carbon\Carbon::parse($examBooking->taken_to)->format('H:i') }}Z</li>
 </ul>
 
 <h4>Reason for cancellation:</h4>

--- a/resources/views/emails/training/exams/exam_cancelled_student.blade.php
+++ b/resources/views/emails/training/exams/exam_cancelled_student.blade.php
@@ -2,9 +2,9 @@
 
 @section('body')
 <p>
-Your {{ $examType }} practical exam on <strong>{{ $position }}</strong> scheduled for
-<strong>{{ \Carbon\Carbon::parse($takenDate)->format('l jS M Y') }}</strong> at
-<strong>{{ \Carbon\Carbon::parse($takenFrom)->format('H:i') }}Z &ndash; {{ \Carbon\Carbon::parse($takenTo)->format('H:i') }}Z</strong>
+Your {{ $examBooking->exam }} practical exam on <strong>{{ $examBooking->position_1 }}</strong> scheduled for
+<strong>{{ \Carbon\Carbon::parse($examBooking->taken_date)->format('l jS M Y') }}</strong> at
+<strong>{{ \Carbon\Carbon::parse($examBooking->taken_from)->format('H:i') }}Z &ndash; {{ \Carbon\Carbon::parse($examBooking->taken_to)->format('H:i') }}Z</strong>
 has been successfully cancelled.
 </p>
 

--- a/resources/views/emails/training/exams/exam_session_cancelled_for_co_examiner.blade.php
+++ b/resources/views/emails/training/exams/exam_session_cancelled_for_co_examiner.blade.php
@@ -1,0 +1,24 @@
+@extends('emails.messages.post')
+
+@section('body')
+<p>
+{{ $cancelledByExaminer->name }} ({{ $cancelledByExaminer->id }}) has cancelled the {{ $examBooking->exam }} practical exam for {{ $examBooking->student?->account?->name ?? 'Unknown' }} ({{ $examBooking->student?->account?->id ?? 'Unknown' }}). Details are shown below.
+</p>
+
+<h4>Position</h4>
+<p>{{ $examBooking->position_1 }}</p>
+
+<h4>Exam date</h4>
+<p>
+{{ \Carbon\Carbon::parse($examBooking->taken_date)->format('l jS M y') }}<br>
+{{ \Carbon\Carbon::parse($examBooking->taken_from)->format('H:i') }}Z &ndash; {{ \Carbon\Carbon::parse($examBooking->taken_to)->format('H:i') }}Z
+</p>
+
+<p>
+However, the student's exam request will remain in the system so it may be picked up by another examiner.
+</p>
+@stop
+
+@section('signature')
+VATSIM UK Training Department
+@stop

--- a/tests/Feature/TrainingPanel/Exams/ExamsOverviewTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamsOverviewTest.php
@@ -6,9 +6,15 @@ use App\Filament\Training\Pages\Exam\ConductExam;
 use App\Filament\Training\Pages\Exam\Exams;
 use App\Livewire\Training\AcceptedExamsTable;
 use App\Models\Cts\ExamBooking;
+use App\Models\Cts\ExamSetup;
 use App\Models\Cts\Member;
+use App\Models\Cts\PracticalExaminers;
 use App\Models\Mship\Account;
+use App\Notifications\Training\Exams\ExamCancelledByExaminerStudentNotification;
+use App\Notifications\Training\Exams\ExamSessionCancelledForCoExaminerNotification;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\View;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
@@ -119,5 +125,128 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
             ->test(AcceptedExamsTable::class)
             ->assertTableActionHasUrl('Conduct', ConductExam::getUrl(['examId' => $exam->id]), $exam)
             ->callTableAction('Conduct', $exam);
+    }
+
+    #[Test]
+    public function test_primary_examiner_can_cancel_accepted_exam_from_accepted_table(): void
+    {
+        Notification::fake();
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $student = Account::factory()->create([
+            'name_first' => 'Alex',
+            'name_last' => 'Student',
+        ]);
+        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+
+        $exam = ExamBooking::factory()->create([
+            'taken' => 1,
+            'finished' => ExamBooking::NOT_FINISHED_FLAG,
+            'student_id' => $student->id,
+            'exam' => 'TWR',
+            'position_1' => 'EGKK_TWR',
+            'taken_date' => now()->addDays(3)->format('Y-m-d'),
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+            'exmr_id' => $this->panelUser->id,
+        ]);
+
+        $examSetup = ExamSetup::create([
+            'rts_id' => 1,
+            'student_id' => $student->id,
+            'position_1' => 'EGKK_TWR',
+            'exam' => 'TWR',
+            'bookid' => $exam->id,
+            'booked' => 1,
+        ]);
+
+        $exam->examiners()->create([
+            'examid' => $exam->id,
+            'senior' => $this->panelUser->id,
+        ]);
+
+        $reason = 'Unforeseen circumstances.';
+
+        Livewire::actingAs($this->panelUser)
+            ->test(AcceptedExamsTable::class)
+            ->assertTableActionVisible('CancelExam', $exam)
+            ->callTableAction('CancelExam', $exam, [
+                'reason' => $reason,
+            ])
+            ->assertHasNoTableActionErrors();
+
+        $exam->refresh();
+        $examSetup->refresh();
+
+        $this->assertEquals(0, $exam->taken);
+        $this->assertNull($exam->taken_date);
+        $this->assertEquals(0, $examSetup->booked);
+        $this->assertDatabaseMissing('practical_examiners', ['examid' => $exam->id], 'cts');
+        $this->assertDatabaseHas('cancel_reason', [
+            'sesh_id' => $exam->id,
+            'sesh_type' => 'EX',
+            'reason' => $reason,
+            'reason_by' => $this->panelUser->id,
+        ], 'cts');
+
+        Notification::assertSentTo(
+            $student,
+            ExamCancelledByExaminerStudentNotification::class,
+            function (ExamCancelledByExaminerStudentNotification $notification) use ($student): bool {
+                $mail = $notification->toMail($student);
+                $html = View::make($mail->view, $mail->data())->render();
+
+                return $mail->subject === 'Your practical exam has been cancelled'
+                    && $mail->viewData['cancelledByExaminer']->id === $this->panelUser->id
+                    && str_contains($html, 'has cancelled your TWR practical exam')
+                    && str_contains($html, 'remain in the system');
+            },
+        );
+    }
+
+    #[Test]
+    public function test_cancelling_accepted_exam_from_accepted_table_notifies_co_examiner(): void
+    {
+        Notification::fake();
+        $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
+
+        $coExaminer = Account::factory()->create();
+        Member::factory()->create(['id' => $coExaminer->id, 'cid' => $coExaminer->id]);
+
+        $student = Account::factory()->create();
+        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+
+        $exam = ExamBooking::factory()->create([
+            'taken' => 1,
+            'finished' => ExamBooking::NOT_FINISHED_FLAG,
+            'student_id' => $student->id,
+            'exam' => 'TWR',
+        ]);
+
+        ExamSetup::create([
+            'rts_id' => 1,
+            'student_id' => $student->id,
+            'position_1' => 'EGKK_TWR',
+            'exam' => 'TWR',
+            'bookid' => $exam->id,
+            'booked' => 1,
+        ]);
+
+        PracticalExaminers::create([
+            'examid' => $exam->id,
+            'senior' => $this->panelUser->id,
+            'other' => $coExaminer->id,
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(AcceptedExamsTable::class)
+            ->callTableAction('CancelExam', $exam, [
+                'reason' => 'Examiner unavailable.',
+            ])
+            ->assertHasNoTableActionErrors();
+
+        Notification::assertSentTo($student, ExamCancelledByExaminerStudentNotification::class);
+        Notification::assertSentTo($coExaminer, ExamSessionCancelledForCoExaminerNotification::class);
+        Notification::assertNotSentTo($this->panelUser, ExamSessionCancelledForCoExaminerNotification::class);
     }
 }

--- a/tests/Feature/TrainingPanel/MyTraining/MyPendingExamsTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyPendingExamsTest.php
@@ -6,9 +6,14 @@ use App\Filament\Training\Pages\MyTraining\MyPendingExams;
 use App\Models\Cts\ExamBooking;
 use App\Models\Cts\ExamSetup;
 use App\Models\Cts\Member;
+use App\Models\Cts\PracticalExaminers;
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
+use App\Notifications\Training\Exams\ExamCancelledExaminerNotification;
+use App\Notifications\Training\Exams\ExamCancelledStudentNotification;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\View;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
@@ -152,5 +157,77 @@ class MyPendingExamsTest extends BaseTrainingPanelTestCase
             ->assertSuccessful();
 
         $this->assertCount(0, $component->instance()->getTable()->getRecords());
+    }
+
+    #[Test]
+    public function it_student_can_cancel_accepted_exam_from_pending_exams_table(): void
+    {
+        Notification::fake();
+
+        $examinerAccount = Account::factory()->create();
+        Member::factory()->create([
+            'id' => $examinerAccount->id,
+            'cid' => $examinerAccount->id,
+            'examiner' => true,
+        ]);
+
+        $this->examBooking->update([
+            'taken' => 1,
+            'taken_date' => now()->addDays(3)->format('Y-m-d'),
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+            'exmr_id' => $examinerAccount->id,
+        ]);
+
+        $this->examSetup->update(['booked' => 1]);
+
+        PracticalExaminers::create([
+            'examid' => $this->examBooking->id,
+            'senior' => $examinerAccount->id,
+        ]);
+
+        $reason = 'I can no longer make the scheduled time.';
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyPendingExams::class)
+            ->assertTableActionVisible('cancelExamRequest', $this->examBooking)
+            ->callTableAction('cancelExamRequest', $this->examBooking, [
+                'reason' => $reason,
+            ])
+            ->assertHasNoTableActionErrors();
+
+        $this->examBooking->refresh();
+        $this->examSetup->refresh();
+
+        $this->assertEquals(0, $this->examBooking->taken);
+        $this->assertNull($this->examBooking->taken_date);
+        $this->assertEquals(0, $this->examSetup->booked);
+        $this->assertDatabaseMissing('practical_examiners', ['examid' => $this->examBooking->id], 'cts');
+        $this->assertDatabaseHas('cancel_reason', [
+            'sesh_id' => $this->examBooking->id,
+            'sesh_type' => 'EX',
+            'reason' => $reason,
+            'reason_by' => $this->studentAccount->id,
+        ], 'cts');
+
+        Notification::assertSentTo(
+            $this->studentAccount,
+            ExamCancelledStudentNotification::class,
+            function (ExamCancelledStudentNotification $notification): bool {
+                $mail = $notification->toMail($this->studentAccount);
+                $html = View::make($mail->view, $mail->data())->render();
+
+                return str_contains($html, 'has been successfully cancelled');
+            },
+        );
+        Notification::assertSentTo(
+            $examinerAccount,
+            ExamCancelledExaminerNotification::class,
+            function (ExamCancelledExaminerNotification $notification) use ($reason, $examinerAccount): bool {
+                $mail = $notification->toMail($examinerAccount);
+
+                return $mail->viewData['reason'] === $reason;
+            },
+        );
     }
 }

--- a/tests/Unit/Notifications/Training/Exams/ExamCancellationNotificationsTest.php
+++ b/tests/Unit/Notifications/Training/Exams/ExamCancellationNotificationsTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications\Training\Exams;
+
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use App\Notifications\Training\Exams\ExamCancelledByExaminerStudentNotification;
+use App\Notifications\Training\Exams\ExamCancelledExaminerNotification;
+use App\Notifications\Training\Exams\ExamCancelledStudentNotification;
+use App\Notifications\Training\Exams\ExamSessionCancelledForCoExaminerNotification;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\View;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ExamCancellationNotificationsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Account $studentAccount;
+
+    private Account $examinerAccount;
+
+    private Member $studentMember;
+
+    private ExamBooking $examBooking;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->studentAccount = Account::factory()->create([
+            'name_first' => 'Alex',
+            'name_last' => 'Student',
+        ]);
+        $this->studentMember = Member::factory()->create([
+            'id' => $this->studentAccount->id,
+            'cid' => $this->studentAccount->id,
+        ]);
+
+        $this->examinerAccount = Account::factory()->create([
+            'name_first' => 'Jamie',
+            'name_last' => 'Examiner',
+        ]);
+
+        $this->examBooking = ExamBooking::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'exam' => 'TWR',
+            'position_1' => 'EGKK_TWR',
+            'taken' => 1,
+            'taken_date' => '2026-05-20',
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+        ]);
+    }
+
+    #[Test]
+    public function student_self_cancel_notification_uses_expected_subject_view_and_data(): void
+    {
+        $notification = new ExamCancelledStudentNotification($this->examBooking);
+        $mail = $notification->toMail($this->studentAccount);
+
+        $this->assertContains('mail', $notification->via($this->studentAccount));
+        $this->assertSame('TWR Practical Exam Cancelled', $mail->subject);
+        $this->assertSame('emails.training.exams.exam_cancelled_student', $mail->view);
+        $this->assertSame(
+            ['recipient', 'examBooking'],
+            array_keys($mail->viewData),
+        );
+        $this->assertSame($this->examBooking->id, $mail->viewData['examBooking']->id);
+
+        $html = View::make($mail->view, $mail->data())->render();
+
+        $this->assertStringContainsString('Dear Alex Student', $html);
+        $this->assertStringContainsString('Your TWR practical exam', $html);
+        $this->assertStringContainsString('EGKK_TWR', $html);
+        $this->assertStringContainsString('has been successfully cancelled', $html);
+    }
+
+    #[Test]
+    public function examiner_notified_of_student_cancel_notification_includes_reason(): void
+    {
+        $notification = new ExamCancelledExaminerNotification($this->examBooking, 'Cannot make the date.');
+        $mail = $notification->toMail($this->examinerAccount);
+
+        $this->assertSame('TWR Practical Exam Cancelled', $mail->subject);
+        $this->assertSame('emails.training.exams.exam_cancelled_examiner', $mail->view);
+        $this->assertSame(
+            ['recipient', 'examBooking', 'reason'],
+            array_keys($mail->viewData),
+        );
+        $this->assertSame('Cannot make the date.', $mail->viewData['reason']);
+
+        $html = View::make($mail->view, $mail->data())->render();
+
+        $this->assertStringContainsString('Alex Student', $html);
+        $this->assertStringContainsString((string) $this->studentAccount->id, $html);
+        $this->assertStringContainsString('has cancelled their TWR practical exam', $html);
+        $this->assertStringContainsString('Cannot make the date.', $html);
+    }
+
+    #[Test]
+    public function student_notified_of_examiner_cancel_notification_uses_expected_subject_view_and_data(): void
+    {
+        $notification = new ExamCancelledByExaminerStudentNotification(
+            $this->examBooking,
+            $this->examinerAccount,
+        );
+        $mail = $notification->toMail($this->studentAccount);
+
+        $this->assertSame('Your practical exam has been cancelled', $mail->subject);
+        $this->assertSame('emails.training.exams.exam_cancelled_by_examiner_student', $mail->view);
+        $this->assertSame(
+            ['recipient', 'examBooking', 'cancelledByExaminer'],
+            array_keys($mail->viewData),
+        );
+        $this->assertSame($this->examinerAccount->id, $mail->viewData['cancelledByExaminer']->id);
+
+        $html = View::make($mail->view, $mail->data())->render();
+
+        $this->assertStringContainsString('Jamie Examiner', $html);
+        $this->assertStringContainsString((string) $this->examinerAccount->id, $html);
+        $this->assertStringContainsString('has cancelled your TWR practical exam', $html);
+        $this->assertStringContainsString('EGKK_TWR', $html);
+        $this->assertStringContainsString('remain in the system', $html);
+    }
+
+    #[Test]
+    public function co_examiner_notified_of_examiner_cancel_notification_uses_expected_subject_view_and_data(): void
+    {
+        $coExaminer = Account::factory()->create([
+            'name_first' => 'Sam',
+            'name_last' => 'Co-Examiner',
+        ]);
+
+        $notification = new ExamSessionCancelledForCoExaminerNotification(
+            $this->examBooking,
+            $this->examinerAccount,
+        );
+        $mail = $notification->toMail($coExaminer);
+
+        $this->assertSame('TWR Practical Exam Session Cancelled', $mail->subject);
+        $this->assertSame('emails.training.exams.exam_session_cancelled_for_co_examiner', $mail->view);
+        $this->assertSame(
+            ['recipient', 'examBooking', 'cancelledByExaminer'],
+            array_keys($mail->viewData),
+        );
+
+        $html = View::make($mail->view, $mail->data())->render();
+
+        $this->assertStringContainsString('Jamie Examiner', $html);
+        $this->assertStringContainsString('Alex Student', $html);
+        $this->assertStringContainsString('practical exam for Alex Student', $html);
+        $this->assertStringContainsString("the student's exam request will remain", $html);
+    }
+}

--- a/tests/Unit/Training/Exams/CancelPendingExamTest.php
+++ b/tests/Unit/Training/Exams/CancelPendingExamTest.php
@@ -1,24 +1,25 @@
 <?php
 
-namespace Tests\Feature\Training\Exams;
+namespace Tests\Unit\Training\Exams;
 
 use App\Models\Cts\ExamBooking;
 use App\Models\Cts\ExamSetup;
 use App\Models\Cts\Member;
 use App\Models\Cts\PracticalExaminers;
 use App\Models\Mship\Account;
+use App\Notifications\Training\Exams\ExamCancelledByExaminerStudentNotification;
 use App\Notifications\Training\Exams\ExamCancelledExaminerNotification;
 use App\Notifications\Training\Exams\ExamCancelledStudentNotification;
+use App\Notifications\Training\Exams\ExamSessionCancelledForCoExaminerNotification;
 use App\Services\Training\CancelPendingExamService;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\View;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class CancelPendingExamTest extends TestCase
 {
-    use DatabaseTransactions;
-
     private CancelPendingExamService $service;
 
     protected Account $studentAccount;
@@ -85,7 +86,7 @@ class CancelPendingExamTest extends TestCase
     #[Test]
     public function it_resets_booking_taken_fields_to_pre_acceptance_state(): void
     {
-        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+        $this->service->cancelByStudent($this->examBooking, 'Cannot make it.', $this->studentAccount);
 
         $this->examBooking->refresh();
 
@@ -101,7 +102,7 @@ class CancelPendingExamTest extends TestCase
     #[Test]
     public function it_resets_exam_setup_booked_flag(): void
     {
-        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+        $this->service->cancelByStudent($this->examBooking, 'Cannot make it.', $this->studentAccount);
         $this->examSetup->refresh();
 
         $this->assertEquals(0, $this->examSetup->booked);
@@ -110,7 +111,7 @@ class CancelPendingExamTest extends TestCase
     #[Test]
     public function it_deletes_practical_examiner_record(): void
     {
-        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+        $this->service->cancelByStudent($this->examBooking, 'Cannot make it.', $this->studentAccount);
 
         $this->assertDatabaseMissing('practical_examiners', ['examid' => $this->examBooking->id], 'cts');
     }
@@ -120,7 +121,7 @@ class CancelPendingExamTest extends TestCase
     {
         $reason = 'I have a scheduling conflict.';
 
-        $this->service->cancel($this->examBooking, $reason, $this->studentAccount);
+        $this->service->cancelByStudent($this->examBooking, $reason, $this->studentAccount);
 
         $this->assertDatabaseHas('cancel_reason', [
             'sesh_id' => $this->examBooking->id,
@@ -131,20 +132,132 @@ class CancelPendingExamTest extends TestCase
     }
 
     #[Test]
-    public function it_sends_student_cancellation_notification(): void
+    public function it_sends_student_cancellation_notification_with_expected_mail_content(): void
     {
         Notification::fake();
-        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+        $this->service->cancelByStudent($this->examBooking, 'Cannot make it.', $this->studentAccount);
 
-        Notification::assertSentTo($this->studentAccount, ExamCancelledStudentNotification::class);
+        Notification::assertSentTo(
+            $this->studentAccount,
+            ExamCancelledStudentNotification::class,
+            function (ExamCancelledStudentNotification $notification): bool {
+                $mail = $notification->toMail($this->studentAccount);
+                $html = View::make($mail->view, $mail->data())->render();
+
+                return $mail->viewData['examBooking']->id === $this->examBooking->id
+                    && str_contains($html, 'has been successfully cancelled');
+            },
+        );
     }
 
     #[Test]
-    public function it_sends_examiner_cancellation_notification(): void
+    public function it_sends_examiner_cancellation_notification_with_reason_in_mail(): void
     {
         Notification::fake();
-        $this->service->cancel($this->examBooking, 'Cannot make it.', $this->studentAccount);
+        $reason = 'Cannot make it.';
 
-        Notification::assertSentTo($this->examinerAccount, ExamCancelledExaminerNotification::class);
+        $this->service->cancelByStudent($this->examBooking, $reason, $this->studentAccount);
+
+        Notification::assertSentTo(
+            $this->examinerAccount,
+            ExamCancelledExaminerNotification::class,
+            function (ExamCancelledExaminerNotification $notification) use ($reason): bool {
+                $mail = $notification->toMail($this->examinerAccount);
+
+                return $mail->viewData['reason'] === $reason
+                    && $mail->viewData['examBooking']->id === $this->examBooking->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_throws_when_stranger_attempts_cancel_by_student(): void
+    {
+        $stranger = Account::factory()->create();
+
+        $this->expectException(AuthorizationException::class);
+        $this->service->cancelByStudent($this->examBooking, 'No access.', $stranger);
+    }
+
+    #[Test]
+    public function it_throws_when_stranger_attempts_cancel_by_examiner(): void
+    {
+        $stranger = Account::factory()->create();
+
+        $this->expectException(AuthorizationException::class);
+        $this->service->cancelByExaminer($this->examBooking, 'No access.', $stranger);
+    }
+
+    #[Test]
+    public function it_throws_when_examiner_uses_cancel_by_student(): void
+    {
+        $this->examinerAccount->givePermissionTo('training.exams.conduct.twr');
+
+        $this->expectException(AuthorizationException::class);
+        $this->service->cancelByStudent($this->examBooking, 'Wrong API.', $this->examinerAccount);
+    }
+
+    #[Test]
+    public function it_throws_when_student_uses_cancel_by_examiner(): void
+    {
+        $this->expectException(AuthorizationException::class);
+        $this->service->cancelByExaminer($this->examBooking, 'Wrong API.', $this->studentAccount);
+    }
+
+    #[Test]
+    public function it_throws_when_assigned_examiner_lacks_conduct_permission(): void
+    {
+        $this->expectException(AuthorizationException::class);
+        $this->service->cancelByExaminer($this->examBooking, 'No permission.', $this->examinerAccount);
+    }
+
+    #[Test]
+    public function it_sends_examiner_initiated_notifications_to_student_and_co_examiner(): void
+    {
+        $coExaminerAccount = Account::factory()->create();
+        Member::factory()->create([
+            'id' => $coExaminerAccount->id,
+            'cid' => $coExaminerAccount->id,
+        ]);
+        $this->examBooking->examiners->update(['other' => $coExaminerAccount->id]);
+
+        Notification::fake();
+        $this->examinerAccount->givePermissionTo('training.exams.conduct.twr');
+        $this->service->cancelByExaminer($this->examBooking, 'Department decision.', $this->examinerAccount);
+
+        Notification::assertSentTo(
+            $this->studentAccount,
+            ExamCancelledByExaminerStudentNotification::class,
+            function (ExamCancelledByExaminerStudentNotification $notification): bool {
+                $mail = $notification->toMail($this->studentAccount);
+
+                return $mail->subject === 'Your practical exam has been cancelled'
+                    && $mail->viewData['cancelledByExaminer']->id === $this->examinerAccount->id
+                    && $mail->viewData['examBooking']->id === $this->examBooking->id;
+            },
+        );
+        Notification::assertSentTo(
+            $coExaminerAccount,
+            ExamSessionCancelledForCoExaminerNotification::class,
+            function (ExamSessionCancelledForCoExaminerNotification $notification) use ($coExaminerAccount): bool {
+                $mail = $notification->toMail($coExaminerAccount);
+
+                return $mail->viewData['cancelledByExaminer']->id === $this->examinerAccount->id;
+            },
+        );
+        Notification::assertNotSentTo($this->examinerAccount, ExamSessionCancelledForCoExaminerNotification::class);
+        Notification::assertNotSentTo($this->examinerAccount, ExamCancelledExaminerNotification::class);
+        Notification::assertNotSentTo($this->studentAccount, ExamCancelledStudentNotification::class);
+    }
+
+    #[Test]
+    public function it_resets_booking_when_cancelled_by_examiner(): void
+    {
+        $this->examinerAccount->givePermissionTo('training.exams.conduct.twr');
+        $this->service->cancelByExaminer($this->examBooking, 'Weather.', $this->examinerAccount);
+
+        $this->examBooking->refresh();
+
+        $this->assertEquals(0, $this->examBooking->taken);
     }
 }


### PR DESCRIPTION
## Summary

Adds examiner-initiated cancellation for accepted practical exams and aligns cancellation emails with legacy CTS behaviour. `CancelPendingExamService` is split into student and examiner paths with separate notifications, and cancellation emails are only sent after the CTS transaction commits.

## Changes

### Service layer

- Split `CancelPendingExamService::cancel()` into `cancelByStudent()` and `cancelByExaminer()` with role-specific authorization.
- Examiner cancellation checks the user is an assigned examiner and has `training.exams.conduct.{exam}` permission.
- Persistence runs in a `cts` database transaction; notifications are dispatched via `DB::afterCommit()` so emails are not sent if the transaction rolls back.
- Booking details are snapshotted before reset so emails still show the scheduled date, time, and position.

### UI

- **Accepted Exams** (`AcceptedExamsTable`): new **Cancel exam** action with confirmation modal, reason field, and authorization error handling.
- **My Pending Exams**: wired to `cancelByStudent()` (replacing the old `cancel()` call).
- Examiner cancel copy clarifies that the reason is sent to the student and that co-examiners can view it on the **Exam Cancellations** dashboard.

### Notifications & emails

| Scenario | Recipient | Email |
|----------|-----------|--------|
| Student cancels | Student | Confirmation (`exam_cancelled_student`) |
| Student cancels | Primary examiner | Cancellation + reason (`exam_cancelled_examiner`) |
| Examiner cancels | Student | Cancellation by examiner (`exam_cancelled_by_examiner_student`) |
| Examiner cancels | Co-examiners (not the cancelling examiner) | Session cancelled (`exam_session_cancelled_for_co_examiner`) |

- Student email subject: **Your practical exam has been cancelled**
- Examiner-initiated student/co-examiner emails match legacy wording (examiner attribution, position/date details, note that the request remains in the system for reassignment).
- Notification classes pass `examBooking` (and `reason` where relevant) into views instead of duplicating fields.

### Tests

- Expanded `CancelPendingExamTest` (auth, DB side effects, notification assertions).
- New `ExamCancellationNotificationsTest` (subjects, view data, rendered content).
- Feature tests for examiner cancel via `AcceptedExamsTable` and student cancel via `MyPendingExams`.