### PR TITLE
feat: add no-show and cancellation callouts on view mentoring page

### DIFF
--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -138,7 +138,11 @@ class ViewMentoringReport extends Page implements HasInfolists
 
                     Callout::make('Session Cancelled')
                         ->heading(function (Session $record): string {
-                            $cancelledBy = $record->cancelReason->member->name;
+                            $cancelledBy = $record->cancelReason?->member?->name;
+
+                            if (! $cancelledBy) {
+                                return 'Session Cancelled';
+                            }
 
                             return "Session Cancelled by {$cancelledBy}";
                         })

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -179,7 +179,8 @@ class ViewMentoringReport extends Page implements HasInfolists
                                 ->count();
 
                             return [
-                                Text::make("Total student no-shows recorded: {$noShowCount}")
+                                Text::make('noShowCount')
+                                    ->content("Total student no-shows recorded: {$noShowCount}")
                                     ->color('gray'),
                             ];
                         })

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -11,16 +11,19 @@ use App\Livewire\Training\SessionCriteriaTable;
 use App\Models\Cts\Session;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Filament\Actions\Action;
 use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Concerns\InteractsWithInfolists;
 use Filament\Infolists\Contracts\HasInfolists;
 use Filament\Pages\Page;
+use Filament\Schemas\Components\Callout;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Text;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\FontWeight;
 use Filament\Support\Enums\TextSize;
@@ -56,6 +59,7 @@ class ViewMentoringReport extends Page implements HasInfolists
             'mentor',
             'reportSheets.field.category',
             'reportSheets.progSheet',
+            'cancelReason',
         ])->findOrFail($this->sessionId);
 
         $this->allSessions = Session::query()
@@ -131,6 +135,55 @@ class ViewMentoringReport extends Page implements HasInfolists
                     TextEntry::make('position')
                         ->label('Position & Time')
                         ->helperText(fn (Session $record) => Carbon::parse($record->taken_date)->format('d/m/Y').' | '.Carbon::parse($record->taken_from)->format('H:i').' - '.Carbon::parse($record->taken_to)->format('H:i')),
+
+                    Callout::make('Session Cancelled')
+                        ->heading(function (Session $record): string {
+                            $cancelledBy = $record->cancelReason->member->name;
+
+                            return "Session Cancelled by {$cancelledBy}";
+                        })
+                        ->description(function (Session $record): string {
+                            if (! $record->cancelReason) {
+                                return 'This session was cancelled, but no reason was provided.';
+                            }
+
+                            return $record->cancelReason->reason;
+                        })
+                        ->warning()
+                        ->footer(function (Session $record): array {
+                            if (! $record->cancelReason || ! $record->cancelled_datetime) {
+                                return [];
+                            }
+
+                            $sessionStart = Carbon::parse($record->taken_date.' '.$record->taken_from);
+                            $cancelDate = Carbon::parse($record->cancelled_datetime);
+
+                            $notice = $cancelDate->diffForHumans($sessionStart, ['syntax' => CarbonInterface::DIFF_ABSOLUTE, 'parts' => 2]).' notice given';
+
+                            return [
+                                Text::make('notice')
+                                    ->content($notice),
+                            ];
+                        })
+                        ->columnSpanFull()
+                        ->visible(fn (Session $record) => $record->cancelled_datetime !== null),
+
+                    Callout::make('Student No-Showed')
+                        ->description('This session has been marked as a student no-show.')
+                        ->columnSpanFull()
+                        ->danger()
+                        ->footer(function (Session $record): array {
+                            $noShowCount = Session::query()
+                                ->where('student_id', $record->student_id)
+                                ->where('noShow', true)
+                                ->count();
+
+                            return [
+                                Text::make("Total student no-shows recorded: {$noShowCount}")
+                                    ->color('gray'),
+                            ];
+                        })
+                        ->visible(fn (Session $record) => (bool) $record->noShow),
                 ]),
 
             Section::make('Additional Comments')

--- a/app/Models/Cts/Session.php
+++ b/app/Models/Cts/Session.php
@@ -44,4 +44,9 @@ class Session extends Model
     {
         return $this->hasOne(ReportNote::class, 'seshid', 'id');
     }
+
+    public function cancelReason(): HasOne
+    {
+        return $this->hasOne(CancelReason::class, 'sesh_id', 'id')->where('sesh_type', 'ME');
+    }
 }

--- a/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\TrainingPanel\Mentor;
 
 use App\Enums\FieldScore;
 use App\Filament\Training\Pages\Mentor\ViewMentoringReport;
+use App\Models\Cts\CancelReason;
 use App\Models\Cts\Member;
 use App\Models\Cts\ProgSheet;
 use App\Models\Cts\ProgSheetCategory;
@@ -575,5 +576,60 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
         Livewire::actingAs($newStudent)
             ->test(ViewMentoringReport::class, ['sessionId' => $bareSession->id])
             ->assertSee('No report data found for this session.');
+    }
+
+    #[Test]
+    public function test_it_displays_session_cancelled_callout_with_correct_details(): void
+    {
+        $cancellingMember = Member::factory()->create(['name' => 'John Doe']);
+
+        CancelReason::factory()->create([
+            'sesh_id' => $this->mentoringSession->id,
+            'sesh_type' => 'ME',
+            'reason' => 'Family emergency.',
+            'reason_by' => $cancellingMember->id,
+        ]);
+
+        $this->mentoringSession->update([
+            'cancelled_datetime' => '2025-03-15 16:00:00',
+        ]);
+
+        Livewire::actingAs($this->student)
+            ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
+            ->assertSee('Session Cancelled by John Doe')
+            ->assertSee('Family emergency.')
+            ->assertSee('2 hours notice given');
+    }
+
+    #[Test]
+    public function test_it_displays_student_no_show_callout_with_correct_historical_counter(): void
+    {
+        Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'noShow' => true,
+        ]);
+
+        $this->mentoringSession->update([
+            'noShow' => true,
+        ]);
+
+        Livewire::actingAs($this->student)
+            ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
+            ->assertSee('This session has been marked as a student no-show.')
+            ->assertSee('Total student no-shows recorded: 2');
+    }
+
+    #[Test]
+    public function test_it_hides_cancelled_and_no_show_callouts_when_session_is_normal(): void
+    {
+        $this->mentoringSession->update([
+            'cancelled_datetime' => null,
+            'noShow' => false,
+        ]);
+
+        Livewire::actingAs($this->student)
+            ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
+            ->assertDontSee('Session Cancelled by')
+            ->assertDontSee('This session has been marked as a student no-show.');
     }
 }


### PR DESCRIPTION
# Summary of changes
- Adds no-show and session cancellation callouts on view mentoring page

# Screenshots (if necessary)
<img width="1258" height="471" alt="image" src="https://github.com/user-attachments/assets/0538ad7e-d20a-4791-93ac-06a84306e0cf" />
