### PR TITLE
Add table to show upcoming sessions and pending reports for TG

### DIFF
--- a/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
+++ b/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
@@ -38,84 +38,118 @@ abstract class BaseMentoringHistoryPage extends Page implements HasTable
         return true;
     }
 
+    protected function defaultTableSortDirection(): string
+    {
+        return 'desc';
+    }
+
+    protected function tableRecordActions(): array
+    {
+        return [
+            Action::make('view')
+                ->label('View Report')
+                ->url(fn ($record) => ViewMentoringReport::getUrl(['sessionId' => $record->id]))
+                ->visible(fn ($record) => $record->filed !== null)
+                ->openUrlInNewTab(),
+        ];
+    }
+
+    protected function tableEmptyStateHeading(): string
+    {
+        return 'No mentoring sessions found in this training group';
+    }
+
+    protected function includeStatusColumn(): bool
+    {
+        return true;
+    }
+
+    protected function includeStatusFilter(): bool
+    {
+        return true;
+    }
+
     public function table(Table $table): Table
     {
         return $table
             ->query($this->getSessionQuery())
-            ->defaultSort('taken_date', 'desc')
+            ->defaultSort('taken_date', $this->defaultTableSortDirection())
             ->striped()
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(25)
-            ->columns([
-                TextColumn::make('student_name')
-                    ->label('Student')
-                    ->getStateUsing(fn ($record) => $record->student->name)
-                    ->description(fn ($record) => $record->student->cid)
-                    ->action(function ($record, $livewire) {
-                        if (! $this->showStudentFilter()) {
-                            return;
-                        }
-
-                        $livewire->tableFilters['student']['value'] = $record->student->cid;
-                        $livewire->updatedTableFilters();
-                    }),
-
-                TextColumn::make('mentor_name')
-                    ->label('Mentor')
-                    ->getStateUsing(fn ($record) => $record->mentor->name)
-                    ->description(fn ($record) => $record->mentor->cid)
-                    ->action(function ($record, $livewire) {
-                        if (! $this->showMentorFilter()) {
-                            return;
-                        }
-
-                        $livewire->tableFilters['mentor']['value'] = $record->mentor->cid;
-                        $livewire->updatedTableFilters();
-                    }),
-
-                TextColumn::make('position')
-                    ->label('Position')
-                    ->badge()
-                    ->color('gray'),
-
-                TextColumn::make('taken_date')
-                    ->label('Date & Time')
-                    ->getStateUsing(function ($record) {
-                        $date = Carbon::parse($record->taken_date)->format('d/m/Y');
-                        $time = Carbon::parse($record->taken_from)->format('H:i');
-
-                        return trim("{$date} {$time}");
-                    })
-                    ->sortable(query: fn (Builder $query, string $direction) => $query
-                        ->orderBy('taken_date', $direction)
-                        ->orderBy('taken_from', $direction)
-                    ),
-
-                TextColumn::make('status')
-                    ->label('Status')
-                    ->badge()
-                    ->getStateUsing(fn ($record) => match (true) {
-                        $record->noShow == 1 => 'No Show',
-                        $record->cancelled_datetime !== null => 'Cancelled',
-                        $record->filed !== null => 'Completed',
-                        default => 'Pending',
-                    })
-                    ->color(fn ($state) => match ($state) {
-                        'Pending' => 'primary',
-                        'No Show' => 'danger',
-                        'Cancelled' => 'warning',
-                        'Completed' => 'success',
-                    }),
-            ])
+            ->columns($this->getTableColumns())
             ->filters($this->getTableFilters())
-            ->recordActions([
-                Action::make('view')
-                    ->label('View Report')
-                    ->url(fn ($record) => ViewMentoringReport::getUrl(['sessionId' => $record->id]))
-                    ->visible(fn ($record) => $record->filed !== null)
-                    ->openUrlInNewTab(),
-            ])
-            ->emptyStateHeading('No mentoring sessions found in this training group');
+            ->recordActions($this->tableRecordActions())
+            ->emptyStateHeading($this->tableEmptyStateHeading());
+    }
+
+    protected function getTableColumns(): array
+    {
+        $columns = [
+            TextColumn::make('student_name')
+                ->label('Student')
+                ->getStateUsing(fn ($record) => $record->student->name)
+                ->description(fn ($record) => $record->student->cid)
+                ->action(function ($record, $livewire) {
+                    if (! $this->showStudentFilter()) {
+                        return;
+                    }
+
+                    $livewire->tableFilters['student']['value'] = $record->student->cid;
+                    $livewire->updatedTableFilters();
+                }),
+
+            TextColumn::make('mentor_name')
+                ->label('Mentor')
+                ->getStateUsing(fn ($record) => $record->mentor->name)
+                ->description(fn ($record) => $record->mentor->cid)
+                ->action(function ($record, $livewire) {
+                    if (! $this->showMentorFilter()) {
+                        return;
+                    }
+
+                    $livewire->tableFilters['mentor']['value'] = $record->mentor->cid;
+                    $livewire->updatedTableFilters();
+                }),
+
+            TextColumn::make('position')
+                ->label('Position')
+                ->badge()
+                ->color('gray'),
+
+            TextColumn::make('taken_date')
+                ->label('Date & Time')
+                ->getStateUsing(function ($record) {
+                    $date = Carbon::parse($record->taken_date)->format('d/m/Y');
+                    $time = Carbon::parse($record->taken_from)->format('H:i');
+
+                    return trim("{$date} {$time}");
+                })
+                ->sortable(query: fn (Builder $query, string $direction) => $query
+                    ->orderBy('taken_date', $direction)
+                    ->orderBy('taken_from', $direction)
+                ),
+        ];
+
+        if ($this->includeStatusColumn()) {
+            $columns[] = TextColumn::make('status')
+                ->label('Status')
+                ->badge()
+                ->getStateUsing(fn ($record) => match (true) {
+                    $record->noShow == 1 => 'No Show',
+                    $record->cancelled_datetime !== null => 'Cancelled',
+                    $record->filed !== null => 'Completed',
+                    default => 'Pending',
+                })
+                ->color(fn ($state) => match ($state) {
+                    'Pending' => 'primary',
+                    'No Show' => 'danger',
+                    'Cancelled' => 'warning',
+                    'Completed' => 'success',
+                });
+        }
+
+        return $columns;
     }
 
     private function getTableFilters(): array
@@ -154,7 +188,10 @@ abstract class BaseMentoringHistoryPage extends Page implements HasTable
                 ));
         }
 
-        $filters[] = $this->statusFilter();
+        if ($this->includeStatusFilter()) {
+            $filters[] = $this->statusFilter();
+        }
+
         $filters[] = $this->dateRangeFilter();
 
         return $filters;

--- a/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
+++ b/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Pages\Mentor;
+
+use App\Filament\Training\Pages\Mentor\Base\BaseMentoringHistoryPage;
+use App\Repositories\Cts\SessionRepository;
+use App\Services\Training\MentorPermissionService;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Attributes\Url;
+
+class UpcomingMentoringSessions extends BaseMentoringHistoryPage
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-calendar-days';
+
+    protected string $view = 'filament.training.pages.upcoming-mentoring-sessions';
+
+    protected static ?int $navigationSort = 25;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Mentoring';
+
+    protected static ?string $title = 'Upcoming Sessions';
+
+    protected static ?string $navigationLabel = 'Upcoming Sessions';
+
+    #[Url]
+    public string $category = '';
+
+    public static function canAccess(): bool
+    {
+        if (! app()->runningUnitTests() && ! auth()->user()?->can('training.beta')) {
+            return false;
+        }
+
+        if (auth()->user()?->can('training.mentoring.view.*')) {
+            return true;
+        }
+
+        return auth()->user()?->can('training.mentors.view.atc')
+            || auth()->user()?->can('training.mentors.view.pilot');
+    }
+
+    public function mount(): void
+    {
+        if (empty($this->category) || ! $this->canViewCategory($this->category)) {
+            $this->category = $this->firstVisibleCategory() ?? '';
+        }
+    }
+
+    protected function getHeaderActions(): array
+    {
+        $allCategories = collect(MentorPermissionService::atcCategories())
+            ->merge(MentorPermissionService::pilotCategories());
+
+        return [
+            ActionGroup::make(
+                $allCategories
+                    ->filter(fn (string $cat) => $this->canViewCategory($cat))
+                    ->map(fn (string $cat) => Action::make('cat_'.str($cat)->slug('_'))
+                        ->label($cat)
+                        ->url(static::getUrl(['category' => $cat]))
+                        ->icon($this->category === $cat ? 'heroicon-m-check' : null)
+                    )
+                    ->all()
+            )
+                ->label('Training Group: '.($this->category ?: 'All'))
+                ->icon('heroicon-m-chevron-down')
+                ->color('gray')
+                ->button(),
+        ];
+    }
+
+    public function table(Table $table): Table
+    {
+        return parent::table($table)
+            ->heading('Upcoming Sessions')
+            ->description('Accepted mentoring sessions scheduled for the future.');
+    }
+
+    protected function getSessionQuery(): Builder
+    {
+        return (new SessionRepository)
+            ->getUpcomingAcceptedSessionsForPositionsQuery($this->getVisibleCtsPositions());
+    }
+
+    protected function getPositionFilterOptions(): array
+    {
+        $positions = $this->getVisibleCtsPositions();
+
+        return array_combine($positions, $positions);
+    }
+
+    protected function defaultTableSortDirection(): string
+    {
+        return 'asc';
+    }
+
+    protected function tableRecordActions(): array
+    {
+        return [];
+    }
+
+    protected function tableEmptyStateHeading(): string
+    {
+        return 'No upcoming mentoring sessions in this training group';
+    }
+
+    protected function includeStatusColumn(): bool
+    {
+        return false;
+    }
+
+    protected function includeStatusFilter(): bool
+    {
+        return false;
+    }
+
+    private function getVisibleCtsPositions(): array
+    {
+        if (empty($this->category)) {
+            return [];
+        }
+
+        return app(MentorPermissionService::class)->getAllCtsCallsignsForCategory($this->category);
+    }
+
+    private function canViewCategory(string $category): bool
+    {
+        if (auth()->user()->can('training.mentoring.view.*')) {
+            return true;
+        }
+
+        return auth()->user()->can('training.mentors.view.'.MentorPermissionService::categoryType($category));
+    }
+
+    private function firstVisibleCategory(): ?string
+    {
+        return collect(MentorPermissionService::atcCategories())
+            ->merge(MentorPermissionService::pilotCategories())
+            ->first(fn (string $cat) => $this->canViewCategory($cat));
+    }
+}

--- a/app/Livewire/Training/PendingMentoringReportsTable.php
+++ b/app/Livewire/Training/PendingMentoringReportsTable.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Training;
+
+use App\Models\Cts\Session;
+use App\Repositories\Cts\SessionRepository;
+use App\Services\Training\MentorPermissionService;
+use Carbon\Carbon;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Component;
+
+class PendingMentoringReportsTable extends Component implements HasActions, HasForms, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+    use InteractsWithTable;
+
+    public string $category = '';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->heading('Pending Reports')
+            ->description('Accepted sessions that have taken place but do not yet have a filed mentoring report.')
+            ->query(
+                (new SessionRepository)->getPendingReportSessionsForPositionsQuery(
+                    $this->getVisibleCtsPositions()
+                )
+            )
+            ->defaultSort('taken_date', 'asc')
+            ->striped()
+            ->paginated([10, 25, 50, 100])
+            ->defaultPaginationPageOption(25)
+            ->columns([
+                TextColumn::make('student_name')
+                    ->label('Student')
+                    ->getStateUsing(fn (Session $record) => $record->student->name)
+                    ->description(fn (Session $record) => $record->student->cid),
+
+                TextColumn::make('mentor_name')
+                    ->label('Mentor')
+                    ->getStateUsing(fn (Session $record) => $record->mentor->name)
+                    ->description(fn (Session $record) => $record->mentor->cid),
+
+                TextColumn::make('position')
+                    ->label('Position')
+                    ->badge()
+                    ->color('gray'),
+
+                TextColumn::make('taken_date')
+                    ->label('Date & Time')
+                    ->getStateUsing(function (Session $record) {
+                        $date = Carbon::parse($record->taken_date)->format('d/m/Y');
+                        $time = Carbon::parse($record->taken_from)->format('H:i');
+
+                        return trim("{$date} {$time}");
+                    })
+                    ->sortable(query: fn (Builder $query, string $direction) => $query
+                        ->orderBy('taken_date', $direction)
+                        ->orderBy('taken_from', $direction)
+                    ),
+            ])
+            ->emptyStateHeading('No pending mentoring reports in this training group');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getVisibleCtsPositions(): array
+    {
+        if (empty($this->category)) {
+            return [];
+        }
+
+        return app(MentorPermissionService::class)->getAllCtsCallsignsForCategory($this->category);
+    }
+
+    public function render()
+    {
+        return view('livewire.training.pending-mentoring-reports-table');
+    }
+}

--- a/app/Repositories/Cts/SessionRepository.php
+++ b/app/Repositories/Cts/SessionRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repositories\Cts;
 
 use App\Models\Cts\Session;
+use Illuminate\Database\Eloquent\Builder;
 
 class SessionRepository
 {
@@ -26,6 +27,26 @@ class SessionRepository
             })
             ->whereIn('position', $positionCallsigns)
             ->where('taken', 1);
+    }
+
+    public function getUpcomingAcceptedSessionsForPositionsQuery(array $positionCallsigns): Builder
+    {
+        return $this->getAllAcceptedSessionsForPositionsQuery($positionCallsigns)
+            ->whereNotNull('mentor_id')
+            ->whereNull('filed')
+            ->whereNull('cancelled_datetime')
+            ->where('noShow', 0)
+            ->where('taken_date', '>=', now());
+    }
+
+    public function getPendingReportSessionsForPositionsQuery(array $positionCallsigns): Builder
+    {
+        return $this->getAllAcceptedSessionsForPositionsQuery($positionCallsigns)
+            ->whereNotNull('mentor_id')
+            ->whereNull('filed')
+            ->whereNull('cancelled_datetime')
+            ->where('noShow', 0)
+            ->where('taken_date', '<', now());
     }
 
     public function getTotalSessionsForPosition(string $positionCallsign)

--- a/resources/views/filament/training/pages/upcoming-mentoring-sessions.blade.php
+++ b/resources/views/filament/training/pages/upcoming-mentoring-sessions.blade.php
@@ -1,0 +1,7 @@
+<x-filament-panels::page>
+	<div class="space-y-6">
+		{{ $this->table }}
+
+		<livewire:training.pending-mentoring-reports-table :category="$this->category" :key="'pending-mentoring-reports-' . $this->category" />
+	</div>
+</x-filament-panels::page>

--- a/resources/views/livewire/training/pending-mentoring-reports-table.blade.php
+++ b/resources/views/livewire/training/pending-mentoring-reports-table.blade.php
@@ -1,0 +1,3 @@
+<div>
+	{{ $this->table }}
+</div>

--- a/tests/Feature/TrainingPanel/Mentor/UpcomingMentoringSessionsTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/UpcomingMentoringSessionsTest.php
@@ -1,0 +1,503 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\Mentor;
+
+use App\Filament\Training\Pages\Mentor\UpcomingMentoringSessions;
+use App\Livewire\Training\PendingMentoringReportsTable;
+use App\Models\Cts\Member;
+use App\Models\Cts\Position as CtsPosition;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\MentorPermissionService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class UpcomingMentoringSessionsTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_loads_when_user_has_atc_view_permission(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGLL_GND');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class)
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_is_forbidden_when_user_has_no_view_permission(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_defaults_to_the_first_visible_category_when_category_is_empty(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGLL_GND');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class)
+            ->assertSet('category', $category);
+    }
+
+    #[Test]
+    public function it_defaults_to_the_first_visible_category_when_category_is_invalid(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGLL_GND');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => 'Not A Real Category'])
+            ->assertSet('category', $category);
+    }
+
+    #[Test]
+    public function it_shows_future_accepted_sessions_for_the_selected_category(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPH_GND');
+
+        $mentor = Account::factory()->create();
+        $mentorCtsMember = $this->getOrCreateCtsMember($mentor);
+
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPH_GND',
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertCanSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function it_does_not_show_past_sessions(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPK_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPK_GND',
+            takenDate: Carbon::yesterday()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertCanNotSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function it_does_not_show_filed_sessions(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPL_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPL_GND',
+            filed: now()->toDateTimeString(),
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertCanNotSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function it_does_not_show_cancelled_sessions(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPQ_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPQ_GND',
+            cancelledDatetime: now()->toDateTimeString(),
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertCanNotSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function it_does_not_show_no_show_sessions(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPR_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPR_GND',
+            noShow: 1,
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertCanNotSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function it_shows_sessions_for_the_selected_category_only(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $categoryOne = MentorPermissionService::atcCategories()[0];
+        $categoryTwo = MentorPermissionService::atcCategories()[1];
+
+        $this->createTrainingPosition($categoryOne, 'EGKK_GND');
+        $this->createTrainingPosition($categoryTwo, 'EGKK_TWR');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $tomorrow = Carbon::tomorrow()->format('Y-m-d H:i:s');
+
+        $sessionInCategory = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGKK_GND', takenDate: $tomorrow);
+        $sessionOutOfCategory = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGKK_TWR', takenDate: $tomorrow);
+
+        $sessionInRecord = Session::on('cts')->find($sessionInCategory);
+        $sessionOutRecord = Session::on('cts')->find($sessionOutOfCategory);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $categoryOne])
+            ->assertCanSeeTableRecords([$sessionInRecord])
+            ->assertCanNotSeeTableRecords([$sessionOutRecord]);
+    }
+
+    #[Test]
+    public function it_shows_sessions_for_all_positions_in_the_training_group(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGKK_GND');
+        $this->createTrainingPosition($category, 'EGKK_TWR');
+
+        $otherMentor = Account::factory()->create();
+        $otherMentorCtsMember = $this->getOrCreateCtsMember($otherMentor);
+
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $otherMentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGKK_TWR',
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertCanSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function it_has_no_table_record_actions(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPF_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPF_GND',
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertCanSeeTableRecords([$session])
+            ->assertDontSee('View Report');
+    }
+
+    #[Test]
+    public function it_displays_an_empty_state_when_no_upcoming_sessions_exist(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPO_GND');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertSee('No upcoming mentoring sessions in this training group');
+    }
+
+    #[Test]
+    public function pending_reports_table_shows_past_sessions_without_filed_reports(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPD_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPD_GND',
+            takenDate: Carbon::yesterday()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(PendingMentoringReportsTable::class, ['category' => $category])
+            ->assertCanSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function pending_reports_table_does_not_show_future_sessions(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPE_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPE_GND',
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(PendingMentoringReportsTable::class, ['category' => $category])
+            ->assertCanNotSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function pending_reports_table_does_not_show_filed_sessions(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPJ_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPJ_GND',
+            filed: now()->toDateTimeString(),
+            takenDate: Carbon::yesterday()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(PendingMentoringReportsTable::class, ['category' => $category])
+            ->assertCanNotSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function pending_reports_table_does_not_show_cancelled_or_no_show_sessions(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPM_GND');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $yesterday = Carbon::yesterday()->format('Y-m-d H:i:s');
+
+        $cancelledId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPM_GND',
+            cancelledDatetime: now()->toDateTimeString(),
+            takenDate: $yesterday,
+        );
+        $noShowId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPM_GND',
+            noShow: 1,
+            takenDate: $yesterday,
+        );
+
+        $cancelledSession = Session::on('cts')->find($cancelledId);
+        $noShowSession = Session::on('cts')->find($noShowId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(PendingMentoringReportsTable::class, ['category' => $category])
+            ->assertCanNotSeeTableRecords([$cancelledSession, $noShowSession]);
+    }
+
+    #[Test]
+    public function pending_reports_table_scopes_to_the_selected_category(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $categoryOne = MentorPermissionService::atcCategories()[0];
+        $categoryTwo = MentorPermissionService::atcCategories()[1];
+
+        $this->createTrainingPosition($categoryOne, 'EGPC_GND');
+        $this->createTrainingPosition($categoryTwo, 'EGPC_TWR');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $yesterday = Carbon::yesterday()->format('Y-m-d H:i:s');
+
+        $sessionInCategory = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGPC_GND', takenDate: $yesterday);
+        $sessionOutOfCategory = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGPC_TWR', takenDate: $yesterday);
+
+        $sessionInRecord = Session::on('cts')->find($sessionInCategory);
+        $sessionOutRecord = Session::on('cts')->find($sessionOutOfCategory);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(PendingMentoringReportsTable::class, ['category' => $categoryOne])
+            ->assertCanSeeTableRecords([$sessionInRecord])
+            ->assertCanNotSeeTableRecords([$sessionOutRecord]);
+    }
+
+    #[Test]
+    public function the_page_renders_the_pending_reports_section(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPN_GND');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertSee('Pending Reports')
+            ->assertSee('Upcoming Sessions');
+    }
+
+    private function createTrainingPosition(string $category, string $callsign): TrainingPosition
+    {
+        CtsPosition::firstOrCreate(['callsign' => $callsign]);
+
+        return TrainingPosition::factory()->create([
+            'category' => $category,
+            'cts_positions' => [$callsign],
+        ]);
+    }
+
+    private function insertSession(
+        int $mentorId,
+        int $studentId,
+        string $position,
+        int $taken = 1,
+        int $noShow = 0,
+        ?string $filed = null,
+        ?string $cancelledDatetime = null,
+        ?string $takenDate = null,
+    ): int {
+        return DB::connection('cts')->table('sessions')->insertGetId([
+            'mentor_id' => $mentorId,
+            'student_id' => $studentId,
+            'position' => $position,
+            'progress_sheet_id' => 1,
+            'taken' => $taken,
+            'session_done' => $filed !== null ? 1 : 0,
+            'noShow' => $noShow,
+            'filed' => $filed,
+            'cancelled_datetime' => $cancelledDatetime,
+            'taken_date' => $takenDate ?? now()->format('Y-m-d H:i:s'),
+            'taken_from' => '10:00:00',
+        ]);
+    }
+
+    private function getOrCreateCtsMember(Account $account): Member
+    {
+        return Member::on('cts')->firstOrCreate(
+            ['cid' => $account->id],
+            [
+                'id' => $account->id,
+                'old_rts_id' => 0,
+                'name' => $account->name,
+                'joined' => now(),
+                'joined_div' => now(),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes **TECH-595** — adds an **Upcoming Sessions** page to the Training Panel Mentoring group so TGIs can monitor accepted mentoring sessions across their training group.

The page has two read-only tables:

1. **Upcoming Sessions** — future accepted sessions (`taken_date >= now`) that are active (not filed, cancelled, or no-show).
2. **Pending Reports** — past accepted sessions (`taken_date < now`) that still have no filed mentoring report.

This replicates the CTS “upcoming sessions” view for TGIs without ASR monitoring or session management actions (no cancel/reschedule).

## Changes

### New page
- **`UpcomingMentoringSessions`** (`/training/upcoming-mentoring-sessions`) — Filament page in the Mentoring nav group (sort 25, between Mentoring and History).
- Training group selector (URL `?category=`) — same pattern as Manage Mentors.
- Scoped to **all positions** in the selected TG via `MentorPermissionService::getAllCtsCallsignsForCategory()`.

### Repository
- **`SessiontUpcomingAcceptedSessionsForPositionsQuery()`** — future active accepted sessions.
- **`SessionRepository::getPendingReportSessionsForPositionsQuery()`** — past active accepted sessions awaiting reports.

### Shared table base
- **`BaseMentoringHistoryPage`** — refactored with hooks for sort direction, record actions, empty state, and optional status column/filter (used by History and Upcoming without duplicating table setup).

### Livewire
- **`PendingMentoringReportsTable`** — embedded on the Upcoming Sessions page; respects the selected training group category.

## Access control

Page is available to users with:

- `training.mentors.view.atc` or `training.mentors.view.pilot`, or
- `training.mentoring.view.*`

Also gated by `training.beta` outside unit tests (consistent with other Mentoring pages).

