### PR TITLE
fix: allow viewing all positions with view all permission

### DIFF
--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -6,6 +6,7 @@ namespace App\Filament\Training\Pages\Mentor;
 
 use App\Filament\Training\Pages\Mentor\Base\BaseMentoringHistoryPage;
 use App\Repositories\Cts\SessionRepository;
+use App\Services\Training\MentorPermissionService;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Illuminate\Database\Eloquent\Builder;
@@ -91,7 +92,7 @@ class MentoringHistory extends BaseMentoringHistoryPage
         if ($user->can('training.mentoring.view.*')) {
             return app(MentorPermissionService::class)->getAllCtsCallsignsForCategory($this->category);
         }
-      
+
         return $this->category ? $user->getAssignedCallsignsForCategory($this->category) : $user->getAllAssignedCallsigns();
     }
 

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -83,6 +83,10 @@ class MentoringHistory extends BaseMentoringHistoryPage
 
     private function getVisibleCtsPositions(): array
     {
+        if (auth()->user()->can('training.mentoring.view.*')) {
+            return app(MentorPermissionService::class)->getAllCtsCallsignsForCategory($this->category);
+        }
+
         return app(MentorPermissionService::class)->getAssignedCtsCallsigns(auth()->user(), $this->category);
     }
 

--- a/app/Services/Training/MentorPermissionService.php
+++ b/app/Services/Training/MentorPermissionService.php
@@ -309,6 +309,24 @@ class MentorPermissionService
         return Carbon::parse($lastMentoredDate);
     }
 
+    public function getAllCtsCallsignsForCategory(string $category): array
+    {
+        if (self::categoryType($category) === 'atc') {
+            return TrainingPosition::where('category', $category)
+                ->get()
+                ->flatMap(fn ($tp) => $tp->cts_positions ?? [])
+                ->unique()
+                ->filter()
+                ->values()
+                ->toArray();
+        }
+
+        $qualCode = self::PILOT_CATEGORY_QUALIFICATION_MAP[$category] ?? null;
+        $callsign = $qualCode ? (self::QUALIFICATION_CTS_POSITION_MAP[$qualCode] ?? null) : null;
+
+        return $callsign ? [$callsign] : [];
+    }
+
     public function getAssignedCtsCallsigns(Account $account, string $category): array
     {
         $callsigns = collect();


### PR DESCRIPTION
# Summary of changes
- allow viewing all positions on mentoring history page with view all permission

# Screenshots (if necessary)
