### PR TITLE
Add breadcrumb navigation back from ViewTrainingPlace

### DIFF
--- a/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
+++ b/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
@@ -72,7 +72,25 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
 
     public function getTitle(): string|Htmlable
     {
-        return "View Training Place - {$this->trainingPlace->account->name}";
+        $title = "View Training Place - {$this->trainingPlace->account->name}";
+        $callsign = $this->trainingPlace->trainingPosition?->position?->callsign;
+
+        if (filled($callsign)) {
+            $title .= " ({$callsign})";
+        }
+
+        return $title;
+    }
+
+    /**
+     * @return array<string, string>|array<int, string|Htmlable>
+     */
+    public function getBreadcrumbs(): array
+    {
+        return [
+            ListTrainingPlaces::getUrl() => 'Training Places',
+            $this->getTitle(),
+        ];
     }
 
     protected function getHeaderWidgets(): array


### PR DESCRIPTION
## Summary

Allows easy navigation back to the main training place index page.

<img width="1517" height="287" alt="image" src="https://github.com/user-attachments/assets/b3977b52-6e32-4d66-a49b-ab1e0ef96613" />
