### PR TITLE
Add log viewer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -179,6 +179,7 @@ jobs:
             $PHP_PATH artisan telescope:publish
             $PHP_PATH artisan horizon:publish
             $PHP_PATH artisan filament:assets
+            $PHP_PATH artisan log-viewer:publish
 
             # Run migrations
             $PHP_PATH artisan migrate --force

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\URL;
@@ -20,6 +21,7 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Testing\ParallelTesting;
 use Livewire\Livewire;
+use Opcodes\LogViewer\Facades\LogViewer;
 use Spatie\Permission\PermissionRegistrar;
 use Whitecube\LaravelCookieConsent\Facades\Cookies;
 
@@ -67,6 +69,14 @@ class AppServiceProvider extends ServiceProvider
         Cookies::essentials()
             ->session()
             ->csrf();
+
+        Gate::define('viewLogViewer', function ($user) {
+            return $user?->hasPermissionTo('log-viewer.access') ?? false;
+        });
+
+        LogViewer::auth(function ($request) {
+            return $request->user()?->hasPermissionTo('log-viewer.access') ?? false;
+        });
 
         $this->configureParallelTesting();
     }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -78,6 +78,11 @@ class AdminPanelProvider extends PanelProvider
                     ->icon('heroicon-o-magnifying-glass')
                     ->url(fn () => route('telescope'))
                     ->visible(fn () => request()->user()->can('viewTelescope')),
+                NavigationItem::make('Log Viewer')
+                    ->group('Technology')
+                    ->icon('heroicon-o-document-text')
+                    ->url(fn () => route('log-viewer.index'))
+                    ->visible(fn () => request()->user()->can('viewLogViewer')),
             ])
             ->renderHook(
                 PanelsRenderHook::TOPBAR_LOGO_AFTER,

--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
         "maatwebsite/excel": "~3.1.17",
         "malahierba-lab/public-id": "dev-main",
         "ohdearapp/ohdear-php-sdk": "^4.4",
+        "opcodesio/log-viewer": "^3.24",
         "planetteamspeak/ts3-php-framework": "~1.3.0",
         "predis/predis": "^3.4",
         "pusher/pusher-php-server": "~7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3a109eb9646c0d66693587ee32b173b",
+    "content-hash": "9a90f5078185f99c1d566bc20451979e",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
@@ -6283,6 +6283,147 @@
                 "source": "https://github.com/ohdearapp/ohdear-php-sdk/tree/4.7.0"
             },
             "time": "2026-03-30T20:58:53+00:00"
+        },
+        {
+            "name": "opcodesio/log-viewer",
+            "version": "v3.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opcodesio/log-viewer.git",
+                "reference": "8afefde09f6005f7d8ee3f628aa311f27c91d125"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opcodesio/log-viewer/zipball/8afefde09f6005f7d8ee3f628aa311f27c91d125",
+                "reference": "8afefde09f6005f7d8ee3f628aa311f27c91d125",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "opcodesio/mail-parser": "^0.2.3",
+                "php": "^8.0"
+            },
+            "conflict": {
+                "arcanedev/log-viewer": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.2",
+                "itsgoingd/clockwork": "^5.1",
+                "laravel/pint": "^1.0",
+                "nunomaduro/collision": "^7.0|^8.0",
+                "orchestra/testbench": "^7.6|^8.0|^9.5|^10.0|^11.0",
+                "pestphp/pest": "^2.0|^3.7|^4.4",
+                "pestphp/pest-plugin-laravel": "^2.0|^3.1|^4.1",
+                "spatie/test-time": "^1.3"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Required for multi-host support. ^7.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "LogViewer": "Opcodes\\LogViewer\\Facades\\LogViewer"
+                    },
+                    "providers": [
+                        "Opcodes\\LogViewer\\LogViewerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opcodes\\LogViewer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Arunas Skirius",
+                    "email": "arukomp@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Fast and easy-to-use log viewer for your Laravel application",
+            "homepage": "https://github.com/opcodesio/log-viewer",
+            "keywords": [
+                "arukompas",
+                "better-log-viewer",
+                "laravel",
+                "log viewer",
+                "logs",
+                "opcodesio"
+            ],
+            "support": {
+                "issues": "https://github.com/opcodesio/log-viewer/issues",
+                "source": "https://github.com/opcodesio/log-viewer/tree/v3.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/arunas",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/arukompas",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T19:31:14+00:00"
+        },
+        {
+            "name": "opcodesio/mail-parser",
+            "version": "v0.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opcodesio/mail-parser.git",
+                "reference": "6f9544a1e526d5849cf8d96600556b2951893aec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opcodesio/mail-parser/zipball/6f9544a1e526d5849cf8d96600556b2951893aec",
+                "reference": "6f9544a1e526d5849cf8d96600556b2951893aec",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^2.16",
+                "symfony/var-dumper": "^6.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Opcodes\\MailParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Arunas Skirius",
+                    "email": "arukomp@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parse emails without the mailparse extension",
+            "keywords": [
+                "arukompas",
+                "email",
+                "email parser",
+                "mail",
+                "opcodesio",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/opcodesio/mail-parser/issues",
+                "source": "https://github.com/opcodesio/mail-parser/tree/v0.2.3"
+            },
+            "time": "2026-02-28T09:04:57+00:00"
         },
         {
             "name": "openspout/openspout",

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -51,6 +51,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'admin.access',
             'horizon.access',
             'telescope.access',
+            'log-viewer.access',
 
             // Training Panel Permissions
             'training.access',

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -6,3 +6,4 @@
 mix-manifest.json
 !vendor/telescope/mix-manifest.json
 /images/vendor
+vendor/log-viewer

--- a/tests/Unit/Admin/LogViewerAccessTest.php
+++ b/tests/Unit/Admin/LogViewerAccessTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Admin;
+
+use App\Models\Mship\Account;
+use Illuminate\Support\Facades\Gate;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class LogViewerAccessTest extends TestCase
+{
+    #[Test]
+    public function it_allows_user_with_log_viewer_role()
+    {
+        $user = Account::factory()->create();
+
+        $role = Role::create(['name' => 'log-viewer-test-role', 'guard_name' => 'web']);
+        $role->givePermissionTo('log-viewer.access');
+        $user->assignRole($role);
+
+        $this->assertTrue(
+            Gate::forUser($user)->allows('viewLogViewer')
+        );
+    }
+
+    #[Test]
+    public function it_denies_user_without_permission()
+    {
+        $user = $this->user;
+
+        $this->assertFalse(
+            Gate::forUser($user)->allows('viewLogViewer')
+        );
+    }
+}


### PR DESCRIPTION
Cool log viewer as per our discussion
 - Accessible via the admin panel (default url is `/log-viewer`)
 - Guarded by the `log-viewer.index` (@AxonC gotta give it to tech - I think we lost role edit perms)
 - Asset publishing in build script
 
 
<img width="2557" height="1329" alt="image" src="https://github.com/user-attachments/assets/b19715af-ae0f-404b-aa28-86bdaa2d1cb7" />
