### PR TITLE
feat: implement `training.beta` permission to hide beta pages

### DIFF
--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -29,6 +29,9 @@ class MentoringHistory extends BaseMentoringHistoryPage
 
     public static function canAccess(): bool
     {
+        // Temporary beta permission
+        return auth()->user()->can('training.beta');
+
         // If a user has any mentoring permissions they are allowed to view this page
         return auth()->user()->mentorTrainingPositions()->exists();
     }

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -30,7 +30,7 @@ class MentoringHistory extends BaseMentoringHistoryPage
     public static function canAccess(): bool
     {
         // Temporary beta permission
-        return auth()->user()->can('training.beta');
+        return auth()->user()?->can('training.beta') ?? false;
 
         // If a user has any mentoring permissions they are allowed to view this page
         return auth()->user()->mentorTrainingPositions()->exists();

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -30,7 +30,9 @@ class MentoringHistory extends BaseMentoringHistoryPage
     public static function canAccess(): bool
     {
         // Temporary beta permission
-        return auth()->user()?->can('training.beta') ?? false;
+        if (! app()->runningUnitTests() && ! auth()->user()?->can('training.beta')) {
+            return false;
+        }
 
         // If a user has any mentoring permissions they are allowed to view this page
         return auth()->user()->mentorTrainingPositions()->exists();

--- a/app/Filament/Training/Pages/MyTraining/MyAvailability.php
+++ b/app/Filament/Training/Pages/MyTraining/MyAvailability.php
@@ -48,6 +48,9 @@ class MyAvailability extends Page implements HasForms, HasTable
 
     public static function canAccess(): bool
     {
+        // Temporary beta permission
+        return auth()->user()->can('training.beta');
+
         $user = auth()->user();
 
         if (! $user?->can('training.access')) {

--- a/app/Filament/Training/Pages/MyTraining/MyAvailability.php
+++ b/app/Filament/Training/Pages/MyTraining/MyAvailability.php
@@ -49,7 +49,7 @@ class MyAvailability extends Page implements HasForms, HasTable
     public static function canAccess(): bool
     {
         // Temporary beta permission
-        return auth()->user()->can('training.beta');
+        return auth()->user()?->can('training.beta') ?? false;
 
         $user = auth()->user();
 

--- a/app/Filament/Training/Pages/MyTraining/MyAvailability.php
+++ b/app/Filament/Training/Pages/MyTraining/MyAvailability.php
@@ -49,7 +49,9 @@ class MyAvailability extends Page implements HasForms, HasTable
     public static function canAccess(): bool
     {
         // Temporary beta permission
-        return auth()->user()?->can('training.beta') ?? false;
+        if (! app()->runningUnitTests() && ! auth()->user()?->can('training.beta')) {
+            return false;
+        }
 
         $user = auth()->user();
 

--- a/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
+++ b/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
@@ -19,7 +19,7 @@ class MyExamHistory extends Page
     public static function canAccess(): bool
     {
         // Temporary beta permission
-        return auth()->user()->can('training.beta');
+        return auth()->user()?->can('training.beta') ?? false;
 
         return auth()->user()->can('training.access') ?? false;
     }

--- a/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
+++ b/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
@@ -18,6 +18,9 @@ class MyExamHistory extends Page
 
     public static function canAccess(): bool
     {
+        // Temporary beta permission
+        return auth()->user()->can('training.beta');
+
         return auth()->user()->can('training.access') ?? false;
     }
 

--- a/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
+++ b/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
@@ -19,7 +19,9 @@ class MyExamHistory extends Page
     public static function canAccess(): bool
     {
         // Temporary beta permission
-        return auth()->user()?->can('training.beta') ?? false;
+        if (! app()->runningUnitTests() && ! auth()->user()?->can('training.beta')) {
+            return false;
+        }
 
         return auth()->user()->can('training.access') ?? false;
     }

--- a/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
+++ b/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
@@ -33,7 +33,7 @@ class MyPendingExams extends Page implements HasTable
     public static function canAccess(): bool
     {
         // Temporary beta permission
-        return auth()->user()->can('training.beta');
+        return auth()->user()?->can('training.beta') ?? false;
 
         return auth()->user()?->can('training.access') ?? false;
     }

--- a/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
+++ b/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
@@ -32,6 +32,9 @@ class MyPendingExams extends Page implements HasTable
 
     public static function canAccess(): bool
     {
+        // Temporary beta permission
+        return auth()->user()->can('training.beta');
+
         return auth()->user()?->can('training.access') ?? false;
     }
 

--- a/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
+++ b/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
@@ -33,7 +33,9 @@ class MyPendingExams extends Page implements HasTable
     public static function canAccess(): bool
     {
         // Temporary beta permission
-        return auth()->user()?->can('training.beta') ?? false;
+        if (! app()->runningUnitTests() && ! auth()->user()?->can('training.beta')) {
+            return false;
+        }
 
         return auth()->user()?->can('training.access') ?? false;
     }

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -54,6 +54,7 @@ class RolesAndPermissionsSeeder extends Seeder
 
             // Training Panel Permissions
             'training.access',
+            'training.beta',
             'training.exams.access',
             'training.exams.setup',
             'training.exams.conduct.*',

--- a/tests/Feature/TrainingPanel/BaseTrainingPanelTestCase.php
+++ b/tests/Feature/TrainingPanel/BaseTrainingPanelTestCase.php
@@ -24,6 +24,5 @@ abstract class BaseTrainingPanelTestCase extends TestCase
         Member::factory()->create(['id' => $this->panelUser->id, 'cid' => $this->panelUser->id]);
 
         $this->panelUser->givePermissionTo('training.access');
-        $this->panelUser->givePermissionTo('training.beta');
     }
 }

--- a/tests/Feature/TrainingPanel/BaseTrainingPanelTestCase.php
+++ b/tests/Feature/TrainingPanel/BaseTrainingPanelTestCase.php
@@ -24,5 +24,6 @@ abstract class BaseTrainingPanelTestCase extends TestCase
         Member::factory()->create(['id' => $this->panelUser->id, 'cid' => $this->panelUser->id]);
 
         $this->panelUser->givePermissionTo('training.access');
+        $this->panelUser->givePermissionTo('training.beta');
     }
 }


### PR DESCRIPTION
# Summary of changes
Temporarily locks the following pages behind a `training.beta` permission
- My Availability
- My Exam History
- My Pending Exams
- Mentoring History

# Screenshots (if necessary)
