### PR TITLE
fix: make feedback responses no longer copyable

### DIFF
--- a/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
+++ b/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
@@ -123,8 +123,7 @@ class FeedbackResource extends Resource
                                 TextEntry::make('response')
                                     ->label('Answer')
                                     ->extraAttributes(['style' => 'white-space: pre-line;'])
-                                    ->state(fn ($record) => $record->response)
-                                    ->copyable(),
+                                    ->state(fn ($record) => $record->response),
                             ]),
                     ]),
             ]);


### PR DESCRIPTION
# Summary of changes
- Make feedback responses not copyable via click so that hyperlinks work

# Screenshots (if necessary)
