### PR TITLE
Add mentoring session history to local dev seeder

### DIFF
--- a/database/seeders/LocalDevelopment/README.md
+++ b/database/seeders/LocalDevelopment/README.md
@@ -104,8 +104,8 @@ Creates ad-hoc **training places** and related compliance data:
 
 | Scenario | Account | Callsign | Data |
 |----------|---------|----------|------|
-| Availability checks | `9000010` | `EGKK_TWR` | Passed + failed checks, pending warning, CTS `availability` |
-| Leave of absence | `9000011` | `EGLL_N_APP` | Active LOA on training place |
+| Availability checks | `9000010` | `EGKK_TWR` | Passed + failed checks, pending warning, CTS `availability`, mentoring session history |
+| Leave of absence | `9000011` | `EGLL_N_APP` | Active LOA on training place, mentoring session history |
 
 Requires `DevTrainingPersonasSeeder` and `AtcAndCtsTrainingPositionsSeeder` to have run first.
 
@@ -123,7 +123,7 @@ Seeds **CTS** practical exam and mentoring records for account `9000012`:
 | Scheduled exam (`taken=1`) + `practical_examiners` | Accepted exams / student pending exams |
 | Completed exam (`finished=1`) + `practical_results` | Exam history |
 | Cancelled exam + `cancel_reason` | Training place exam cancellations |
-| Completed + open mentoring `sessions` | Mentoring history |
+| Mentoring session history (completed, cancelled, no-show, upcoming) + open request | Training place mentoring history / mentor mentoring page |
 | Staff mentor on `EGKK_TWR` | Manage mentors |
 
 Staff (`9000001`) receives `ExaminerSettings` (TWR) and a `MentorTrainingPosition` via `MentorPermissionService`.
@@ -142,6 +142,7 @@ php artisan db:seed --class=Database\\Seeders\\LocalDevelopment\\Training\\CtsEx
 | `Concerns\CreatesLinkedAccount` | `firstOrCreate` mship `Account` + CTS `Member` + qualifications |
 | `Concerns\CreatesDevTrainingPlace` | Ad-hoc training place via `TrainingPlaceService` (CTS validations) |
 | `Concerns\SeedsCtsPosition` | `firstOrCreate` core `Position` and CTS `Position` for a callsign |
+| `Concerns\SeedsDevMentoringSessions` | Historical and pending CTS `sessions` for dev students |
 
 ## Idempotency
 

--- a/database/seeders/LocalDevelopment/Training/Concerns/SeedsDevMentoringSessions.php
+++ b/database/seeders/LocalDevelopment/Training/Concerns/SeedsDevMentoringSessions.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\LocalDevelopment\Training\Concerns;
+
+use App\Models\Cts\CancelReason;
+use App\Models\Cts\Member;
+use App\Models\Cts\Session;
+
+/**
+ * Idempotent CTS mentoring session fixtures for local development personas.
+ */
+trait SeedsDevMentoringSessions
+{
+    /**
+     * Completed, cancelled, and no-show sessions tied to a training place's CTS position.
+     */
+    protected function seedDevMentoringHistory(Member $student, Member $mentor, string $position): void
+    {
+        $this->upsertDevMentoringSession(
+            [
+                'student_id' => $student->id,
+                'position' => $position,
+                'taken_date' => now()->subDays(56)->format('Y-m-d'),
+                'session_done' => 1,
+            ],
+            [
+                'mentor_id' => $mentor->id,
+                'mentor_rating' => 3,
+                'taken' => 1,
+                'taken_time' => now()->subDays(56),
+                'taken_from' => '18:00:00',
+                'taken_to' => '20:00:00',
+                'cancelled_datetime' => null,
+                'noShow' => 0,
+                'request_time' => now()->subDays(63),
+            ],
+        );
+
+        $this->upsertDevMentoringSession(
+            [
+                'student_id' => $student->id,
+                'position' => $position,
+                'taken_date' => now()->subDays(28)->format('Y-m-d'),
+                'session_done' => 1,
+                'mentor_id' => $mentor->id,
+            ],
+            [
+                'mentor_rating' => 3,
+                'taken' => 1,
+                'taken_time' => now()->subDays(28),
+                'taken_from' => '19:30:00',
+                'taken_to' => '21:30:00',
+                'cancelled_datetime' => null,
+                'noShow' => 0,
+                'request_time' => now()->subDays(35),
+            ],
+        );
+
+        $cancelled = $this->upsertDevMentoringSession(
+            [
+                'student_id' => $student->id,
+                'position' => $position,
+                'taken_date' => now()->subDays(10)->format('Y-m-d'),
+                'cancelled_datetime' => now()->subDays(9),
+            ],
+            [
+                'mentor_id' => $mentor->id,
+                'mentor_rating' => 3,
+                'taken' => 1,
+                'session_done' => 0,
+                'taken_time' => now()->subDays(10),
+                'taken_from' => '14:00:00',
+                'taken_to' => '16:00:00',
+                'noShow' => 0,
+                'request_time' => now()->subDays(17),
+            ],
+        );
+
+        CancelReason::query()->updateOrCreate(
+            [
+                'sesh_id' => $cancelled->id,
+                'sesh_type' => 'ME',
+            ],
+            [
+                'reason' => 'Dev seed: student cancelled mentoring session.',
+                'used' => 0,
+                'reason_by' => $student->cid,
+                'date' => now()->subDays(9),
+            ],
+        );
+
+        $this->upsertDevMentoringSession(
+            [
+                'student_id' => $student->id,
+                'position' => $position,
+                'taken_date' => now()->subDays(21)->format('Y-m-d'),
+                'noShow' => 1,
+            ],
+            [
+                'mentor_id' => $mentor->id,
+                'mentor_rating' => 3,
+                'taken' => 1,
+                'session_done' => 0,
+                'taken_time' => now()->subDays(21),
+                'taken_from' => '20:00:00',
+                'taken_to' => '22:00:00',
+                'cancelled_datetime' => null,
+                'request_time' => now()->subDays(28),
+            ],
+        );
+
+        $this->upsertDevMentoringSession(
+            [
+                'student_id' => $student->id,
+                'position' => $position,
+                'taken_date' => now()->addDays(7)->format('Y-m-d'),
+                'session_done' => 0,
+                'mentor_id' => $mentor->id,
+            ],
+            [
+                'mentor_rating' => 3,
+                'taken' => 1,
+                'taken_time' => now()->addDays(7),
+                'taken_from' => '18:00:00',
+                'taken_to' => '20:00:00',
+                'cancelled_datetime' => null,
+                'noShow' => 0,
+                'request_time' => now()->subDays(3),
+            ],
+        );
+    }
+
+    /**
+     * Open mentoring request awaiting mentor acceptance.
+     */
+    protected function seedDevMentoringPendingRequest(Member $student, string $position): void
+    {
+        $this->upsertDevMentoringSession(
+            [
+                'student_id' => $student->id,
+                'position' => $position,
+                'session_done' => 0,
+                'mentor_id' => null,
+            ],
+            [
+                'taken' => 0,
+                'request_time' => now()->subDay(),
+            ],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $match
+     * @param  array<string, mixed>  $attributes
+     */
+    private function upsertDevMentoringSession(array $match, array $attributes): Session
+    {
+        return Session::query()->updateOrCreate(
+            $match,
+            array_merge([
+                'rts_id' => 1,
+                'student_rating' => 1,
+                'progress_sheet_id' => 0,
+            ], $attributes),
+        );
+    }
+}

--- a/database/seeders/LocalDevelopment/Training/CtsExamsAndMentoringSeeder.php
+++ b/database/seeders/LocalDevelopment/Training/CtsExamsAndMentoringSeeder.php
@@ -13,12 +13,12 @@ use App\Models\Cts\ExamSetup;
 use App\Models\Cts\Member;
 use App\Models\Cts\PracticalExaminers;
 use App\Models\Cts\PracticalResult;
-use App\Models\Cts\Session;
 use App\Services\Training\MentorPermissionService;
 use Database\Seeders\LocalDevelopment\Training\Concerns\AssignsDevTrainingRoles;
 use Database\Seeders\LocalDevelopment\Training\Concerns\CreatesDevTrainingPlace;
 use Database\Seeders\LocalDevelopment\Training\Concerns\CreatesLinkedAccount;
 use Database\Seeders\LocalDevelopment\Training\Concerns\SeedsCtsPosition;
+use Database\Seeders\LocalDevelopment\Training\Concerns\SeedsDevMentoringSessions;
 use Illuminate\Database\Seeder;
 use RuntimeException;
 
@@ -33,6 +33,7 @@ class CtsExamsAndMentoringSeeder extends Seeder
     use CreatesDevTrainingPlace;
     use CreatesLinkedAccount;
     use SeedsCtsPosition;
+    use SeedsDevMentoringSessions;
 
     public function run(): void
     {
@@ -92,7 +93,8 @@ class CtsExamsAndMentoringSeeder extends Seeder
         $this->seedScheduledExam($examStudentMember, $staffMember);
         $this->seedCompletedExam($examStudentMember, $staffMember);
         $this->seedCancelledExam($examStudentMember);
-        $this->seedMentoringSessions($examStudentMember, $staffMember);
+        $this->seedDevMentoringHistory($examStudentMember, $staffMember, 'EGKK_TWR');
+        $this->seedDevMentoringPendingRequest($examStudentMember, 'EGKK_TWR');
         $this->seedMentorAssignment();
 
         $this->command?->info('CTS exams, sessions, and mentor assignment seeded.');
@@ -249,46 +251,6 @@ class CtsExamsAndMentoringSeeder extends Seeder
                 'used' => 0,
                 'reason_by' => $student->cid,
                 'date' => now()->subDays(2),
-            ],
-        );
-    }
-
-    private function seedMentoringSessions(Member $student, Member $mentor): void
-    {
-        Session::query()->updateOrCreate(
-            [
-                'student_id' => $student->id,
-                'position' => 'EGKK_TWR',
-                'session_done' => 1,
-            ],
-            [
-                'rts_id' => 1,
-                'student_rating' => 1,
-                'mentor_id' => $mentor->id,
-                'mentor_rating' => 3,
-                'taken_date' => now()->subDays(14)->format('Y-m-d'),
-                'taken_time' => now()->subDays(14),
-                'taken_from' => '19:00:00',
-                'taken_to' => '21:00:00',
-                'cancelled_datetime' => null,
-                'noShow' => 0,
-                'request_time' => now()->subDays(21),
-                'progress_sheet_id' => 0,
-            ],
-        );
-
-        Session::query()->updateOrCreate(
-            [
-                'student_id' => $student->id,
-                'position' => 'EGKK_TWR',
-                'session_done' => 0,
-                'mentor_id' => null,
-            ],
-            [
-                'rts_id' => 1,
-                'student_rating' => 1,
-                'request_time' => now()->subDay(),
-                'progress_sheet_id' => 0,
             ],
         );
     }

--- a/database/seeders/LocalDevelopment/Training/TrainingPlaceAvailabilitySeeder.php
+++ b/database/seeders/LocalDevelopment/Training/TrainingPlaceAvailabilitySeeder.php
@@ -14,6 +14,7 @@ use Carbon\Carbon;
 use Database\Seeders\LocalDevelopment\Training\Concerns\AssignsDevTrainingRoles;
 use Database\Seeders\LocalDevelopment\Training\Concerns\CreatesDevTrainingPlace;
 use Database\Seeders\LocalDevelopment\Training\Concerns\CreatesLinkedAccount;
+use Database\Seeders\LocalDevelopment\Training\Concerns\SeedsDevMentoringSessions;
 use Illuminate\Database\Seeder;
 use RuntimeException;
 
@@ -27,6 +28,7 @@ class TrainingPlaceAvailabilitySeeder extends Seeder
     use AssignsDevTrainingRoles;
     use CreatesDevTrainingPlace;
     use CreatesLinkedAccount;
+    use SeedsDevMentoringSessions;
 
     public function run(): void
     {
@@ -49,13 +51,13 @@ class TrainingPlaceAvailabilitySeeder extends Seeder
 
         $this->seedAvailabilityChecksAndWarning($availabilityPlace);
 
-        $studentMemberId = Member::query()
-            ->where('cid', DevTrainingFoundation::$student->id)
-            ->value('id');
+        $staffMember = Member::query()->where('cid', DevTrainingFoundation::$staff->id)->firstOrFail();
+        $studentMember = Member::query()->where('cid', DevTrainingFoundation::$student->id)->firstOrFail();
+        $this->seedDevMentoringHistory($studentMember, $staffMember, 'EGKK_TWR');
 
         Availability::query()->updateOrCreate(
             [
-                'student_id' => $studentMemberId,
+                'student_id' => $studentMember->id,
                 'date' => now()->addDays(3)->format('Y-m-d'),
             ],
             [
@@ -83,7 +85,10 @@ class TrainingPlaceAvailabilitySeeder extends Seeder
             ],
         );
 
-        $this->command?->info('Training place availability, warnings, LOA, and CTS availability seeded.');
+        $loaStudentMember = Member::query()->where('cid', DevTrainingFoundation::$studentLoa->id)->firstOrFail();
+        $this->seedDevMentoringHistory($loaStudentMember, $staffMember, 'EGLL_N_APP');
+
+        $this->command?->info('Training place availability, warnings, LOA, mentoring history, and CTS availability seeded.');
     }
 
     private function ensurePrerequisites(): void

--- a/database/seeders/LocalDevelopmentTrainingSeeder.php
+++ b/database/seeders/LocalDevelopmentTrainingSeeder.php
@@ -64,19 +64,19 @@ class LocalDevelopmentTrainingSeeder extends Seeder
                     'Student',
                     (string) DevTrainingPersonas::STUDENT_CID,
                     DevTrainingPersonas::STUDENT_EMAIL,
-                    'Training place with availability checks / warning',
+                    'Training place with availability checks, warning, mentoring history',
                 ],
                 [
                     'Student (LOA)',
                     (string) DevTrainingPersonas::STUDENT_LOA_CID,
                     DevTrainingPersonas::STUDENT_LOA_EMAIL,
-                    'Active leave of absence on EGLL_N_APP',
+                    'LOA on EGLL_N_APP; mentoring history on training place',
                 ],
                 [
                     'Student (exams)',
                     (string) DevTrainingPersonas::STUDENT_EXAMS_CID,
                     DevTrainingPersonas::STUDENT_EXAMS_EMAIL,
-                    'Exam request, scheduled, completed, cancelled',
+                    'Exams + mentoring history; open mentoring request',
                 ],
             ],
         );

--- a/tests/Feature/Seeders/LocalDevelopmentTrainingSeederTest.php
+++ b/tests/Feature/Seeders/LocalDevelopmentTrainingSeederTest.php
@@ -96,7 +96,36 @@ class LocalDevelopmentTrainingSeederTest extends TestCase
         $this->assertTrue(CancelReason::query()->where('sesh_type', 'EX')->exists());
         $this->assertDatabaseHas('positions', ['callsign' => 'EGLL_N_TWR'], 'cts');
         $this->assertTrue(ExamSetup::query()->where('student_id', $examMemberId)->exists());
-        $this->assertTrue(Session::query()->where('student_id', $examMemberId)->exists());
+        $studentMemberId = Member::query()->where('cid', DevTrainingPersonas::STUDENT_CID)->value('id');
+        $loaMemberId = Member::query()->where('cid', DevTrainingPersonas::STUDENT_LOA_CID)->value('id');
+        $this->assertNotNull($studentMemberId);
+        $this->assertNotNull($loaMemberId);
+
+        foreach ([$studentMemberId, $loaMemberId, $examMemberId] as $memberId) {
+            $this->assertTrue(
+                Session::query()
+                    ->where('student_id', $memberId)
+                    ->where('session_done', 1)
+                    ->where('taken', 1)
+                    ->exists(),
+                "Expected completed mentoring sessions for CTS member {$memberId}",
+            );
+            $this->assertTrue(
+                Session::query()
+                    ->where('student_id', $memberId)
+                    ->whereNotNull('cancelled_datetime')
+                    ->exists(),
+                "Expected cancelled mentoring sessions for CTS member {$memberId}",
+            );
+        }
+
+        $this->assertTrue(
+            Session::query()
+                ->where('student_id', $examMemberId)
+                ->whereNull('mentor_id')
+                ->where('session_done', 0)
+                ->exists()
+        );
         $this->assertTrue(
             MentorTrainingPosition::query()->where('account_id', DevTrainingPersonas::STAFF_CID)->exists()
         );


### PR DESCRIPTION
## Summary

Adds realistic CTS mentoring session fixtures to the local development training seeders so all three student personas have data on their training places.

- Introduces `SeedsDevMentoringSessions` with idempotent completed, cancelled, no-show, and upcoming sessions (plus an open request for the exams persona).
- Seeds history on `EGKK_TWR` and `EGLL_N_APP` training places via `TrainingPlaceAvailabilitySeeder`, and on the exams student via `CtsExamsAndMentoringSeeder`.
- Sets `taken=1` on accepted sessions so they appear in training place mentoring history and stats widgets.

