### PR TITLE
Validate non epoc time is set when date is not overriden on waiting list add

### DIFF
--- a/app/Filament/Training/Resources/WaitingLists/Pages/ViewWaitingList.php
+++ b/app/Filament/Training/Resources/WaitingLists/Pages/ViewWaitingList.php
@@ -41,7 +41,7 @@ class ViewWaitingList extends ViewRecord
                 ->action(function ($data, $action) {
                     $account = Account::find($data['account_id']);
                     $joinDate = Arr::get($data, 'join_date');
-                    $createdAt = $joinDate ? new Carbon($joinDate) : null;
+                    $createdAt = filled($joinDate) ? Carbon::parse($joinDate) : null;
                     $this->record->addToWaitingList($account, auth()->user(), $createdAt);
 
                     $action->success();
@@ -81,7 +81,10 @@ class ViewWaitingList extends ViewRecord
                         ->required(),
                     DatePicker::make('join_date')
                         ->visible(fn () => auth()->user()->can('addAccountsAdmin', $this->record))
-                        ->helperText('This field should only be used to override the date a member joined the waiting list. It is only available to admin-level users..'),
+                        ->nullable()
+                        ->rules(['nullable', 'date', 'after:1970-01-01', 'before_or_equal:today'])
+                        ->maxDate(now())
+                        ->helperText('This field should only be used to override the date a member joined the waiting list. It is only available to admin-level users.'),
                 ])
                 ->visible(fn () => auth()->user()->can('addAccounts', $this->record)),
 

--- a/tests/Feature/TrainingPanel/WaitingLists/Pages/ViewWaitingListPageTest.php
+++ b/tests/Feature/TrainingPanel/WaitingLists/Pages/ViewWaitingListPageTest.php
@@ -158,6 +158,61 @@ class ViewWaitingListPageTest extends BaseTrainingPanelTestCase
         ]);
     }
 
+    public function test_admin_can_add_student_without_join_date()
+    {
+        /** @var WaitingList $waitingList */
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
+        $accountToAdd = Account::factory()->create();
+        $accountToAdd->addState(State::findByCode('DIVISION'));
+
+        $this->panelUser->givePermissionTo('waiting-lists.view.atc');
+        $this->panelUser->givePermissionTo('waiting-lists.access');
+        $this->panelUser->givePermissionTo('waiting-lists.add-accounts.*');
+        $this->panelUser->givePermissionTo('waiting-lists.add-accounts-admin.*');
+
+        Livewire::actingAs($this->panelUser);
+        Livewire::test(ViewWaitingList::class, ['record' => $waitingList->id])
+            ->callAction('add_student', data: [
+                'account_id' => $accountToAdd->id,
+            ]);
+
+        $this->assertTrue($waitingList->includesAccount($accountToAdd->id));
+
+        $this->assertDatabaseHas('training_waiting_list_account', [
+            'list_id' => $waitingList->id,
+            'account_id' => $accountToAdd->id,
+            'created_at' => $this->knownDate,
+        ]);
+    }
+
+    public function test_admin_cannot_add_student_with_epoch_join_date()
+    {
+        /** @var WaitingList $waitingList */
+        $waitingList = WaitingList::factory()->create(['department' => 'atc']);
+        $accountToAdd = Account::factory()->create();
+        $accountToAdd->addState(State::findByCode('DIVISION'));
+
+        $this->panelUser->givePermissionTo('waiting-lists.view.atc');
+        $this->panelUser->givePermissionTo('waiting-lists.access');
+        $this->panelUser->givePermissionTo('waiting-lists.add-accounts.*');
+        $this->panelUser->givePermissionTo('waiting-lists.add-accounts-admin.*');
+
+        Livewire::actingAs($this->panelUser);
+        Livewire::test(ViewWaitingList::class, ['record' => $waitingList->id])
+            ->callAction('add_student', data: [
+                'account_id' => $accountToAdd->id,
+                'join_date' => '1970-01-01',
+            ])
+            ->assertHasActionErrors(['join_date']);
+
+        $this->assertFalse($waitingList->includesAccount($accountToAdd->id));
+
+        $this->assertDatabaseMissing('training_waiting_list_account', [
+            'list_id' => $waitingList->id,
+            'account_id' => $accountToAdd->id,
+        ]);
+    }
+
     public function test_admin_can_add_manual_flag_to_waiting_list()
     {
         $waitingList = WaitingList::factory()->create(['department' => 'atc']);


### PR DESCRIPTION
## Summary

Fixes TECH-608: admin users adding a student to a waiting list could trigger a `QueryException` when the optional join date override was empty or invalid.

When adding a student via the **Add student** action, admin users see an optional `join_date` field to backdate when someone joined the list. If Filament submitted an empty or invalid value (e.g. `1970-01-01`), the action passed it through to `WaitingList::addToWaitingList()`, which attempted to save `1970-01-01 00:00:00` as `created_at`. MySQL strict mode rejects that timestamp, causing the Livewire update to fail.

This PR validates the join date at the form layer and parses it safely, so only genuinely provided, valid dates are used as overrides. Leaving the field blank still defaults to today's date.

## Changes

**`ViewWaitingList.php`**
- Replaced the truthy `$joinDate ? new Carbon($joinDate) : null` check with `filled($joinDate) ? Carbon::parse($joinDate) : null`, so empty strings and other blank values correctly fall back to `now()`.
- Added validation on the `join_date` DatePicker: `nullable`, `date`, `after:1970-01-01`, `before_or_equal:today`.
- Added `->maxDate(now())` to prevent future dates in the UI.
- Marked the field explicitly as `->nullable()` to preserve optional override behaviour.

**`ViewWaitingListPageTest.php`**
- Added coverage for admin add without a join date (defaults to `now()`).
- Added coverage for rejecting an epoch join date (`1970-01-01`) with a validation error and no DB insert.

