### PR TITLE
Add support for mandatory 2FA on configurable roles

### DIFF
--- a/app/Auth/LoginFlow.php
+++ b/app/Auth/LoginFlow.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth;
+
+use App\Models\Mship\Account;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
+use Symfony\Component\HttpFoundation\Response;
+
+class LoginFlow
+{
+    public static function redirectAfterVatsimOAuth(Request $request, Account $account): Response
+    {
+        if ($account->requiresMandatoryPasswordSetup()) {
+            return redirect()
+                ->route('login.password.setup')
+                ->withError('You are required to set a secondary password before continuing.');
+        }
+
+        if ($account->hasPassword()) {
+            return redirect()->route('auth-secondary');
+        }
+
+        return self::establishWebSession($request, $account, true);
+    }
+
+    public static function redirectAfterMandatoryPasswordSetup(Request $request, Account $account): Response
+    {
+        return self::establishWebSession($request, $account, true, passwordVerified: true);
+    }
+
+    public static function establishWebSession(
+        Request $request,
+        Account $account,
+        bool $remember,
+        bool $passwordVerified = false,
+    ): Response {
+        $intended = Session::pull('url.intended', route('site.home'));
+
+        Auth::login($account, $remember);
+
+        if ($response = TwoFactorLoginRedirect::afterSuccessfulLogin(
+            $request,
+            $account,
+            $remember,
+            $passwordVerified,
+        )) {
+            return $response;
+        }
+
+        return redirect($intended);
+    }
+}

--- a/app/Auth/TwoFactorLoginRedirect.php
+++ b/app/Auth/TwoFactorLoginRedirect.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth;
+
+use App\Models\Mship\Account;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class TwoFactorLoginRedirect
+{
+    public static function afterSuccessfulLogin(
+        Request $request,
+        Account $user,
+        bool $remember = false,
+        bool $passwordVerified = false,
+    ): ?Response {
+        if ($user->requiresTwoFactorChallenge()) {
+            $request->session()->put([
+                'login.id' => $user->getKey(),
+                'login.remember' => $remember,
+            ]);
+
+            if ($passwordVerified) {
+                $request->session()->put('auth.password_confirmed_at', now()->unix());
+            }
+
+            Auth::guard('web')->logout();
+
+            return redirect()->route('two-factor.login');
+        }
+
+        $request->session()->put('auth.password_confirmed_at', now()->unix());
+
+        return null;
+    }
+}

--- a/app/Filament/Admin/Resources/Roles/RoleResource.php
+++ b/app/Filament/Admin/Resources/Roles/RoleResource.php
@@ -13,6 +13,7 @@ use Filament\Actions\Action;
 use Filament\Actions\BulkAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
@@ -39,6 +40,10 @@ class RoleResource extends Resource
             ->components([
                 TextInput::make('name')->required()->unique(ignorable: fn ($record) => $record),
                 TextInput::make('guard_name')->default('web')->in(array_keys(config('auth.guards'))),
+                Checkbox::make('password_mandatory')
+                    ->label('Secondary password mandatory'),
+                Checkbox::make('two_factor_mandatory')
+                    ->label('Two-factor authentication mandatory'),
                 CheckboxList::make('permissions')
                     ->relationship('permissions', 'name')
                     ->columns(3)

--- a/app/Http/Controllers/Auth/ChangePasswordController.php
+++ b/app/Http/Controllers/Auth/ChangePasswordController.php
@@ -59,7 +59,16 @@ class ChangePasswordController extends BaseController
     {
         $this->authorize('create', 'password');
 
-        return $this->viewMake('auth.passwords.create');
+        return $this->viewMake('auth.passwords.create')->with($this->createFormViewData());
+    }
+
+    protected function createFormViewData(): array
+    {
+        return [
+            'heading' => 'Secondary Password',
+            'intro' => 'To create your secondary password, complete the form below.',
+            'formAction' => route('password.create'),
+        ];
     }
 
     public function create(Request $request)

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Auth\LoginFlow;
 use App\Http\Controllers\BaseController;
 use App\Models\Mship\Account;
 use App\Providers\VATSIMOAuthProvider;
@@ -9,7 +10,6 @@ use Carbon\Carbon;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Session;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 
 /**
@@ -80,15 +80,7 @@ class LoginController extends BaseController
 
         Auth::guard('vatsim-sso')->loginUsingId($account->id);
 
-        if ($account->hasPassword()) {
-            return redirect()->route('auth-secondary');
-        }
-
-        $intended = Session::pull('url.intended', route('site.home'));
-
-        Auth::login(Auth::guard('vatsim-sso')->user(), true);
-
-        return redirect($intended);
+        return LoginFlow::redirectAfterVatsimOAuth($request, $account);
     }
 
     protected function completeLogin(object $resourceOwner, object $token)

--- a/app/Http/Controllers/Auth/LoginPasswordSetupController.php
+++ b/app/Http/Controllers/Auth/LoginPasswordSetupController.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Auth;
+
+use App\Auth\LoginFlow;
+use App\Http\Controllers\BaseController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LoginPasswordSetupController extends BaseController
+{
+    public function show(Request $request)
+    {
+        if (! Auth::guard('vatsim-sso')->check()) {
+            return redirect()->route('login')
+                ->withError('Could not authenticate: VATSIM.net authentication is not present.');
+        }
+
+        $account = Auth::guard('vatsim-sso')->user();
+
+        if (! $account->requiresMandatoryPasswordSetup()) {
+            return $this->redirectAwayFromSetup($request, $account);
+        }
+
+        $this->authorize('setupDuringLogin', 'password');
+
+        return $this->viewMake('auth.passwords.create')->with([
+            'heading' => 'Secondary Password Required',
+            'intro' => 'Your role requires a secondary password. Create one below to continue signing in.',
+            'formAction' => route('login.password.setup.store'),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        if (! Auth::guard('vatsim-sso')->check()) {
+            return redirect()->route('login')
+                ->withError('Could not authenticate: VATSIM.net authentication is not present.');
+        }
+
+        $account = Auth::guard('vatsim-sso')->user();
+
+        $this->authorize('setupDuringLogin', 'password');
+
+        $this->validate($request, [
+            'new_password' => 'required|string|confirmed|min:8|upperchars:1|lowerchars:1|numbers:1',
+        ]);
+
+        $account->setPassword($request->input('new_password'));
+
+        return LoginFlow::redirectAfterMandatoryPasswordSetup($request, $account->fresh());
+    }
+
+    protected function redirectAwayFromSetup(Request $request, $account)
+    {
+        if ($account->hasPassword()) {
+            return redirect()->route('auth-secondary');
+        }
+
+        return LoginFlow::establishWebSession($request, $account, true);
+    }
+}

--- a/app/Http/Controllers/Auth/LogoutController.php
+++ b/app/Http/Controllers/Auth/LogoutController.php
@@ -3,13 +3,21 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\BaseController;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class LogoutController extends BaseController
 {
-    public function __invoke()
+    public function __invoke(Request $request)
     {
-        Auth::logout();
+        $request->session()->forget([
+            'login.id',
+            'login.remember',
+            'auth.password_confirmed_at',
+        ]);
+
+        Auth::guard('web')->logout();
+        Auth::guard('vatsim-sso')->logout();
 
         return redirect()->route('site.home');
     }

--- a/app/Http/Controllers/Auth/SecondaryLoginController.php
+++ b/app/Http/Controllers/Auth/SecondaryLoginController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Auth\TwoFactorLoginRedirect;
 use App\Http\Controllers\BaseController;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
@@ -43,5 +44,25 @@ class SecondaryLoginController extends BaseController
     protected function credentials(Request $request)
     {
         return ['id' => Auth::guard('vatsim-sso')->user()->id, 'password' => $request->input('password')];
+    }
+
+    protected function sendLoginResponse(Request $request)
+    {
+        $request->session()->regenerate();
+
+        $this->clearLoginAttempts($request);
+
+        $user = Auth::guard('web')->user();
+
+        if ($response = TwoFactorLoginRedirect::afterSuccessfulLogin(
+            $request,
+            $user,
+            $request->boolean('remember'),
+            passwordVerified: true,
+        )) {
+            return $response;
+        }
+
+        return redirect()->intended($this->redirectPath());
     }
 }

--- a/app/Http/Controllers/Auth/TwoFactorSetupController.php
+++ b/app/Http/Controllers/Auth/TwoFactorSetupController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\BaseController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class TwoFactorSetupController extends BaseController
+{
+    public function show(Request $request)
+    {
+        $user = Auth::user();
+
+        if ($user->hasEnabledTwoFactorAuthentication()) {
+            $this->setTitle('Two-Factor Authentication');
+
+            return $this->viewMake('auth.two-factor.manage')
+                ->with('recoveryCodes', $user->recoveryCodes());
+        }
+
+        $this->setTitle('Two-Factor Authentication Setup');
+
+        return $this->viewMake('auth.two-factor.setup')
+            ->with('pendingConfirmation', ! is_null($user->two_factor_secret) && is_null($user->two_factor_confirmed_at));
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -52,6 +52,7 @@ class Kernel extends HttpKernel
             'auth',
             'auth.record-info',
             'mandatorypasswords',
+            'mandatorytwofactor',
             'denyifbanned',
             'user.must.read.notifications',
             'redirecttointended',
@@ -80,6 +81,8 @@ class Kernel extends HttpKernel
         'api.tracking' => Middleware\ApiTracking::class,
         'denyifbanned' => Middleware\DenyIfBanned::class,
         'mandatorypasswords' => Middleware\MandatoryPasswords::class,
+        'mandatorytwofactor' => Middleware\MandatoryTwoFactor::class,
+        'password.confirm' => Middleware\RequirePasswordConfirmation::class,
         'redirecttointended' => Middleware\RedirectToIntended::class,
         'auth.record-info' => RecordLoginInfo::class,
     ];

--- a/app/Http/Middleware/MandatoryTwoFactor.php
+++ b/app/Http/Middleware/MandatoryTwoFactor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Traits\Middleware\RedirectsOnFailure;
+use Auth;
+
+class MandatoryTwoFactor
+{
+    use RedirectsOnFailure;
+
+    protected $except = [
+        'auth/two-factor/*',
+        'password/create',
+        'password/change',
+        'logout',
+    ];
+
+    public function validate($makeResponse)
+    {
+        if (Auth::check() && Auth::user()->requiresTwoFactorSetup()) {
+            if ($makeResponse) {
+                return redirect()->guest(route('two-factor.setup'))
+                    ->withError('You are required to set up two-factor authentication before continuing.');
+            }
+
+            return true;
+        }
+    }
+}

--- a/app/Http/Middleware/RequirePasswordConfirmation.php
+++ b/app/Http/Middleware/RequirePasswordConfirmation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class RequirePasswordConfirmation
+{
+    public function handle(Request $request, Closure $next, ?string $redirectToRoute = null)
+    {
+        if ($this->passwordConfirmedRecently($request)) {
+            return $next($request);
+        }
+
+        return redirect()->guest(
+            route('two-factor.confirm-password', [
+                'redirect' => $request->fullUrl(),
+            ])
+        );
+    }
+
+    protected function passwordConfirmedRecently(Request $request): bool
+    {
+        $confirmedAt = $request->session()->get('auth.password_confirmed_at', 0);
+
+        return $confirmedAt >= now()->subSeconds(10800)->unix();
+    }
+}

--- a/app/Http/Responses/Auth/ConfirmedSecondaryPasswordResponse.php
+++ b/app/Http/Responses/Auth/ConfirmedSecondaryPasswordResponse.php
@@ -3,6 +3,7 @@
 namespace App\Http\Responses\Auth;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
 
 class ConfirmedSecondaryPasswordResponse implements PasswordConfirmedResponseContract
@@ -14,7 +15,23 @@ class ConfirmedSecondaryPasswordResponse implements PasswordConfirmedResponseCon
         }
 
         $redirect = $request->input('redirect') ?? $request->query('redirect');
+        $defaultRedirect = route('mship.manage.dashboard');
 
-        return redirect()->to($redirect ?? route('mship.manage.dashboard'));
+        if (! is_string($redirect) || blank($redirect)) {
+            return redirect()->to($defaultRedirect);
+        }
+
+        if (Str::startsWith($redirect, '/') && ! Str::startsWith($redirect, '//')) {
+            return redirect()->to($redirect);
+        }
+
+        $appHost = parse_url(config('app.url'), PHP_URL_HOST);
+        $redirectHost = parse_url($redirect, PHP_URL_HOST);
+
+        if (is_string($appHost) && is_string($redirectHost) && $appHost === $redirectHost) {
+            return redirect()->to($redirect);
+        }
+
+        return redirect()->to($defaultRedirect);
     }
 }

--- a/app/Http/Responses/Auth/ConfirmedSecondaryPasswordResponse.php
+++ b/app/Http/Responses/Auth/ConfirmedSecondaryPasswordResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Responses\Auth;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
+
+class ConfirmedSecondaryPasswordResponse implements PasswordConfirmedResponseContract
+{
+    public function toResponse($request)
+    {
+        if ($request->wantsJson()) {
+            return new JsonResponse('', 201);
+        }
+
+        $redirect = $request->input('redirect') ?? $request->query('redirect');
+
+        return redirect()->to($redirect ?? route('mship.manage.dashboard'));
+    }
+}

--- a/app/Http/Responses/Auth/TwoFactorConfirmedResponse.php
+++ b/app/Http/Responses/Auth/TwoFactorConfirmedResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Responses\Auth;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\TwoFactorConfirmedResponse as TwoFactorConfirmedResponseContract;
+
+class TwoFactorConfirmedResponse implements TwoFactorConfirmedResponseContract
+{
+    public function toResponse($request)
+    {
+        if ($request->wantsJson()) {
+            return new JsonResponse('', 200);
+        }
+
+        return redirect()
+            ->intended(route('mship.manage.dashboard'))
+            ->withSuccess('Two-factor authentication has been enabled for your account.');
+    }
+}

--- a/app/Http/Responses/Auth/TwoFactorLoginResponse.php
+++ b/app/Http/Responses/Auth/TwoFactorLoginResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Responses\Auth;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
+
+class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
+{
+    public function toResponse($request)
+    {
+        if ($request->wantsJson()) {
+            return new JsonResponse('', 204);
+        }
+
+        return redirect()->intended(route('mship.manage.dashboard'));
+    }
+}

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -23,6 +23,7 @@ use App\Models\Mship\Concerns\HasQualifications;
 use App\Models\Mship\Concerns\HasRoles;
 use App\Models\Mship\Concerns\HasStates;
 use App\Models\Mship\Concerns\HasTeamSpeakRegistrations;
+use App\Models\Mship\Concerns\HasTwoFactor;
 use App\Models\Mship\Concerns\HasVisitTransferApplications;
 use App\Models\Mship\Concerns\HasWaitingLists;
 use App\Models\Mship\Note\Type;
@@ -41,6 +42,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes as SoftDeletingTrait;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Passport\HasApiTokens;
 use Spatie\Permission\Models\Role;
 use Watson\Rememberable\Rememberable;
@@ -103,6 +105,7 @@ use Watson\Rememberable\Rememberable;
  * @property-read bool $is_on_network
  * @property-read mixed $is_system_banned
  * @property-read bool $mandatory_password
+ * @property-read bool $mandatory_two_factor
  * @property-read mixed|string $name_preferred
  * @property-read mixed $network_ban
  * @property-read mixed $new_ts_registration
@@ -238,11 +241,13 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
         HasRoles,
         HasStates,
         HasTeamSpeakRegistrations,
+        HasTwoFactor,
         HasVisitTransferApplications,
         HasWaitingLists,
         Notifiable,
         Rememberable,
-        SoftDeletingTrait;
+        SoftDeletingTrait,
+        TwoFactorAuthenticatable;
     use HasApiTokens {
         clients as oAuthClients;
         tokens as oAuthTokens;
@@ -291,11 +296,14 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
         'deleted_at' => 'datetime',
         'password_set_at' => 'datetime',
         'password_expires_at' => 'datetime',
+        'two_factor_confirmed_at' => 'datetime',
     ];
 
     protected $hidden = [
         'password',
         'remember_token',
+        'two_factor_secret',
+        'two_factor_recovery_codes',
         'discord_access_token',
         'discord_refresh_token',
         'vatsim_access_token',

--- a/app/Models/Mship/Concerns/HasPassword.php
+++ b/app/Models/Mship/Concerns/HasPassword.php
@@ -72,6 +72,11 @@ trait HasPassword
         return $this->password !== null;
     }
 
+    public function requiresMandatoryPasswordSetup(): bool
+    {
+        return $this->mandatory_password && ! $this->hasPassword();
+    }
+
     /**
      * Determine whether the current password has expired.
      *

--- a/app/Models/Mship/Concerns/HasTwoFactor.php
+++ b/app/Models/Mship/Concerns/HasTwoFactor.php
@@ -6,9 +6,13 @@ trait HasTwoFactor
 {
     public function getMandatoryTwoFactorAttribute(): bool
     {
+        if ($this->relationLoaded('roles')) {
+            return $this->roles->contains(fn ($role) => (bool) $role->two_factor_mandatory);
+        }
+
         return $this->roles()
-            ->get()
-            ->contains(fn ($role) => (bool) $role->two_factor_mandatory);
+            ->where('two_factor_mandatory', true)
+            ->exists();
     }
 
     public function requiresTwoFactorSetup(): bool

--- a/app/Models/Mship/Concerns/HasTwoFactor.php
+++ b/app/Models/Mship/Concerns/HasTwoFactor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models\Mship\Concerns;
+
+trait HasTwoFactor
+{
+    public function getMandatoryTwoFactorAttribute(): bool
+    {
+        return $this->roles()
+            ->get()
+            ->contains(fn ($role) => (bool) $role->two_factor_mandatory);
+    }
+
+    public function requiresTwoFactorSetup(): bool
+    {
+        return $this->mandatory_two_factor && ! $this->hasEnabledTwoFactorAuthentication();
+    }
+
+    public function requiresTwoFactorChallenge(): bool
+    {
+        return $this->hasEnabledTwoFactorAuthentication();
+    }
+}

--- a/app/Policies/PasswordPolicy.php
+++ b/app/Policies/PasswordPolicy.php
@@ -20,6 +20,15 @@ class PasswordPolicy extends Policy
         return $this->allow();
     }
 
+    public function setupDuringLogin(Account $user)
+    {
+        if (! $user->requiresMandatoryPasswordSetup()) {
+            return $this->deny('You are not required to set a secondary password at login.');
+        }
+
+        return $this->allow();
+    }
+
     /**
      * Determine whether the user can update their password.
      *

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers\Filament;
 use App\Filament\Admin\Pages\Dashboard;
 use App\Filament\Widgets\AccountInfoWidget;
 use App\Http\Middleware\AdminPanelFilamentAccessMiddleware;
+use App\Http\Middleware\MandatoryTwoFactor;
 use App\Http\Middleware\TrackInactivity;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -51,6 +52,7 @@ class AdminPanelProvider extends PanelProvider
                 VerifyCsrfToken::class,
                 SubstituteBindings::class,
                 TrackInactivity::class,
+                MandatoryTwoFactor::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
             ])

--- a/app/Providers/Filament/TrainingPanelProvider.php
+++ b/app/Providers/Filament/TrainingPanelProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers\Filament;
 
 use App\Filament\Training\Pages\Dashboard;
 use App\Filament\Widgets\AccountInfoWidget;
+use App\Http\Middleware\MandatoryTwoFactor;
 use App\Http\Middleware\TrackInactivity;
 use App\Http\Middleware\TrainingPanelAccessMiddleware;
 use Filament\Http\Middleware\AuthenticateSession;
@@ -49,6 +50,7 @@ class TrainingPanelProvider extends PanelProvider
                 VerifyCsrfToken::class,
                 SubstituteBindings::class,
                 TrackInactivity::class,
+                MandatoryTwoFactor::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
             ])

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Providers;
+
+use App\Http\Responses\Auth\ConfirmedSecondaryPasswordResponse;
+use App\Http\Responses\Auth\TwoFactorConfirmedResponse;
+use App\Http\Responses\Auth\TwoFactorLoginResponse;
+use App\Models\Mship\Account;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\ServiceProvider;
+use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
+use Laravel\Fortify\Contracts\TwoFactorConfirmedResponse as TwoFactorConfirmedResponseContract;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
+use Laravel\Fortify\Fortify;
+
+class FortifyServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        Fortify::ignoreRoutes();
+
+        $this->app->singleton(TwoFactorLoginResponseContract::class, TwoFactorLoginResponse::class);
+        $this->app->singleton(TwoFactorConfirmedResponseContract::class, TwoFactorConfirmedResponse::class);
+        $this->app->singleton(PasswordConfirmedResponseContract::class, ConfirmedSecondaryPasswordResponse::class);
+    }
+
+    public function boot(): void
+    {
+        Fortify::twoFactorChallengeView('auth.two-factor.challenge');
+
+        Fortify::confirmPasswordView(fn (Request $request) => view('auth.two-factor.confirm-password', [
+            'redirect' => $request->query('redirect'),
+        ]));
+
+        Fortify::confirmPasswordsUsing(function (Account $user, ?string $password): bool {
+            if (! $user->hasPassword()) {
+                return false;
+            }
+
+            return $user->verifyPassword($password);
+        });
+
+        RateLimiter::for('two-factor', function (Request $request) {
+            return Limit::perMinute(5)->by($request->session()->get('login.id') ?? $request->ip());
+        });
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,7 @@
     "filament/filament": "^4.0",
     "filament/notifications": "^4.0",
     "guzzlehttp/guzzle": "^7.2",
+    "laravel/fortify": "^1.37",
     "laravel/framework": "^12.0",
     "laravel/helpers": "^1.1",
     "laravel/horizon": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25965cc02b14cdac7cd5ab7570888525",
+    "content-hash": "4d765e0369538dcee7c17c590e4e8936",
     "packages": [
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.12",
+                "phpunit/phpunit": "^10.5.11 || ^11.0.4",
+                "spatie/phpunit-snapshot-assertions": "^5.1.5",
+                "spatie/pixelmatch-php": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.1.1"
+            },
+            "time": "2026-04-05T21:06:35+00:00"
+        },
         {
             "name": "barryvdh/laravel-debugbar",
             "version": "v4.2.4",
@@ -1328,6 +1383,56 @@
             "time": "2026-03-16T11:29:23+00:00"
         },
         {
+            "name": "dasprid/enum",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
+            },
+            "time": "2025-09-16T12:23:56+00:00"
+        },
+        {
             "name": "defuse/php-encryption",
             "version": "v2.4.0",
             "source": {
@@ -1468,6 +1573,54 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -3109,6 +3262,70 @@
             "time": "2026-03-29T12:05:03+00:00"
         },
         {
+            "name": "laravel/fortify",
+            "version": "v1.37.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/fortify.git",
+                "reference": "5d4b6a53527edd19ecc4f13e8e74ec91bdefab0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/fortify/zipball/5d4b6a53527edd19ecc4f13e8e74ec91bdefab0c",
+                "reference": "5d4b6a53527edd19ecc4f13e8e74ec91bdefab0c",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "^3.0",
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "laravel/passkeys": "^0.2.0",
+                "php": "^8.2",
+                "pragmarx/google2fa": "^9.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Fortify\\FortifyServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Fortify\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Backend controllers and scaffolding for Laravel authentication.",
+            "keywords": [
+                "auth",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/fortify/issues",
+                "source": "https://github.com/laravel/fortify"
+            },
+            "time": "2026-05-15T22:59:10+00:00"
+        },
+        {
             "name": "laravel/framework",
             "version": "v12.58.0",
             "source": {
@@ -3466,6 +3683,74 @@
                 "source": "https://github.com/laravel/horizon/tree/v5.45.5"
             },
             "time": "2026-04-01T07:28:03+00:00"
+        },
+        {
+            "name": "laravel/passkeys",
+            "version": "v0.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/passkeys-server.git",
+                "reference": "a76656ada41b2b4a591f075eddae5ddc67e8ab9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/passkeys-server/zipball/a76656ada41b2b4a591f075eddae5ddc67e8ab9c",
+                "reference": "a76656ada41b2b4a591f075eddae5ddc67e8ab9c",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/http": "^11.0|^12.0|^13.0",
+                "illuminate/routing": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "web-auth/webauthn-lib": "5.3.x"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.28.0",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.0",
+                "rector/rector": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Passkeys\\PasskeysServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Passkeys\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Passwordless authentication using WebAuthn/passkeys for Laravel",
+            "homepage": "https://github.com/laravel/passkeys-server",
+            "keywords": [
+                "Authentication",
+                "Passwordless",
+                "laravel",
+                "passkeys",
+                "webauthn"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/passkeys-server/issues",
+                "source": "https://github.com/laravel/passkeys-server"
+            },
+            "time": "2026-05-18T16:26:00+00:00"
         },
         {
             "name": "laravel/passport",
@@ -6903,6 +7188,182 @@
             "time": "2026-01-15T14:47:34+00:00"
         },
         {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+            },
+            "time": "2026-03-18T20:49:53+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
             "name": "phpoffice/phpspreadsheet",
             "version": "1.30.4",
             "source": {
@@ -7194,6 +7655,53 @@
                 }
             ],
             "time": "2026-04-27T07:02:15+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "planetteamspeak/ts3-php-framework",
@@ -9168,6 +9676,187 @@
                 }
             ],
             "time": "2026-02-01T09:30:04+00:00"
+        },
+        {
+            "name": "spomky-labs/cbor-php",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/cbor-php.git",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "roave/security-advisories": "dev-latest",
+                "symfony/error-handler": "^6.4|^7.1|^8.0",
+                "symfony/var-dumper": "^6.4|^7.1|^8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath extensions will drastically improve the library performance. BCMath extension needed to handle the Big Float and Decimal Fraction Tags",
+                "ext-gmp": "GMP or BCMath extensions will drastically improve the library performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CBOR\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/Spomky-Labs/cbor-php/contributors"
+                }
+            ],
+            "description": "CBOR Encoder/Decoder for PHP",
+            "keywords": [
+                "Concise Binary Object Representation",
+                "RFC7049",
+                "cbor"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/cbor-php/issues",
+                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-01T12:15:20+00:00"
+        },
+        {
+            "name": "spomky-labs/pki-framework",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/pki-framework.git",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "ekino/phpstan-banned-code": "^1.0|^2.0|^3.0",
+                "ext-gmp": "*",
+                "ext-openssl": "*",
+                "infection/infection": "^0.28|^0.29|^0.31|^0.32",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.3|^2.0",
+                "phpstan/phpstan": "^1.8|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.1|^2.0",
+                "phpstan/phpstan-strict-rules": "^1.3|^2.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0|^13.0",
+                "rector/rector": "^1.0|^2.0",
+                "roave/security-advisories": "dev-latest",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symplify/easy-coding-standard": "^12.0|^13.0"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance (or GMP)",
+                "ext-gmp": "For better performance (or BCMath)",
+                "ext-openssl": "For OpenSSL based cyphering"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SpomkyLabs\\Pki\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joni Eskelinen",
+                    "email": "jonieske@gmail.com",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Florent Morselli",
+                    "email": "florent.morselli@spomky-labs.com",
+                    "role": "Spomky-Labs PKI Framework developer"
+                }
+            ],
+            "description": "A PHP framework for managing Public Key Infrastructures. It comprises X.509 public key certificates, attribute certificates, certification requests and certification path validation.",
+            "homepage": "https://github.com/spomky-labs/pki-framework",
+            "keywords": [
+                "DER",
+                "Private Key",
+                "ac",
+                "algorithm identifier",
+                "asn.1",
+                "asn1",
+                "attribute certificate",
+                "certificate",
+                "certification request",
+                "cryptography",
+                "csr",
+                "decrypt",
+                "ec",
+                "encrypt",
+                "pem",
+                "pkcs",
+                "public key",
+                "rsa",
+                "sign",
+                "signature",
+                "verify",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-03-23T22:56:56+00:00"
         },
         {
             "name": "symfony/clock",
@@ -11459,6 +12148,177 @@
             "time": "2026-03-24T13:12:05+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "b7dad9dae8b8a47ef7ecc76c8569e7d8c7d90cfc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/b7dad9dae8b8a47ef7ecc76c8569e7d8c7d90cfc",
+                "reference": "b7dad9dae8b8a47ef7ecc76c8569e7d8c7d90cfc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/property-info": "^6.4.32|~7.3.10|^7.4.4|^8.0.4"
+            },
+            "require-dev": {
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4.1|^7.0.1|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property-path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "ac5e82528b986c4f7cfccbf7764b5d2e824d6175"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/ac5e82528b986c4f7cfccbf7764b5d2e824d6175",
+                "reference": "ac5e82528b986c4f7cfccbf7764b5d2e824d6175",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/type-info": "^7.4.7|^8.0.7"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/cache": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/serializer": "<6.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
             "name": "symfony/psr-http-message-bridge",
             "version": "v7.4.8",
             "source": {
@@ -11630,6 +12490,110 @@
                 }
             ],
             "time": "2026-04-22T15:21:55+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v7.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "268c5aa6c4bd675eddd89348e7ecac292a843ddd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/268c5aa6c4bd675eddd89348e7ecac292a843ddd",
+                "reference": "268c5aa6c4bd675eddd89348e7ecac292a843ddd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php84": "^1.30"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/property-access": "<6.4.31|>=7.0,<7.4.2|>=8.0,<8.0.2",
+                "symfony/property-info": "<6.4",
+                "symfony/type-info": "<7.2.5",
+                "symfony/uid": "<6.4",
+                "symfony/validator": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "seld/jsonlint": "^1.10",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^7.2|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/filesystem": "^6.4|^7.0|^8.0",
+                "symfony/form": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4.31|^7.4.2|^8.0.2",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/type-info": "^7.2.5|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v7.4.10"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-03T13:03:28+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -11990,6 +12954,89 @@
                 }
             ],
             "time": "2025-07-15T13:41:35+00:00"
+        },
+        {
+            "name": "symfony/type-info",
+            "version": "v7.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "cafeedbf157b890e94ac5b83eaed85595106d5d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/cafeedbf157b890e94ac5b83eaed85595106d5d6",
+                "reference": "cafeedbf157b890e94ac5b83eaed85595106d5d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v7.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-22T15:21:55+00:00"
         },
         {
             "name": "symfony/uid",
@@ -12483,6 +13530,229 @@
                 "source": "https://github.com/dwightwatson/rememberable/tree/7.1.0"
             },
             "time": "2026-02-20T23:07:25+00:00"
+        },
+        {
+            "name": "web-auth/cose-lib",
+            "version": "4.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/cose-lib.git",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/cose-lib/zipball/5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "php": ">=8.1",
+                "spomky-labs/pki-framework": "^1.0"
+            },
+            "require-dev": {
+                "spomky-labs/cbor-php": "^3.2.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "ext-gmp": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "spomky-labs/cbor-php": "For COSE Signature support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cose\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/cose/contributors"
+                }
+            ],
+            "description": "CBOR Object Signing and Encryption (COSE) For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "COSE",
+                "RFC8152"
+            ],
+            "support": {
+                "issues": "https://github.com/web-auth/cose-lib/issues",
+                "source": "https://github.com/web-auth/cose-lib/tree/4.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-03T09:49:50+00:00"
+        },
+        {
+            "name": "web-auth/webauthn-lib",
+            "version": "5.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/webauthn-lib.git",
+                "reference": "e6f656d6c6b29fa305382fe6a0a3be8177d177df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/webauthn-lib/zipball/e6f656d6c6b29fa305382fe6a0a3be8177d177df",
+                "reference": "e6f656d6c6b29fa305382fe6a0a3be8177d177df",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "paragonie/constant_time_encoding": "^2.6|^3.0",
+                "php": ">=8.2",
+                "phpdocumentor/reflection-docblock": "^5.3|^6.0",
+                "psr/clock": "^1.0",
+                "psr/event-dispatcher": "^1.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "spomky-labs/cbor-php": "^3.0",
+                "spomky-labs/pki-framework": "^1.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^3.2",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "web-auth/cose-lib": "^4.2.3"
+            },
+            "suggest": {
+                "psr/log-implementation": "Recommended to receive logs from the library",
+                "symfony/event-dispatcher": "Recommended to use dispatched events",
+                "web-token/jwt-library": "Mandatory for fetching Metadata Statement from distant sources"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/web-auth/webauthn-framework",
+                    "name": "web-auth/webauthn-framework"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webauthn\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/webauthn-library/contributors"
+                }
+            ],
+            "description": "FIDO2/Webauthn Support For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "FIDO2",
+                "fido",
+                "webauthn"
+            ],
+            "support": {
+                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-17T19:04:30+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
+            },
+            "time": "2026-05-20T13:07:01+00:00"
         },
         {
             "name": "whitecube/laravel-cookie-consent",

--- a/config/app.php
+++ b/config/app.php
@@ -161,6 +161,7 @@ return [
          * Application Service Providers...
          */
         App\Providers\AppServiceProvider::class,
+        App\Providers\FortifyServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Laravel Fortify — two-factor authentication only.
+ *
+ * VATSIM OAuth and secondary passwords remain the application's login flow.
+ * Fortify's default routes are disabled; 2FA HTTP endpoints live in
+ * routes/fortify-two-factor.php and App\Providers\FortifyServiceProvider.
+ */
+
+use Laravel\Fortify\Features;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Guard
+    |--------------------------------------------------------------------------
+    |
+    | Session guard used for 2FA challenge completion and authenticated 2FA
+    | management actions (enable, confirm, recovery codes).
+    |
+    */
+
+    'guard' => 'web',
+
+    /*
+    |--------------------------------------------------------------------------
+    | TOTP account label
+    |--------------------------------------------------------------------------
+    |
+    | Attribute on Account used as the account name in authenticator QR codes.
+    |
+    */
+
+    'username' => 'email',
+
+    'email' => 'email',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redirects
+    |--------------------------------------------------------------------------
+    |
+    | Default intended URL after a successful 2FA challenge (custom response
+    | classes may override). Not used for login or password reset.
+    |
+    */
+
+    'home' => '/mship/manage/dashboard',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Middleware
+    |--------------------------------------------------------------------------
+    |
+    | Applied to routes in routes/fortify-two-factor.php.
+    |
+    */
+
+    'middleware' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate limiting
+    |--------------------------------------------------------------------------
+    |
+    | Only the two-factor challenge limiter is registered (see
+    | App\Providers\FortifyServiceProvider).
+    |
+    */
+
+    'limiters' => [
+        'two-factor' => 'two-factor',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Features
+    |--------------------------------------------------------------------------
+    |
+    | Do not add registration, resetPasswords, updatePasswords, passkeys, etc.
+    | confirmPassword gates enable/disable behind secondary-password confirmation.
+    |
+    */
+
+    'features' => [
+        Features::twoFactorAuthentication([
+            'confirm' => true,
+            'confirmPassword' => true,
+        ]),
+    ],
+
+];

--- a/database/migrations/2026_05_24_000001_add_two_factor_columns_to_mship_account_table.php
+++ b/database/migrations/2026_05_24_000001_add_two_factor_columns_to_mship_account_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('mship_account', function (Blueprint $table) {
+            $table->text('two_factor_secret')->after('remember_token')->nullable();
+            $table->text('two_factor_recovery_codes')->after('two_factor_secret')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->after('two_factor_recovery_codes')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('mship_account', function (Blueprint $table) {
+            $table->dropColumn([
+                'two_factor_secret',
+                'two_factor_recovery_codes',
+                'two_factor_confirmed_at',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_05_24_000002_add_two_factor_mandatory_to_mship_role_table.php
+++ b/database/migrations/2026_05_24_000002_add_two_factor_mandatory_to_mship_role_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('mship_role', function (Blueprint $table) {
+            $table->boolean('two_factor_mandatory')->default(false)->after('password_mandatory');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('mship_role', function (Blueprint $table) {
+            $table->dropColumn('two_factor_mandatory');
+        });
+    }
+};

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -13,4 +13,5 @@ import collapse from "@alpinejs/collapse";
 
 Alpine.plugin(collapse);
 
-Livewire.start();
+window.Alpine = Alpine;
+Alpine.start();

--- a/resources/views/auth/passwords/create.blade.php
+++ b/resources/views/auth/passwords/create.blade.php
@@ -2,15 +2,13 @@
 
 @section('content')
 	<div class="panel panel-ukblue">
-		<div class="panel-heading"> Secondary Password</div>
+		<div class="panel-heading">{{ $heading }}</div>
 		<div class="panel-body">
-			<p>
-				To create your secondary password, complete the form below.
-			</p>
+			<p>{{ $intro }}</p>
 
 			<div class="row">
 				<div class="col-md-7 col-md-offset-2">
-					<form action="{{ route('password.create') }}" class="form-horizontal" method="POST">
+					<form action="{{ $formAction }}" class="form-horizontal" method="POST">
 						@csrf
 						@include('auth.passwords.partials._new')
 						@include('auth.passwords.partials._submit')

--- a/resources/views/auth/two-factor/challenge.blade.php
+++ b/resources/views/auth/two-factor/challenge.blade.php
@@ -1,0 +1,153 @@
+@php
+	$challengeAccount = session('login.id') ? \App\Models\Mship\Account::find(session('login.id')) : null;
+@endphp
+
+@extends('layout')
+
+@section('styles')
+	<style>
+		@keyframes two-factor-autofill-start {
+			from {}
+
+			to {}
+		}
+
+		#code:-webkit-autofill {
+			animation-name: two-factor-autofill-start;
+			animation-duration: 0.001s;
+		}
+	</style>
+@endsection
+
+@section('content')
+	<div class="row" x-data="{
+    useRecovery: @js($errors->has('recovery_code')),
+    submitting: false,
+    _submitCheckTimer: null,
+    syncCodeFromInput() {
+        const input = this.$refs.codeInput;
+        const digits = input.value.replace(/\D/g, '');
+        if (input.value !== digits) {
+            input.value = digits;
+        }
+        return digits;
+    },
+    maybeSubmitAuthenticator() {
+        if (this.submitting) {
+            return;
+        }
+        if (this.syncCodeFromInput().length !== 6) {
+            return;
+        }
+        this.submitting = true;
+        this.$refs.authenticatorForm.requestSubmit();
+    },
+    scheduleSubmitCheck() {
+        clearTimeout(this._submitCheckTimer);
+        this._submitCheckTimer = setTimeout(() => this.maybeSubmitAuthenticator(), 75);
+    },
+    onWebkitAutofill(event) {
+        if (event.animationName === 'two-factor-autofill-start') {
+            this.scheduleSubmitCheck();
+        }
+    },
+    showRecovery() {
+        this.useRecovery = true;
+        this.$nextTick(() => this.$refs.recoveryCode?.focus());
+    },
+    showAuthenticator() {
+        this.useRecovery = false;
+        this.submitting = false;
+        this.$nextTick(() => this.$refs.codeInput?.focus());
+    },
+}">
+		<div class="col-md-8 col-md-offset-2">
+			@include('components.html.panel_open', [
+				'title' => 'Two-Factor Authentication',
+				'icon' => ['type' => 'fa', 'key' => 'fa-shield'],
+			])
+
+			<p x-show="!useRecovery">
+				Enter the authentication code from your authenticator application to continue.
+			</p>
+
+			<template x-if="useRecovery">
+				<p>Enter one of your unused recovery codes to continue.</p>
+			</template>
+
+			<form x-ref="authenticatorForm" x-show="!useRecovery" method="POST" action="{{ route('two-factor.login.store') }}"
+				class="form-horizontal" autocomplete="on" @submit="submitting = true">
+				@csrf
+
+				@if ($challengeAccount)
+					<input type="text" name="username" autocomplete="username" value="{{ $challengeAccount->cid }}" tabindex="-1"
+						aria-hidden="true" style="position:absolute;left:-9999px;width:1px;height:1px;opacity:0;padding:0;border:0;">
+				@endif
+
+				<div class="form-group">
+					<label for="code" class="control-label col-sm-5">Authentication Code</label>
+					<div class="col-sm-4">
+						<input x-ref="codeInput" name="code" type="text" inputmode="numeric"
+							class="form-control @error('code') has-error @enderror" id="code" value="{{ old('code') }}"
+							autocomplete="one-time-code" autocapitalize="off" autocorrect="off" spellcheck="false"
+							aria-label="One-time verification code" enterkeyhint="go" @input="scheduleSubmitCheck()"
+							@paste="scheduleSubmitCheck()" @animationstart="onWebkitAutofill($event)" :disabled="submitting" autofocus>
+						@error('code')
+							<span class="help-block">{{ $message }}</span>
+						@enderror
+					</div>
+				</div>
+
+				<div class="form-group">
+					<div class="col-sm-7 col-sm-offset-5">
+						<button type="submit" class="btn btn-primary" :disabled="submitting">
+							<span x-show="!submitting">Continue</span>
+							<span x-show="submitting" x-cloak>Verifying…</span>
+						</button>
+					</div>
+				</div>
+
+				<div class="form-group">
+					<div class="col-sm-7 col-sm-offset-5">
+						<p class="form-control-static">
+							<a href="#" @click.prevent="showRecovery()">Lost access to your authenticator? Use a recovery code</a>
+						</p>
+					</div>
+				</div>
+			</form>
+
+			<template x-if="useRecovery">
+				<form method="POST" action="{{ route('two-factor.login.store') }}" class="form-horizontal">
+					@csrf
+
+					<div class="form-group">
+						<label for="recovery_code" class="control-label col-sm-5">Recovery Code</label>
+						<div class="col-sm-4">
+							<input x-ref="recoveryCode" class="form-control @error('recovery_code') has-error @enderror" name="recovery_code"
+								type="text" value="{{ old('recovery_code') }}" autocomplete="off" id="recovery_code">
+							@error('recovery_code')
+								<span class="help-block">{{ $message }}</span>
+							@enderror
+						</div>
+					</div>
+
+					<div class="form-group">
+						<div class="col-sm-7 col-sm-offset-5">
+							<button type="submit" class="btn btn-primary">Continue</button>
+						</div>
+					</div>
+
+					<div class="form-group">
+						<div class="col-sm-7 col-sm-offset-5">
+							<p class="form-control-static">
+								<a href="#" @click.prevent="showAuthenticator()">Use your authenticator application instead</a>
+							</p>
+						</div>
+					</div>
+				</form>
+			</template>
+
+			@include('components.html.panel_close')
+		</div>
+	</div>
+@stop

--- a/resources/views/auth/two-factor/confirm-password.blade.php
+++ b/resources/views/auth/two-factor/confirm-password.blade.php
@@ -1,0 +1,37 @@
+@extends('layout')
+
+@section('content')
+	<div class="row">
+		<div class="col-md-8 col-md-offset-2">
+			@include('components.html.panel_open', [
+				'title' => 'Confirm Secondary Password',
+				'icon' => ['type' => 'fa', 'key' => 'fa-key'],
+			])
+			<p>
+				Please confirm your secondary password before continuing.
+			</p>
+
+			<form method="POST" action="{{ route('two-factor.confirm-password.store') }}" class="form-horizontal">
+				@csrf
+
+				@if ($redirect)
+					<input type="hidden" name="redirect" value="{{ $redirect }}">
+				@endif
+
+				<div class="form-group">
+					<label for="password" class="control-label col-sm-5">Secondary Password</label>
+					<div class="col-sm-4">
+						<input class="form-control" name="password" type="password" autofocus id="password" required>
+					</div>
+				</div>
+
+				<div class="form-group">
+					<div class="col-sm-4 col-sm-offset-5">
+						<input class="btn btn-default" type="submit" value="Confirm">
+					</div>
+				</div>
+			</form>
+			@include('components.html.panel_close')
+		</div>
+	</div>
+@stop

--- a/resources/views/auth/two-factor/manage.blade.php
+++ b/resources/views/auth/two-factor/manage.blade.php
@@ -1,0 +1,42 @@
+@extends('layout')
+
+@section('content')
+	<div class="row">
+		<div class="col-md-8 col-md-offset-2">
+			@include('components.html.panel_open', [
+				'title' => 'Two-Factor Authentication',
+				'icon' => ['type' => 'fa', 'key' => 'fa-shield'],
+			])
+			<p>Two-factor authentication is enabled for your account.</p>
+
+			<h4>Recovery Codes</h4>
+			<p class="text-muted">Store these recovery codes in a secure location. Each code may only be used once.</p>
+			<ul>
+				@foreach ($recoveryCodes as $code)
+					<li><code>{{ $code }}</code></li>
+				@endforeach
+			</ul>
+
+			<form method="POST" action="{{ route('two-factor.regenerate-recovery-codes') }}" class="form-horizontal"
+				style="margin-bottom: 1.5em;">
+				@csrf
+				<input class="btn btn-default" type="submit" value="Regenerate Recovery Codes"
+					onclick="return confirm('This will invalidate your existing recovery codes. Continue?');">
+			</form>
+
+			@if (!Auth::user()->mandatory_two_factor)
+				<form method="POST" action="{{ route('two-factor.disable') }}"
+					onsubmit="return confirm('Disable two-factor authentication for this account?');">
+					@csrf
+					@method('DELETE')
+					<input class="btn btn-danger" type="submit" value="Disable Two-Factor Authentication">
+				</form>
+			@endif
+
+			<p style="margin-top: 1.5em;">
+				<a href="{{ route('mship.manage.dashboard') }}">Return to dashboard</a>
+			</p>
+			@include('components.html.panel_close')
+		</div>
+	</div>
+@stop

--- a/resources/views/auth/two-factor/setup.blade.php
+++ b/resources/views/auth/two-factor/setup.blade.php
@@ -1,0 +1,74 @@
+@extends('layout')
+
+@section('content')
+	<div class="row">
+		<div class="col-md-8 col-md-offset-2">
+			@include('components.html.panel_open', [
+				'title' => 'Two-Factor Authentication Setup',
+				'icon' => ['type' => 'fa', 'key' => 'fa-shield'],
+			])
+
+			@if (Auth::user()->mandatory_two_factor)
+				<p>
+					Your account role requires two-factor authentication. You must complete setup before you can access
+					VATSIM UK services.
+				</p>
+			@else
+				<p>
+					Protect your account with an additional layer of security using an authenticator application.
+				</p>
+			@endif
+
+			@if ($pendingConfirmation)
+				<p>
+					Scan the QR code below with your authenticator application, then enter the generated code to finish setup.
+				</p>
+
+				<div class="text-center" style="margin: 1.5em 0;">
+					{!! Auth::user()->twoFactorQrCodeSvg() !!}
+				</div>
+
+				<p class="text-muted">
+					If you cannot scan the QR code, configure your application manually using your account email address and
+					the secret from your authenticator setup screen.
+				</p>
+
+				<form method="POST" action="{{ route('two-factor.confirm') }}" class="form-horizontal">
+					@csrf
+
+					<div class="form-group">
+						<label for="code" class="control-label col-sm-5">Authentication Code</label>
+						<div class="col-sm-4">
+							<input class="form-control @error('code', 'confirmTwoFactorAuthentication') has-error @enderror" name="code"
+								type="text" inputmode="numeric" value="{{ old('code') }}" autocomplete="one-time-code" id="code"
+								required autofocus>
+							@error('code', 'confirmTwoFactorAuthentication')
+								<span class="help-block">{{ $message }}</span>
+							@enderror
+						</div>
+					</div>
+
+					<div class="form-group">
+						<div class="col-sm-4 col-sm-offset-5">
+							<input class="btn btn-primary" type="submit" value="Confirm and Enable">
+						</div>
+					</div>
+				</form>
+			@else
+				<p>Click below to generate a QR code for your authenticator application.</p>
+
+				<form method="POST" action="{{ route('two-factor.enable') }}" class="form-horizontal">
+					@csrf
+
+					<div class="form-group">
+						<div class="col-sm-4 col-sm-offset-5">
+							<input class="btn btn-default" type="submit" value="Begin Setup">
+						</div>
+					</div>
+				</form>
+			@endif
+
+			@include('components.html.panel_close')
+		</div>
+	</div>
+@stop

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -186,6 +186,32 @@
 					@endforelse
 				</div>
 			</div>
+			@if ($_account->hasEnabledTwoFactorAuthentication())
+				<div class="panel panel-ukblue">
+					<div class="panel-heading"><i class="fa fa-shield"></i> &thinsp; Two-Factor Authentication
+					</div>
+					<div class="panel-body">
+						<div class="row">
+							<div class="col-xs-12">
+								Two-factor authentication adds an extra layer of security using an authenticator application on
+								your phone or computer.
+							</div>
+						</div>
+						<br />
+						<div class="row">
+							<div class="col-xs-4">
+								<b>STATUS: </b>ENABLED
+							</div>
+							<div class="col-xs-8">
+								<a href="{{ route('two-factor.setup') }}">Manage Settings</a>
+								@if ($_account->mandatory_two_factor)
+									&mdash; Cannot be disabled.
+								@endif
+							</div>
+						</div>
+					</div>
+				</div>
+			@endif
 			<div class="panel panel-ukblue">
 				<div class="panel-heading"><i class="fa fa-lock"></i> &thinsp; Secondary Password
 				</div>

--- a/routes/fortify-two-factor.php
+++ b/routes/fortify-two-factor.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Http\Controllers\Auth\TwoFactorSetupController;
+use Illuminate\Support\Facades\Route;
+use Laravel\Fortify\Features;
+use Laravel\Fortify\Http\Controllers\ConfirmablePasswordController;
+use Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController;
+use Laravel\Fortify\Http\Controllers\RecoveryCodeController;
+use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController;
+use Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController;
+use Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController;
+
+Route::prefix('auth/two-factor')->middleware(config('fortify.middleware', ['web']))->group(function () {
+    $twoFactorLimiter = config('fortify.limiters.two-factor');
+    $authMiddleware = 'auth:'.config('fortify.guard', 'web');
+
+    Route::get('challenge', [TwoFactorAuthenticatedSessionController::class, 'create'])
+        ->middleware(['guest:'.config('fortify.guard', 'web')])
+        ->name('two-factor.login');
+
+    Route::post('challenge', [TwoFactorAuthenticatedSessionController::class, 'store'])
+        ->middleware(array_filter([
+            'guest:'.config('fortify.guard', 'web'),
+            $twoFactorLimiter ? 'throttle:'.$twoFactorLimiter : null,
+        ]))
+        ->name('two-factor.login.store');
+
+    Route::middleware($authMiddleware)->group(function () use ($authMiddleware) {
+        Route::get('setup', [TwoFactorSetupController::class, 'show'])->name('two-factor.setup');
+
+        Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
+            ->name('two-factor.confirm-password');
+
+        Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+            ->name('two-factor.confirm-password.store');
+
+        $twoFactorMiddleware = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')
+            ? [$authMiddleware, 'password.confirm']
+            : [$authMiddleware];
+
+        Route::post('enable', [TwoFactorAuthenticationController::class, 'store'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.enable');
+
+        Route::post('confirm', [ConfirmedTwoFactorAuthenticationController::class, 'store'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.confirm');
+
+        Route::delete('disable', [TwoFactorAuthenticationController::class, 'destroy'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.disable');
+
+        Route::get('qr-code', [TwoFactorQrCodeController::class, 'show'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.qr-code');
+
+        Route::get('recovery-codes', [RecoveryCodeController::class, 'index'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.recovery-codes');
+
+        Route::post('recovery-codes', [RecoveryCodeController::class, 'store'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.regenerate-recovery-codes');
+    });
+});

--- a/routes/web-main.php
+++ b/routes/web-main.php
@@ -9,7 +9,11 @@ Route::get('login')->uses('Auth\LoginController@login')->name('login');
 Route::post('login')->uses('Auth\LoginController@login')->name('login.post');
 Route::get('login-secondary')->uses('Auth\LoginController@showLoginForm')->middleware('auth:vatsim-sso')->name('auth-secondary');
 Route::post('login-secondary')->uses('Auth\SecondaryLoginController@loginSecondary')->middleware('auth:vatsim-sso')->name('auth-secondary.post');
+Route::get('login/password/setup')->uses('Auth\LoginPasswordSetupController@show')->middleware('auth:vatsim-sso')->name('login.password.setup');
+Route::post('login/password/setup')->uses('Auth\LoginPasswordSetupController@store')->middleware('auth:vatsim-sso')->name('login.password.setup.store');
 Route::post('logout')->uses('Auth\LogoutController')->name('logout');
+
+require base_path('routes/fortify-two-factor.php');
 
 Route::get('/staff')->uses('Site\StaffPageController@staff')->middleware('auth_full_group')->name('site.staff');
 

--- a/tests/Feature/Account/Auth/LoginPasswordSetupTest.php
+++ b/tests/Feature/Account/Auth/LoginPasswordSetupTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\Account\Auth;
+
+use App\Auth\LoginFlow;
+use App\Models\Mship\Account;
+use Illuminate\Http\Request;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class LoginPasswordSetupTest extends TestCase
+{
+    protected Account $account;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->account = Account::factory()->create([
+            'password' => null,
+        ]);
+    }
+
+    #[Test]
+    public function vatsim_oauth_redirects_to_login_password_setup_when_mandatory_and_missing(): void
+    {
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $this->account->assignRole($role);
+        $this->enableTwoFactorFor($this->account);
+
+        $response = LoginFlow::redirectAfterVatsimOAuth(
+            Request::create('/'),
+            $this->account->fresh(),
+        );
+
+        $this->assertTrue($response->isRedirect(route('login.password.setup')));
+    }
+
+    #[Test]
+    public function login_password_setup_page_requires_vatsim_sso_authentication(): void
+    {
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $this->account->assignRole($role);
+
+        $this->get(route('login.password.setup'))
+            ->assertRedirect(route('landing'));
+    }
+
+    #[Test]
+    public function login_password_setup_is_accessible_during_partial_login(): void
+    {
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $this->account->assignRole($role);
+
+        $this->actingAs($this->account, 'vatsim-sso')
+            ->get(route('login.password.setup'))
+            ->assertOk()
+            ->assertSee('Secondary Password Required');
+    }
+
+    #[Test]
+    public function completing_login_password_setup_redirects_to_two_factor_challenge(): void
+    {
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $this->account->assignRole($role);
+        $this->enableTwoFactorFor($this->account);
+
+        $this->actingAs($this->account, 'vatsim-sso')
+            ->post(route('login.password.setup.store'), [
+                'new_password' => 'Secret123',
+                'new_password_confirmation' => 'Secret123',
+            ])
+            ->assertRedirect(route('two-factor.login'));
+
+        $this->assertGuest('web');
+        $this->assertEquals($this->account->id, session('login.id'));
+        $this->assertTrue($this->account->fresh()->verifyPassword('Secret123'));
+    }
+
+    #[Test]
+    public function completing_login_password_setup_without_two_factor_establishes_web_session(): void
+    {
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $this->account->assignRole($role);
+
+        $this->actingAs($this->account, 'vatsim-sso')
+            ->post(route('login.password.setup.store'), [
+                'new_password' => 'Secret123',
+                'new_password_confirmation' => 'Secret123',
+            ])
+            ->assertRedirect(route('site.home'));
+
+        $this->assertAuthenticatedAs($this->account);
+    }
+
+    #[Test]
+    public function login_password_setup_redirects_away_when_password_is_not_mandatory(): void
+    {
+        $this->actingAs($this->account, 'vatsim-sso')
+            ->get(route('login.password.setup'))
+            ->assertRedirect(route('site.home'));
+    }
+
+    #[Test]
+    public function login_password_setup_sets_password_confirmed_at_before_two_factor_challenge(): void
+    {
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $this->account->assignRole($role);
+        $this->enableTwoFactorFor($this->account);
+
+        $this->actingAs($this->account, 'vatsim-sso')
+            ->post(route('login.password.setup.store'), [
+                'new_password' => 'Secret123',
+                'new_password_confirmation' => 'Secret123',
+            ])
+            ->assertRedirect(route('two-factor.login'));
+
+        $this->assertNotNull(session('auth.password_confirmed_at'));
+    }
+
+    #[Test]
+    public function vatsim_oauth_skips_password_setup_when_not_mandatory_and_goes_to_two_factor(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $request = Request::create('/');
+        $request->setLaravelSession($this->app['session.store']);
+
+        $response = LoginFlow::establishWebSession(
+            $request,
+            $this->account->fresh(),
+            remember: true,
+        );
+
+        $this->assertTrue($response->isRedirect(route('two-factor.login')));
+        $this->assertGuest('web');
+        $this->assertEquals($this->account->id, session('login.id'));
+    }
+
+    #[Test]
+    public function vatsim_oauth_still_redirects_to_secondary_login_when_password_exists(): void
+    {
+        $this->account->forceFill(['password' => 'Secret123'])->save();
+        $this->enableTwoFactorFor($this->account);
+
+        $response = LoginFlow::redirectAfterVatsimOAuth(
+            Request::create('/'),
+            $this->account->fresh(),
+        );
+
+        $this->assertTrue($response->isRedirect(route('auth-secondary')));
+    }
+
+    protected function enableTwoFactorFor(Account $account): void
+    {
+        app(EnableTwoFactorAuthentication::class)($account, true);
+
+        $account->forceFill([
+            'two_factor_confirmed_at' => now(),
+        ])->save();
+    }
+}

--- a/tests/Feature/Account/Auth/TwoFactorAuthTest.php
+++ b/tests/Feature/Account/Auth/TwoFactorAuthTest.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Tests\Feature\Account\Auth;
+
+use App\Models\Mship\Account;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Fortify;
+use PHPUnit\Framework\Attributes\Test;
+use PragmaRX\Google2FA\Google2FA;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class TwoFactorAuthTest extends TestCase
+{
+    protected Account $account;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->account = Account::factory()->create([
+            'password' => 'secret-password',
+        ]);
+    }
+
+    #[Test]
+    public function mandatory_two_factor_middleware_redirects_to_setup(): void
+    {
+        $role = factory(Role::class)->create(['two_factor_mandatory' => true]);
+        $this->account->assignRole($role);
+
+        $this->actingAs($this->account)
+            ->get(route('mship.manage.dashboard'))
+            ->assertRedirect(route('two-factor.setup'));
+    }
+
+    #[Test]
+    public function setup_page_is_accessible_when_two_factor_is_mandatory(): void
+    {
+        $role = factory(Role::class)->create(['two_factor_mandatory' => true]);
+        $this->account->assignRole($role);
+
+        $this->actingAs($this->account)
+            ->get(route('two-factor.setup'))
+            ->assertOk()
+            ->assertSee('Two-Factor Authentication Setup');
+    }
+
+    #[Test]
+    public function secondary_login_redirects_to_two_factor_challenge_when_enabled(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $this->actingAs($this->account, 'vatsim-sso')
+            ->post(route('auth-secondary.post'), [
+                'password' => 'secret-password',
+            ])
+            ->assertRedirect(route('two-factor.login'));
+
+        $this->assertGuest('web');
+        $this->assertEquals($this->account->id, session('login.id'));
+    }
+
+    #[Test]
+    public function logout_clears_partial_two_factor_session(): void
+    {
+        session([
+            'login.id' => $this->account->id,
+            'login.remember' => false,
+            'auth.password_confirmed_at' => now()->unix(),
+        ]);
+
+        $this->actingAs($this->account)
+            ->post(route('logout'))
+            ->assertRedirect(route('site.home'));
+
+        $this->assertGuest();
+        $this->assertNull(session('login.id'));
+        $this->assertNull(session('auth.password_confirmed_at'));
+    }
+
+    #[Test]
+    public function challenge_page_hides_recovery_input_by_default(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        session(['login.id' => $this->account->id]);
+
+        $this->get(route('two-factor.login'))
+            ->assertOk()
+            ->assertSee('authenticator application', false)
+            ->assertSee('Use a recovery code', false)
+            ->assertSee('autocomplete="one-time-code"', false)
+            ->assertSee('autocomplete="username"', false)
+            ->assertSee('scheduleSubmitCheck()', false)
+            ->assertSee('submitting', false)
+            ->assertSee('x-if="useRecovery"', false);
+    }
+
+    #[Test]
+    public function challenge_page_can_switch_to_recovery_mode(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        session(['login.id' => $this->account->id]);
+
+        $this->get(route('two-factor.login'))
+            ->assertOk()
+            ->assertSee('name="recovery_code"', false)
+            ->assertSee('showRecovery()', false);
+    }
+
+    #[Test]
+    public function challenge_requires_partial_login_session(): void
+    {
+        $this->get(route('two-factor.login'))
+            ->assertRedirect(route('login'));
+    }
+
+    #[Test]
+    public function invalid_two_factor_code_returns_to_challenge(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        session(['login.id' => $this->account->id]);
+
+        $this->from(route('two-factor.login'))
+            ->post(route('two-factor.login.store'), ['code' => '000000'])
+            ->assertRedirect(route('two-factor.login'))
+            ->assertSessionHasErrors('code');
+
+        $this->assertGuest('web');
+    }
+
+    #[Test]
+    public function recovery_code_completes_login(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $recoveryCode = $this->account->fresh()->recoveryCodes()[0];
+
+        session([
+            'login.id' => $this->account->id,
+            'login.remember' => false,
+        ]);
+
+        $this->post(route('two-factor.login.store'), [
+            'recovery_code' => $recoveryCode,
+        ])
+            ->assertRedirect(route('mship.manage.dashboard'));
+
+        $this->assertAuthenticatedAs($this->account);
+        $this->assertNull(session('login.id'));
+    }
+
+    #[Test]
+    public function secondary_login_sets_password_confirmed_at_before_two_factor_challenge(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $this->actingAs($this->account, 'vatsim-sso')
+            ->post(route('auth-secondary.post'), [
+                'password' => 'secret-password',
+            ])
+            ->assertRedirect(route('two-factor.login'));
+
+        $this->assertNotNull(session('auth.password_confirmed_at'));
+    }
+
+    #[Test]
+    public function invalid_setup_confirmation_code_returns_to_setup_with_error(): void
+    {
+        app(EnableTwoFactorAuthentication::class)($this->account, true);
+
+        $this->actingAs($this->account)
+            ->withSession(['auth.password_confirmed_at' => now()->unix()])
+            ->from(route('two-factor.setup'))
+            ->post(route('two-factor.confirm'), ['code' => '000000'])
+            ->assertRedirect(route('two-factor.setup'))
+            ->assertSessionHasErrors('code', null, 'confirmTwoFactorAuthentication');
+
+        $this->assertNull($this->account->fresh()->two_factor_confirmed_at);
+
+        $this->actingAs($this->account)
+            ->get(route('two-factor.setup'))
+            ->assertOk()
+            ->assertSee('The provided two factor authentication code was invalid.', false);
+    }
+
+    #[Test]
+    public function setup_page_shows_manage_view_when_two_factor_is_enabled(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $this->actingAs($this->account)
+            ->get(route('two-factor.setup'))
+            ->assertOk()
+            ->assertSee('Recovery Codes', false);
+    }
+
+    #[Test]
+    public function two_factor_challenge_completes_login(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $secret = Fortify::currentEncrypter()->decrypt($this->account->fresh()->two_factor_secret);
+        $code = app(Google2FA::class)->getCurrentOtp($secret);
+
+        session([
+            'login.id' => $this->account->id,
+            'login.remember' => false,
+        ]);
+
+        $this->post(route('two-factor.login.store'), [
+            'code' => $code,
+        ])
+            ->assertRedirect(route('mship.manage.dashboard'));
+
+        $this->assertAuthenticatedAs($this->account);
+        $this->assertNull(session('login.id'));
+    }
+
+    protected function enableTwoFactorFor(Account $account): void
+    {
+        app(EnableTwoFactorAuthentication::class)($account, true);
+
+        $account->forceFill([
+            'two_factor_confirmed_at' => now(),
+        ])->save();
+    }
+}

--- a/tests/Feature/Account/Auth/TwoFactorAuthTest.php
+++ b/tests/Feature/Account/Auth/TwoFactorAuthTest.php
@@ -188,6 +188,30 @@ class TwoFactorAuthTest extends TestCase
     }
 
     #[Test]
+    public function confirm_password_redirect_accepts_same_host_urls(): void
+    {
+        $redirect = route('site.home');
+
+        $this->actingAs($this->account)
+            ->post(route('two-factor.confirm-password.store'), [
+                'password' => 'secret-password',
+                'redirect' => $redirect,
+            ])
+            ->assertRedirect($redirect);
+    }
+
+    #[Test]
+    public function confirm_password_redirect_rejects_external_urls(): void
+    {
+        $this->actingAs($this->account)
+            ->post(route('two-factor.confirm-password.store'), [
+                'password' => 'secret-password',
+                'redirect' => 'https://example.com/phishing',
+            ])
+            ->assertRedirect(route('mship.manage.dashboard'));
+    }
+
+    #[Test]
     public function setup_page_shows_manage_view_when_two_factor_is_enabled(): void
     {
         $this->enableTwoFactorFor($this->account);

--- a/tests/Unit/Account/MandatoryPasswordSetupTest.php
+++ b/tests/Unit/Account/MandatoryPasswordSetupTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Account;
+
+use App\Models\Mship\Account;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class MandatoryPasswordSetupTest extends TestCase
+{
+    #[Test]
+    public function it_requires_mandatory_password_setup_when_role_requires_password_and_none_is_set(): void
+    {
+        $account = Account::factory()->create(['password' => null]);
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $account->assignRole($role);
+
+        $this->assertTrue($account->fresh()->requiresMandatoryPasswordSetup());
+    }
+
+    #[Test]
+    public function it_does_not_require_mandatory_password_setup_when_password_exists(): void
+    {
+        $account = Account::factory()->create(['password' => 'Secret123']);
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $account->assignRole($role);
+
+        $this->assertFalse($account->fresh()->requiresMandatoryPasswordSetup());
+    }
+
+    #[Test]
+    public function it_does_not_require_mandatory_password_setup_when_password_is_not_mandatory(): void
+    {
+        $account = Account::factory()->create(['password' => null]);
+
+        $this->assertFalse($account->requiresMandatoryPasswordSetup());
+    }
+}

--- a/tests/Unit/Account/TwoFactorTest.php
+++ b/tests/Unit/Account/TwoFactorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Account;
+
+use App\Models\Mship\Account;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class TwoFactorTest extends TestCase
+{
+    protected Account $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = Account::factory()->create();
+    }
+
+    #[Test]
+    public function it_determines_that_two_factor_is_not_mandatory(): void
+    {
+        $this->assertFalse($this->user->mandatory_two_factor);
+    }
+
+    #[Test]
+    public function it_determines_that_two_factor_is_mandatory(): void
+    {
+        $role = factory(Role::class)->create(['two_factor_mandatory' => true]);
+
+        $this->user->assignRole($role);
+
+        $this->assertTrue($this->user->fresh()->mandatory_two_factor);
+    }
+
+    #[Test]
+    public function it_requires_two_factor_setup_when_mandatory_and_not_enabled(): void
+    {
+        $role = factory(Role::class)->create(['two_factor_mandatory' => true]);
+        $this->user->assignRole($role);
+
+        $this->assertTrue($this->user->fresh()->requiresTwoFactorSetup());
+    }
+
+    #[Test]
+    public function it_does_not_require_two_factor_setup_when_enabled(): void
+    {
+        $role = factory(Role::class)->create(['two_factor_mandatory' => true]);
+        $this->user->assignRole($role);
+
+        app(EnableTwoFactorAuthentication::class)($this->user->fresh(), true);
+        $this->user->fresh()->forceFill(['two_factor_confirmed_at' => now()])->save();
+
+        $this->assertFalse($this->user->fresh()->requiresTwoFactorSetup());
+        $this->assertTrue($this->user->fresh()->requiresTwoFactorChallenge());
+    }
+}

--- a/tests/Unit/Policies/PasswordPolicyTest.php
+++ b/tests/Unit/Policies/PasswordPolicyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit\Policies;
+
+use App\Models\Mship\Account;
+use App\Policies\PasswordPolicy;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class PasswordPolicyTest extends TestCase
+{
+    protected PasswordPolicy $policy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->policy = new PasswordPolicy;
+    }
+
+    #[Test]
+    public function it_allows_setup_during_login_when_mandatory_password_is_missing(): void
+    {
+        $account = Account::factory()->create(['password' => null]);
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $account->assignRole($role);
+
+        $this->assertTrue($this->policy->setupDuringLogin($account->fresh()));
+    }
+
+    #[Test]
+    public function it_denies_setup_during_login_when_password_already_exists(): void
+    {
+        $account = Account::factory()->create(['password' => 'Secret123']);
+        $role = factory(Role::class)->create(['password_mandatory' => true]);
+        $account->assignRole($role);
+
+        $this->assertFalse($this->policy->setupDuringLogin($account->fresh()));
+    }
+}


### PR DESCRIPTION
## Summary

Adds **TOTP two-factor authentication** (via Laravel Fortify) on top of the existing VATSIM OAuth + secondary password login. Roles can require 2FA via a new `two_factor_mandatory` flag on `mship_role` (same pattern as `password_mandatory`). Fortify is used **only** for 2FA — default Fortify login/register routes are disabled.

## What changed

### Authentication flow
- Sign-in order is unchanged at a high level, with 2FA inserted **after** secondary password (when applicable):
  **VATSIM OAuth → mandatory secondary password setup (if required) → secondary password (if set) → 2FA challenge (if enabled) → full session**
- `LoginFlow` centralises post-OAuth routing; `TwoFactorLoginRedirect` handles the partial session when 2FA is enabled (`login.id`, `login.remember`, `web` guard logged out until challenge completes).
- `auth.password_confirmed_at` is set when secondary password is verified at login, so users are not immediately re-prompted for password confirmation before managing 2FA.

### Mandatory 2FA
- `mandatory_two_factor` accessor on `Account` (any assigned role with `two_factor_mandatory`).
- `MandatoryTwoFactor` middleware on `auth_full_group`, Filament Admin, Filament Training, Horizon, and Telescope.
- Users who must set up 2FA are redirected to `/auth/two-factor/setup` (except 2FA routes, password create/change, logout).

### Fortify integration
- `laravel/fortify` with `Features::twoFactorAuthentication(['confirm' => true, 'confirmPassword' => true])`.
- Custom routes in `routes/fortify-two-factor.php`; `Fortify::ignoreRoutes()` in `FortifyServiceProvider::register()`.
- Custom responses for login challenge completion, 2FA confirmation, and secondary password confirmation.
- Secondary password verification for Fortify `password.confirm` (enable/disable/confirm/regenerate recovery codes only — **not** normal browsing).

### Database
- `mship_account`: `two_factor_secret`, `two_factor_recovery_codes`, `two_factor_confirmed_at`
- `mship_role`: `two_factor_mandatory` (default `false`)

### UI
- Setup, challenge, manage, and confirm-password Blade views.
- Dashboard security panel link when 2FA is enabled.
- Filament role admin: **Two-factor mandatory** checkbox.
- Setup confirm form shows validation errors (Fortify `confirmTwoFactorAuthentication` error bag).

### Other
- Shared `auth/passwords/create` view for login-time mandatory password setup.
- `app.js`: `Alpine.start()` fix (was calling undefined `Livewire.start()`).
- **31 tests** across feature/unit coverage for login order, middleware, challenge, setup errors, and password policy.

---

## Flow diagrams

### Sign-in (login)

```mermaid
flowchart TD
    A[VATSIM OAuth] --> B{Role requires<br/>secondary password<br/>and none set?}
    B -->|Yes| C[Login password setup<br/>auth:vatsim-sso]
    C --> D[Set password]
    D --> E[Establish web session]
    B -->|No| F{Has secondary<br/>password?}
    F -->|Yes| G[Secondary login]
    G --> H{Password OK?}
    H -->|No| G
    H -->|Yes| E
    F -->|No| E
    E --> I{2FA enabled<br/>and confirmed?}
    I -->|Yes| J[Partial session:<br/>login.id + remember<br/>logout web guard]
    J --> K[2FA challenge page]
    K --> L{Valid TOTP<br/>or recovery code?}
    L -->|No| K
    L -->|Yes| M[Full web session<br/>redirect intended]
    I -->|No| M