### PR TITLE
Dont preload accounts in the select filter for EndorsementRequests

### DIFF
--- a/app/Filament/Admin/Resources/EndorsementRequests/EndorsementRequestResource.php
+++ b/app/Filament/Admin/Resources/EndorsementRequests/EndorsementRequestResource.php
@@ -22,6 +22,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class EndorsementRequestResource extends Resource
 {
@@ -92,7 +93,16 @@ class EndorsementRequestResource extends Resource
                 SelectFilter::make('account')
                     ->label('CID')
                     ->multiple()
-                    ->relationship('account', 'id'),
+                    ->relationship(
+                        'account',
+                        'id',
+                        fn (Builder $query) => $query->whereIn(
+                            'id',
+                            EndorsementRequest::query()->select('account_id'),
+                        ),
+                    )
+                    ->searchable()
+                    ->preload(false),
                 SelectFilter::make('actioned_type')
                     ->label('Status')
                     ->multiple()

--- a/tests/Feature/Admin/EndorsementRequest/EndorsementRequestCreateTest.php
+++ b/tests/Feature/Admin/EndorsementRequest/EndorsementRequestCreateTest.php
@@ -7,6 +7,7 @@ use App\Filament\Admin\Resources\EndorsementRequests\Pages\ListEndorsementReques
 use App\Models\Atc\Position;
 use App\Models\Atc\PositionGroup;
 use App\Models\Mship\Account;
+use App\Models\Mship\Account\EndorsementRequest;
 use App\Notifications\Mship\Endorsement\EndorsementRequestCreated;
 use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
@@ -14,6 +15,26 @@ use Tests\Feature\Admin\BaseAdminTestCase;
 
 class EndorsementRequestCreateTest extends BaseAdminTestCase
 {
+    public function test_list_page_loads_when_many_accounts_exist_without_endorsement_requests(): void
+    {
+        Account::factory()->count(50)->create();
+
+        $accountWithRequest = Account::factory()->create();
+        $positionGroup = PositionGroup::factory()->create();
+        $endorsementRequest = EndorsementRequest::factory()->create([
+            'account_id' => $accountWithRequest->id,
+            'endorsable_id' => $positionGroup->id,
+            'endorsable_type' => PositionGroup::class,
+        ]);
+
+        $this->actingAsAdminUser('endorsement-request.access');
+
+        Livewire::test(ListEndorsementRequests::class)
+            ->assertSuccessful()
+            ->filterTable('account', [$accountWithRequest->id])
+            ->assertCanSeeTableRecords([$endorsementRequest]);
+    }
+
     public function test_create_not_visible_when_no_create_permission()
     {
         $this->actingAsAdminUser('endorsement-request.access');


### PR DESCRIPTION
## Summary

Fixes out-of-memory errors on the **Endorsement Requests** list page (`/admin/endorsement-requests`) by changing how the **CID** table filter loads account options.

## Problem

The list page used a Filament `SelectFilter` with `relationship('account', 'id')` and no scoping or preload controls. Filament relationship filters **preload all options by default**, which meant every request to the page attempted to load the full `Account` table into memory for the filter dropdown.

With a large member base, that hydrates thousands of heavy `Account` models (many traits and relations) and can exceed PHP's memory limit before the table itself renders.

## Why this fixes it

The filter now:

1. **Scopes options** to accounts that actually have endorsement requests, via a subquery on `endorsement_requests.account_id`, instead of every member in the division.
2. **Disables preloading** (`preload(false)`), so options are not fetched until the user opens or searches the filter.
3. **Enables search** (`searchable()`), so mentors can find a CID without loading the full option set upfront.

Together, this removes the unbounded "load all accounts on page load" behaviour that caused the OOM, while keeping the same filter UX for filtering the table by CID.

This aligns with patterns used elsewhere in the app (e.g. searchable `AccountSelect`, and CID filtering on Solo Endorsements via `QueryBuilder` rather than an unscoped relationship dropdown).

## Changes

- `app/Filament/Admin/Resources/EndorsementRequests/EndorsementRequestResource.php` — scoped, searchable, non-preloaded account filter
- `tests/Feature/Admin/EndorsementRequest/EndorsementRequestCreateTest.php` — regression test: list loads with many unrelated accounts and account filter still works