### PR TITLE
feat: update page titles and brand name

### DIFF
--- a/app/Filament/Admin/Pages/Dashboard.php
+++ b/app/Filament/Admin/Pages/Dashboard.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Filament\Admin\Pages;
+
+use Filament\Pages\Dashboard as FilamentDashboard;
+
+class Dashboard extends FilamentDashboard
+{
+    protected static ?string $title = 'Admin Panel';
+
+    protected ?string $heading = 'Dashboard';
+
+    protected static ?string $navigationLabel = 'Dashboard';
+}

--- a/app/Filament/Training/Pages/Dashboard.php
+++ b/app/Filament/Training/Pages/Dashboard.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Filament\Training\Pages;
+
+use Filament\Pages\Dashboard as FilamentDashboard;
+
+class Dashboard extends FilamentDashboard
+{
+    protected static ?string $title = 'Training Panel';
+
+    protected ?string $heading = 'Dashboard';
+
+    protected static ?string $navigationLabel = 'Dashboard';
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Admin\Pages\Dashboard;
 use App\Filament\Widgets\AccountInfoWidget;
 use App\Http\Middleware\AdminPanelFilamentAccessMiddleware;
 use App\Http\Middleware\TrackInactivity;
@@ -9,7 +10,6 @@ use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
-use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\View\PanelsRenderHook;
@@ -36,7 +36,7 @@ class AdminPanelProvider extends PanelProvider
             ->discoverResources(in: app_path('Filament/Admin/Resources'), for: 'App\\Filament\\Admin\\Resources')
             ->discoverPages(in: app_path('Filament/Admin/Pages'), for: 'App\\Filament\\Admin\\Pages')
             ->pages([
-                Pages\Dashboard::class,
+                Dashboard::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Admin/Widgets'), for: 'App\\Filament\\Admin\\Widgets')
             ->widgets([
@@ -59,6 +59,7 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->brandLogo(asset('images/branding/vatsimuk_blackblue.png'))
             ->darkModeBrandLogo(asset('images/branding/vatsimuk_whiteblue.png'))
+            ->brandName('VATSIM UK')
             ->navigationGroups([
                 NavigationGroup::make('Technology'),
             ])

--- a/app/Providers/Filament/TrainingPanelProvider.php
+++ b/app/Providers/Filament/TrainingPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Training\Pages\Dashboard;
 use App\Filament\Widgets\AccountInfoWidget;
 use App\Http\Middleware\TrackInactivity;
 use App\Http\Middleware\TrainingPanelAccessMiddleware;
@@ -9,7 +10,6 @@ use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\NavigationItem;
-use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\View\PanelsRenderHook;
@@ -34,7 +34,7 @@ class TrainingPanelProvider extends PanelProvider
             ->discoverResources(in: app_path('Filament/Training/Resources'), for: 'App\\Filament\\Training\\Resources')
             ->discoverPages(in: app_path('Filament/Training/Pages'), for: 'App\\Filament\\Training\\Pages')
             ->pages([
-                Pages\Dashboard::class,
+                Dashboard::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Training/Widgets'), for: 'App\\Filament\\Training\\Widgets')
             ->widgets([
@@ -57,6 +57,7 @@ class TrainingPanelProvider extends PanelProvider
             ])
             ->brandLogo(asset('images/branding/vatsimuk_blackblue.png'))
             ->darkModeBrandLogo(asset('images/branding/vatsimuk_whiteblue.png'))
+            ->brandName('VATSIM UK')
             ->navigationGroups([
                 'My Training',
                 'Exams',


### PR DESCRIPTION
# Summary of changes
## Page Titles
Currently the titles for the Filament pages feel a bit weird. The current format is `{page} - VATSIM UK Core`, compared to the main website which uses `VATSIM UK | {page}`

To bring the filament pages closer inline to the main website, I have changed the filament page titles to be `{page} - VATSIM UK`

## Panel dashboard titles
Right now the dashboard pages for both admin and training have the title `Dashboard - VATSIM UK Core` which makes it impossible to distinguish the tabs when open.

I have changed the admin panel dashboard title to be:
`Admin Panel - VATSIM UK` 

and the training panel dashboard title to be:
`Training Panel - VATSIM UK`

the titles still change with page. e.g. on the exams page the title is
`Exams - VATSIM UK`

# Screenshots (if necessary)
<img width="217" height="39" alt="image" src="https://github.com/user-attachments/assets/24c41d5b-44a3-4d62-b768-a8ed49be01c1" />
<img width="231" height="43" alt="image" src="https://github.com/user-attachments/assets/7c11e7e3-ace4-4d6e-9f47-1ec430c0a581" />
<img width="191" height="40" alt="image" src="https://github.com/user-attachments/assets/1c196318-9ce8-444f-ae70-819fb3339699" />
