### PR TITLE
Ensure Discord roles for endorsements etc. are synced when roster reactivation occurs

### DIFF
--- a/app/Models/Roster.php
+++ b/app/Models/Roster.php
@@ -10,6 +10,8 @@ use App\Models\Mship\Account\Endorsement;
 use App\Models\Mship\Account\Note;
 use App\Models\Mship\Qualification;
 use App\Notifications\Roster\RemovedFromRoster;
+use App\Observers\RosterObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Facades\DB;
@@ -25,6 +27,7 @@ use Illuminate\Support\Facades\DB;
  *
  * @mixin \Eloquent
  */
+#[ObservedBy([RosterObserver::class])]
 class Roster extends Model
 {
     use HasFactory;

--- a/app/Observers/RosterObserver.php
+++ b/app/Observers/RosterObserver.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Observers;
+
+use App\Jobs\Mship\SyncToDiscord;
+use App\Models\Mship\Account;
+use App\Models\Roster;
+use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
+
+class RosterObserver implements ShouldHandleEventsAfterCommit
+{
+    public function created(Roster $roster): void
+    {
+        $this->syncAccountToDiscord($roster->account);
+    }
+
+    public function deleted(Roster $roster): void
+    {
+        $account = $roster->account ?? Account::find($roster->account_id);
+
+        $this->syncAccountToDiscord($account);
+    }
+
+    private function syncAccountToDiscord(?Account $account): void
+    {
+        if ($account?->discord_id) {
+            SyncToDiscord::dispatch($account);
+        }
+    }
+}

--- a/tests/Unit/Roster/RosterObserverTest.php
+++ b/tests/Unit/Roster/RosterObserverTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Roster;
+
+use App\Jobs\Mship\SyncToDiscord;
+use App\Models\Mship\Account;
+use App\Models\Roster;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class RosterObserverTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['services.discord.token' => null]);
+    }
+
+    #[Test]
+    public function it_dispatches_sync_to_discord_when_roster_is_created(): void
+    {
+        Queue::fake();
+
+        $account = Account::factory()->create();
+        $account->discord_id = 1234;
+        $account->saveQuietly();
+
+        Roster::create(['account_id' => $account->id]);
+
+        Queue::assertPushed(SyncToDiscord::class, 1);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_sync_when_account_has_no_discord(): void
+    {
+        Queue::fake();
+
+        $account = Account::factory()->create();
+
+        Roster::create(['account_id' => $account->id]);
+
+        Queue::assertNotPushed(SyncToDiscord::class);
+    }
+
+    #[Test]
+    public function it_dispatches_sync_to_discord_when_roster_is_deleted(): void
+    {
+        $account = Account::factory()->create();
+        $account->discord_id = 1234;
+        $account->saveQuietly();
+
+        $roster = new Roster(['account_id' => $account->id]);
+        $roster->saveQuietly();
+
+        Queue::fake();
+
+        $roster->delete();
+
+        Queue::assertPushed(SyncToDiscord::class, 1);
+    }
+}


### PR DESCRIPTION
Those re-activating on the roster weren't getting their Discord roles back.
