### PR TITLE
feat: add view all mentoring permission

### DIFF
--- a/app/Filament/Training/Pages/Mentor/Mentoring.php
+++ b/app/Filament/Training/Pages/Mentor/Mentoring.php
@@ -21,6 +21,11 @@ class Mentoring extends Page
             return false;
         }
 
+        // Admin permission to allow access even without mentoring permissions
+        if (auth()->user()?->can('training.mentoring.view.*')) {
+            return true;
+        }
+
         return auth()->user()->mentorTrainingPositions()->exists();
     }
 }

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -6,7 +6,6 @@ namespace App\Filament\Training\Pages\Mentor;
 
 use App\Filament\Training\Pages\Mentor\Base\BaseMentoringHistoryPage;
 use App\Repositories\Cts\SessionRepository;
-use App\Services\Training\MentorPermissionService;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Illuminate\Database\Eloquent\Builder;
@@ -52,12 +51,11 @@ class MentoringHistory extends BaseMentoringHistoryPage
 
     protected function getHeaderActions(): array
     {
-        $allCategories = collect(MentorPermissionService::atcCategories())->merge(MentorPermissionService::pilotCategories());
+        $availableCategories = auth()->user()->getAvailableMentoringCategories();
 
         return [
             ActionGroup::make(
-                $allCategories
-                    ->filter(fn (string $cat) => $this->canViewCategory($cat))
+                collect($availableCategories)
                     ->map(fn (string $cat) => Action::make('cat_'.str($cat)->slug('_'))
                         ->label($cat)
                         ->url(static::getUrl(['category' => $cat]))
@@ -65,7 +63,7 @@ class MentoringHistory extends BaseMentoringHistoryPage
                     )
                     ->all()
             )
-                ->label("Training Group: {$this->category}")
+                ->label('Training Group: '.($this->category ?: 'All'))
                 ->icon('heroicon-m-chevron-down')
                 ->color('gray')
                 ->button(),
@@ -88,18 +86,18 @@ class MentoringHistory extends BaseMentoringHistoryPage
 
     private function getVisibleCtsPositions(): array
     {
-        return app(MentorPermissionService::class)->getAssignedCtsCallsigns(auth()->user(), $this->category);
+        $user = auth()->user();
+
+        return $this->category ? $user->getAssignedCallsignsForCategory($this->category) : $user->getAllAssignedCallsigns();
     }
 
     private function canViewCategory(string $category): bool
     {
-        $assignedCallsigns = app(MentorPermissionService::class)->getAssignedCtsCallsigns(auth()->user(), $category);
-
-        return count($assignedCallsigns) > 0;
+        return in_array($category, auth()->user()->getAvailableMentoringCategories(), true);
     }
 
     private function firstVisibleCategory(): ?string
     {
-        return collect(MentorPermissionService::atcCategories())->merge(MentorPermissionService::pilotCategories())->first(fn (string $cat) => $this->canViewCategory($cat));
+        return collect(auth()->user()->getAvailableMentoringCategories())->first();
     }
 }

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -34,6 +34,11 @@ class MentoringHistory extends BaseMentoringHistoryPage
             return false;
         }
 
+        // Admin permission to allow access even without mentoring permissions
+        if (auth()->user()?->can('training.mentoring.view.*')) {
+            return true;
+        }
+
         // If a user has any mentoring permissions they are allowed to view this page
         return auth()->user()->mentorTrainingPositions()->exists();
     }

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -86,6 +86,11 @@ class ViewMentoringReport extends Page implements HasInfolists
             return;
         }
 
+        // Admin permission to allow access even without mentoring permissions
+        if (auth()->user()?->can('training.mentoring.view.*')) {
+            return;
+        }
+
         if ($user->canMentorPosition($this->session->position)) {
             return;
         }

--- a/app/Livewire/Training/AvailabilityGantt.php
+++ b/app/Livewire/Training/AvailabilityGantt.php
@@ -33,7 +33,10 @@ class AvailabilityGantt extends Component implements HasForms
         $this->date = request()->query('date', Carbon::today()->format('Y-m-d'));
         $this->category = request()->query('category', null);
 
-        if ($this->category && ! auth()->user()->hasMentoringPermissionForCategory($this->category)) {
+        $isAdmin = auth()->user()?->can('training.mentoring.view.*');
+
+        // Allow admins to bypass the category permission check
+        if ($this->category && ! $isAdmin && ! auth()->user()->hasMentoringPermissionForCategory($this->category)) {
             $this->category = null;
         }
     }
@@ -102,16 +105,23 @@ class AvailabilityGantt extends Component implements HasForms
         $targetDate = Carbon::parse($this->date);
         $allowedCallsigns = $this->getAllowedCallsigns();
 
-        if (empty($allowedCallsigns)) {
+        // Check if the user has the admin bypass permission
+        $hasViewAllPermission = auth()->user()?->can('training.mentoring.view.*');
+
+        if (empty($allowedCallsigns) && ! $hasViewAllPermission) {
             return collect();
         }
 
         return Member::query()
-            ->whereHas('sessions', function ($query) use ($allowedCallsigns) {
+            ->whereHas('sessions', function ($query) use ($allowedCallsigns, $hasViewAllPermission) {
                 $query->whereNull('mentor_id')
                     ->whereNull('filed')
-                    ->whereNull('cancelled_datetime')
-                    ->whereIn('position', $allowedCallsigns);
+                    ->whereNull('cancelled_datetime');
+
+                // If doesn't have view all permission, filter strictly by their allowed mentoring callsigns
+                if (! $hasViewAllPermission) {
+                    $query->whereIn('position', $allowedCallsigns);
+                }
             })
             ->whereHas('availabilities', function ($query) use ($targetDate) {
                 $query->whereDate('date', $targetDate);

--- a/app/Models/Mship/Concerns/HasMentoringPermissions.php
+++ b/app/Models/Mship/Concerns/HasMentoringPermissions.php
@@ -34,6 +34,11 @@ trait HasMentoringPermissions
             MentorPermissionService::pilotCategories()
         );
 
+        // Allow admins to bypass the individual category checks and see all categories
+        if ($this->can('training.mentoring.view.*')) {
+            return $allCategories;
+        }
+
         return collect($allCategories)
             ->filter(fn (string $cat) => $this->hasMentoringPermissionForCategory($cat))
             ->values()

--- a/app/Models/Mship/Concerns/HasMentoringPermissions.php
+++ b/app/Models/Mship/Concerns/HasMentoringPermissions.php
@@ -47,11 +47,19 @@ trait HasMentoringPermissions
 
     public function hasMentoringPermissionForCategory(string $category): bool
     {
+        if ($this->can('training.mentoring.view.*')) {
+            return true;
+        }
+
         return ! empty($this->getAssignedCallsignsForCategory($category));
     }
 
     public function hasMentoringPermissionForPosition(string $position): bool
     {
+        if ($this->can('training.mentoring.view.*')) {
+            return true;
+        }
+
         return in_array($position, $this->getAllAssignedCallsigns(), true);
     }
 

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -93,6 +93,8 @@ class RolesAndPermissionsSeeder extends Seeder
             'training.mentors.manage.atc',
             'training.mentors.manage.pilot',
 
+            'training.mentoring.view.*',
+
             // Account Permissions
             'account.self',
             'account.view-insensitive.*',


### PR DESCRIPTION
# Summary of changes
- adds `training.mentoring.view.*` which allows the user to view everything in the mentoring system irrelevant of assigned mentoring permissions

# Screenshots (if necessary)
