### PR TITLE
Allow 'all' option on upcoming mentoring sessions page

### DIFF
--- a/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
+++ b/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
@@ -46,28 +46,42 @@ class UpcomingMentoringSessions extends BaseMentoringHistoryPage
 
     public function mount(): void
     {
+        if ($this->category === MentorPermissionService::ALL_CATEGORIES) {
+            if (! $this->hasMultipleVisibleCategories()) {
+                $this->category = $this->firstVisibleCategory() ?? '';
+            }
+
+            return;
+        }
+
         if (empty($this->category) || ! $this->canViewCategory($this->category)) {
-            $this->category = $this->firstVisibleCategory() ?? '';
+            $this->category = $this->defaultCategory();
         }
     }
 
     protected function getHeaderActions(): array
     {
-        $allCategories = collect(MentorPermissionService::atcCategories())
-            ->merge(MentorPermissionService::pilotCategories());
+        $visibleCategories = $this->getVisibleCategories();
+
+        $categoryActions = collect($visibleCategories)
+            ->map(fn (string $cat) => Action::make('cat_'.str($cat)->slug('_'))
+                ->label($cat)
+                ->url(static::getUrl(['category' => $cat]))
+                ->icon($this->category === $cat ? 'heroicon-m-check' : null)
+            );
+
+        if ($this->hasMultipleVisibleCategories()) {
+            $categoryActions = $categoryActions->prepend(
+                Action::make('cat_all')
+                    ->label('All')
+                    ->url(static::getUrl(['category' => MentorPermissionService::ALL_CATEGORIES]))
+                    ->icon($this->category === MentorPermissionService::ALL_CATEGORIES ? 'heroicon-m-check' : null)
+            );
+        }
 
         return [
-            ActionGroup::make(
-                $allCategories
-                    ->filter(fn (string $cat) => $this->canViewCategory($cat))
-                    ->map(fn (string $cat) => Action::make('cat_'.str($cat)->slug('_'))
-                        ->label($cat)
-                        ->url(static::getUrl(['category' => $cat]))
-                        ->icon($this->category === $cat ? 'heroicon-m-check' : null)
-                    )
-                    ->all()
-            )
-                ->label('Training Group: '.($this->category ?: 'All'))
+            ActionGroup::make($categoryActions->all())
+                ->label('Training Group: '.$this->trainingGroupLabel())
                 ->icon('heroicon-m-chevron-down')
                 ->color('gray')
                 ->button(),
@@ -121,11 +135,52 @@ class UpcomingMentoringSessions extends BaseMentoringHistoryPage
 
     private function getVisibleCtsPositions(): array
     {
+        $service = app(MentorPermissionService::class);
+
+        if ($this->category === MentorPermissionService::ALL_CATEGORIES) {
+            return $service->getAllCtsCallsignsForCategories($this->getVisibleCategories());
+        }
+
         if (empty($this->category)) {
             return [];
         }
 
-        return app(MentorPermissionService::class)->getAllCtsCallsignsForCategory($this->category);
+        return $service->getAllCtsCallsignsForCategory($this->category);
+    }
+
+    private function trainingGroupLabel(): string
+    {
+        if ($this->category === MentorPermissionService::ALL_CATEGORIES) {
+            return 'All';
+        }
+
+        return $this->category;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getVisibleCategories(): array
+    {
+        return collect(MentorPermissionService::atcCategories())
+            ->merge(MentorPermissionService::pilotCategories())
+            ->filter(fn (string $cat) => $this->canViewCategory($cat))
+            ->values()
+            ->all();
+    }
+
+    private function hasMultipleVisibleCategories(): bool
+    {
+        return count($this->getVisibleCategories()) > 1;
+    }
+
+    private function defaultCategory(): string
+    {
+        if ($this->hasMultipleVisibleCategories()) {
+            return MentorPermissionService::ALL_CATEGORIES;
+        }
+
+        return $this->firstVisibleCategory() ?? '';
     }
 
     private function canViewCategory(string $category): bool

--- a/app/Livewire/Training/PendingMentoringReportsTable.php
+++ b/app/Livewire/Training/PendingMentoringReportsTable.php
@@ -78,11 +78,41 @@ class PendingMentoringReportsTable extends Component implements HasActions, HasF
      */
     private function getVisibleCtsPositions(): array
     {
+        $service = app(MentorPermissionService::class);
+
+        if ($this->category === MentorPermissionService::ALL_CATEGORIES) {
+            return $service->getAllCtsCallsignsForCategories($this->getVisibleCategories());
+        }
+
         if (empty($this->category)) {
             return [];
         }
 
-        return app(MentorPermissionService::class)->getAllCtsCallsignsForCategory($this->category);
+        return $service->getAllCtsCallsignsForCategory($this->category);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getVisibleCategories(): array
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return [];
+        }
+
+        return collect(MentorPermissionService::atcCategories())
+            ->merge(MentorPermissionService::pilotCategories())
+            ->filter(function (string $category) use ($user) {
+                if ($user->can('training.mentoring.view.*')) {
+                    return true;
+                }
+
+                return $user->can('training.mentors.view.'.MentorPermissionService::categoryType($category));
+            })
+            ->values()
+            ->all();
     }
 
     public function render()

--- a/app/Services/Training/MentorPermissionService.php
+++ b/app/Services/Training/MentorPermissionService.php
@@ -21,6 +21,8 @@ use Illuminate\Support\Facades\Log;
 
 class MentorPermissionService
 {
+    public const ALL_CATEGORIES = 'all';
+
     public const ATC_CATEGORY_ROLE_MAP = [
         'OBS to S1 Training' => 'ATC Mentor (OBS)',
         'S2 Training' => 'ATC Mentor (TWR)',
@@ -325,6 +327,20 @@ class MentorPermissionService
         $callsign = $qualCode ? (self::QUALIFICATION_CTS_POSITION_MAP[$qualCode] ?? null) : null;
 
         return $callsign ? [$callsign] : [];
+    }
+
+    /**
+     * @param  array<int, string>  $categories
+     * @return array<int, string>
+     */
+    public function getAllCtsCallsignsForCategories(array $categories): array
+    {
+        return collect($categories)
+            ->flatMap(fn (string $category) => $this->getAllCtsCallsignsForCategory($category))
+            ->unique()
+            ->filter()
+            ->values()
+            ->toArray();
     }
 
     public function getAssignedCtsCallsigns(Account $account, string $category): array

--- a/tests/Feature/TrainingPanel/Mentor/UpcomingMentoringSessionsTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/UpcomingMentoringSessionsTest.php
@@ -45,7 +45,7 @@ class UpcomingMentoringSessionsTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
-    public function it_defaults_to_the_first_visible_category_when_category_is_empty(): void
+    public function it_defaults_to_all_when_category_is_empty_and_multiple_groups_are_visible(): void
     {
         $this->panelUser->givePermissionTo('training.mentors.view.atc');
 
@@ -54,11 +54,11 @@ class UpcomingMentoringSessionsTest extends BaseTrainingPanelTestCase
 
         Livewire::actingAs($this->panelUser)
             ->test(UpcomingMentoringSessions::class)
-            ->assertSet('category', $category);
+            ->assertSet('category', MentorPermissionService::ALL_CATEGORIES);
     }
 
     #[Test]
-    public function it_defaults_to_the_first_visible_category_when_category_is_invalid(): void
+    public function it_defaults_to_all_when_category_is_invalid_and_multiple_groups_are_visible(): void
     {
         $this->panelUser->givePermissionTo('training.mentors.view.atc');
 
@@ -67,7 +67,7 @@ class UpcomingMentoringSessionsTest extends BaseTrainingPanelTestCase
 
         Livewire::actingAs($this->panelUser)
             ->test(UpcomingMentoringSessions::class, ['category' => 'Not A Real Category'])
-            ->assertSet('category', $category);
+            ->assertSet('category', MentorPermissionService::ALL_CATEGORIES);
     }
 
     #[Test]
@@ -198,6 +198,35 @@ class UpcomingMentoringSessionsTest extends BaseTrainingPanelTestCase
         Livewire::actingAs($this->panelUser)
             ->test(UpcomingMentoringSessions::class, ['category' => $category])
             ->assertCanNotSeeTableRecords([$session]);
+    }
+
+    #[Test]
+    public function it_shows_sessions_from_all_visible_categories_when_all_is_selected(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $categoryOne = MentorPermissionService::atcCategories()[0];
+        $categoryTwo = MentorPermissionService::atcCategories()[1];
+
+        $this->createTrainingPosition($categoryOne, 'EGKK_GND');
+        $this->createTrainingPosition($categoryTwo, 'EGKK_TWR');
+
+        $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $tomorrow = Carbon::tomorrow()->format('Y-m-d H:i:s');
+
+        $sessionInCategoryOne = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGKK_GND', takenDate: $tomorrow);
+        $sessionInCategoryTwo = $this->insertSession($mentorCtsMember->id, $studentCtsMember->id, 'EGKK_TWR', takenDate: $tomorrow);
+
+        $sessionOne = Session::on('cts')->find($sessionInCategoryOne);
+        $sessionTwo = Session::on('cts')->find($sessionInCategoryTwo);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => MentorPermissionService::ALL_CATEGORIES])
+            ->assertSet('category', MentorPermissionService::ALL_CATEGORIES)
+            ->assertCanSeeTableRecords([$sessionOne, $sessionTwo]);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Adds an **All** option to the training group dropdown on the Upcoming Sessions page, so mentors with access to multiple training groups can view upcoming sessions and pending reports across all of them in one place.

- Shows **All** in the dropdown only when the user can view more than one training group
- Defaults to **All** on first load when multiple groups are available (falls back to the single group when only one is visible)
- Scopes both the **Upcoming Sessions** table and the **Pending Reports** table to all viewable CTS positions when **All** is selected
- Uses `category=all` in the URL to persist the selection

## Changes

- **`UpcomingMentoringSessions`** — adds the **All** dropdown action, default category logic, and position scoping across visible categories
- **`PendingMentoringReportsTable`** — mirrors the same **All** scoping behaviour for the pending reports section on the page
- **`MentorPermissionService`** — adds `ALL_CATEGORIES` constant and `getAllCtsCallsignsFoories()` helper
- **`UpcomingMentoringSessionsTest`** — updates default category assertions and adds coverage for the cross-category **All** view

