### PR TITLE
fix: hide bulk remove behind can manage

### DIFF
--- a/app/Filament/Training/Pages/Mentor/ManageMentors.php
+++ b/app/Filament/Training/Pages/Mentor/ManageMentors.php
@@ -137,6 +137,7 @@ class ManageMentors extends Page implements HasTable
                     ->label('Remove Selected')
                     ->icon('heroicon-o-x-mark')
                     ->color('danger')
+                    ->visible(fn () => $canManage && ! empty($this->category))
                     ->modalHeading(fn () => 'Remove Selected Mentors from '.$this->category)
                     ->modalSubheading('This will revoke all mentoring permissions for the selected members within this specific training group.')
                     ->action(function (Collection $records) {


### PR DESCRIPTION
# Summary of changes
- Hide bulk remove action behind manage permission

# Screenshots (if necessary)
