### PR TITLE
Automatically unlink from Discord when DiscordUserNotFoundException raised

### DIFF
--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -63,48 +63,47 @@ trait HasDiscordAccount
 
         $suspendedRoleId = config('services.discord.suspended_member_role_id');
 
-        // Attempt to set user's nickname
         try {
             $discord->setNickname($this, $this->discordName);
-        } catch (DiscordUserNotFoundException $e) {
-            return event(new DiscordUnlinked($this));
-        }
 
-        // Retrieve users current roles
-        $currentRoles = $discord->getUserRoles($this);
+            // Retrieve users current roles
+            $currentRoles = $discord->getUserRoles($this);
 
-        if ($currentRoles === null) {
-            return;
-        }
-
-        if (! $currentRoles instanceof Collection) {
-            $currentRoles = collect($currentRoles);
-        }
-
-        // Handle if the user is banned on core
-        if ($this->isBanned) {
-            // If they are already in the suspended role, we are happy
-            if ($currentRoles->contains($suspendedRoleId)) {
+            if ($currentRoles === null) {
                 return;
             }
 
-            // Set their roles to only the suspended role (replaces all current roles
-            $discord->setRoles($this, [(int) $suspendedRoleId]);
+            if (! $currentRoles instanceof Collection) {
+                $currentRoles = collect($currentRoles);
+            }
 
-            return;
-        }
+            // Handle if the user is banned on core
+            if ($this->isBanned) {
+                // If they are already in the suspended role, we are happy
+                if ($currentRoles->contains($suspendedRoleId)) {
+                    return;
+                }
 
-        // Compute desired roles based on DiscordRoleRules
-        $targetRoles = $this->computeTargetRoles($currentRoles, $suspendedRoleId);
+                // Set their roles to only the suspended role (replaces all current roles
+                $discord->setRoles($this, [(int) $suspendedRoleId]);
 
-        // Only call the API if roles actually changed
-        if ($this->rolesNeedUpdate($currentRoles, $targetRoles)) {
-            Log::info("Updating Discord roles for {$this->full_name} ({$this->getKey()})", [
-                'current' => $currentRoles->toArray(),
-                'target' => $targetRoles->toArray(),
-            ]);
+                return;
+            }
 
-            $discord->setRoles($this, $targetRoles->values()->toArray());
+            // Compute desired roles based on DiscordRoleRules
+            $targetRoles = $this->computeTargetRoles($currentRoles, $suspendedRoleId);
+
+            // Only call the API if roles actually changed
+            if ($this->rolesNeedUpdate($currentRoles, $targetRoles)) {
+                Log::info("Updating Discord roles for {$this->full_name} ({$this->getKey()})", [
+                    'current' => $currentRoles->toArray(),
+                    'target' => $targetRoles->toArray(),
+                ]);
+
+                $discord->setRoles($this, $targetRoles->values()->toArray());
+            }
+        } catch (DiscordUserNotFoundException $e) {
+            return event(new DiscordUnlinked($this));
         }
     }
 

--- a/tests/Unit/Mship/HasDiscordAccountTest.php
+++ b/tests/Unit/Mship/HasDiscordAccountTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Unit\Mship;
 
+use App\Events\Discord\DiscordUnlinked;
 use App\Libraries\Discord;
 use App\Models\Discord\DiscordRoleRule;
 use App\Models\Mship\Account;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
 use Mockery\MockInterface;
 use Spatie\Permission\Models\Permission;
 use Tests\TestCase;
@@ -39,6 +42,50 @@ class HasDiscordAccountTest extends TestCase
         $this->user->syncPermissions([$permissionHas]);
 
         $this->user->syncToDiscord();
+    }
+
+    public function test_sync_to_discord_dispatches_discord_unlinked_when_nickname_unknown_member(): void
+    {
+        Event::fake([DiscordUnlinked::class]);
+        Config::set('services.discord.token', 'test-token');
+        Config::set('services.discord.guild_id', 123);
+
+        $account = Account::factory()->create(['discord_id' => 12345]);
+
+        Http::fake([
+            'discord.com/api/v6/guilds/*/members/12345' => Http::response(['message' => 'Unknown Member'], 404),
+        ]);
+
+        $account->syncToDiscord();
+
+        Event::assertDispatched(DiscordUnlinked::class, fn (DiscordUnlinked $event) => $event->account->is($account));
+    }
+
+    public function test_sync_to_discord_dispatches_discord_unlinked_when_set_roles_unknown_member(): void
+    {
+        Event::fake([DiscordUnlinked::class]);
+        Config::set('services.discord.token', 'test-token');
+        Config::set('services.discord.guild_id', 123);
+
+        $permissionHas = factory(Permission::class)->create(['name' => 'discord.test.role-1']);
+        $missingPermission = factory(Permission::class)->create(['name' => 'discord.test.role-2']);
+
+        DiscordRoleRule::factory()->create(['discord_id' => '1', 'permission_id' => $permissionHas]);
+        DiscordRoleRule::factory()->create(['discord_id' => '2', 'permission_id' => $missingPermission]);
+
+        $account = Account::factory()->create(['discord_id' => 12345]);
+        $account->syncPermissions([$permissionHas]);
+
+        Http::fake([
+            'discord.com/api/v6/guilds/*/members/12345' => Http::sequence()
+                ->push([], 204)
+                ->push(['roles' => ['2']], 200)
+                ->push(['message' => 'Unknown Member'], 404),
+        ]);
+
+        $account->syncToDiscord();
+
+        Event::assertDispatched(DiscordUnlinked::class, fn (DiscordUnlinked $event) => $event->account->is($account));
     }
 
     public function test_includes_cid_in_name()


### PR DESCRIPTION
## Summary

Fixes TECH-607 by auto-unlinking Core accounts when Discord returns **Unknown Member** (API code 10007) during sync.

`syncToDiscord()` already dispatched `DiscordUnlinked` when `setNickname` failed with a missing member, but `setRoles` was uncaught. That caused `SyncToDiscord` jobs to fail, retry, and report to Bugsnag when a user had left the guild (or their Discord account no longer existed) but Core still had a `discord_id`.

All Discord API calls in `syncToDiscord()` are now wrapped in a single `DiscordUserNotFoundException` handler that fires the existing `DiscordUnlinked` event. The queued `RemoveDiscordUser` listener clears `discord_id` as for manual unlinks; `kick()` already treats 404 as success when the member is already gone.

Also closes TECH-611 (same behaviour).

## Changes

- **HasDiscordAccount::syncToDiscord()** — Consolidated try/catch around nickname, role fetch, and both `setRoles` paths (normal sync and banned/suspended role).
- **HasDiscordAccountTest** — Two tesnickname 404 and `setRoles` 404 both assert `DiscordUnlinked` is dispatched.

