### PR TITLE
Conduct mentoring reports via training panel

### DIFF
--- a/app/Enums/FieldScore.php
+++ b/app/Enums/FieldScore.php
@@ -26,6 +26,22 @@ enum FieldScore: int implements HasColor, HasLabel
         };
     }
 
+    /**
+     * Score options for mentoring conduct forms (CTS values 1–5).
+     *
+     * @return array<int, string>
+     */
+    public static function mentoringConductOptions(): array
+    {
+        return [
+            self::NOT_APPLICABLE->value => 'Not Covered',
+            self::COVERED->value => 'Covered',
+            self::DEVELOPING->value => 'Developing',
+            self::GOOD->value => 'Good',
+            self::TEST_STANDARD->value => 'Test Standard',
+        ];
+    }
+
     public function getColor(): string|array|null
     {
         return match ($this) {

--- a/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
+++ b/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
@@ -23,6 +23,8 @@ trait InteractsWithCtsRichEditorNotes
     /**
      * Filament v4 / Tiptap PHP parse HTML via DOMDocument::loadHTML; empty or whitespace-only strings
      * yield no <body> node, so DOMParser::getDocumentBody() returns null and crashes.
+     *
+     * Plain-text notes from CTS are converted into paragraph HTML for the editor.
      */
     protected function ctsRichEditorHtmlForHydration(mixed $html): mixed
     {
@@ -30,11 +32,28 @@ trait InteractsWithCtsRichEditorNotes
             return '<p></p>';
         }
 
-        return $html;
+        if (! is_string($html) || $this->ctsNotesContainHtmlMarkup($html)) {
+            return $html;
+        }
+
+        $lines = preg_split("/\r\n|\n|\r/", $html);
+
+        if ($lines === false || $lines === []) {
+            return '<p></p>';
+        }
+
+        $paragraphs = array_map(
+            fn (string $line): string => $line === ''
+                ? '<p><br></p>'
+                : '<p>'.$this->ctsEscapePlainTextLineForEditor($line).'</p>',
+            $lines,
+        );
+
+        return implode('', $paragraphs);
     }
 
     /**
-     * CTS stores mentoring/exam notes as plain text; Filament RichEditor state is HTML.
+     * Persist RichEditor HTML for CTS, keeping basic formatting (bold, italic, lists, etc.).
      *
      * Returns null when the content is empty.
      */
@@ -44,11 +63,68 @@ trait InteractsWithCtsRichEditorNotes
             return null;
         }
 
-        $withNewlines = preg_replace('/<\/p>\s*<p>/i', "\n", $html);
-        $text = html_entity_decode(strip_tags($withNewlines), ENT_QUOTES | ENT_HTML5, 'UTF-8');
-        $text = str_replace("\xc2\xa0", ' ', $text);
-        $text = trim($text);
+        if (! $this->ctsNotesContainHtmlMarkup($html)) {
+            return trim($html) !== '' ? $html : null;
+        }
 
-        return $text !== '' ? $text : null;
+        $sanitized = $this->ctsSanitizeNotesHtml($html);
+
+        if (trim(strip_tags($sanitized)) === '') {
+            return null;
+        }
+
+        return $this->ctsNormalizeEmptyParagraphs($sanitized);
+    }
+
+    /**
+     * Render CTS notes for Filament TextEntry::html().
+     */
+    protected function ctsPlainNotesForHtmlDisplay(mixed $notes): ?string
+    {
+        if (! is_string($notes) || trim($notes) === '') {
+            return null;
+        }
+
+        $content = $this->ctsNotesContainHtmlMarkup($notes)
+            ? $this->ctsNormalizeEmptyParagraphs($this->ctsSanitizeNotesHtml($notes))
+            : e($notes);
+
+        return '<div class="cts-notes-content" style="white-space:pre-wrap;word-break:break-word">'.$content.'</div>';
+    }
+
+    protected function ctsAllowedNotesHtmlTags(): string
+    {
+        return '<p><br><strong><b><em><i><u><s><ul><ol><li>';
+    }
+
+    protected function ctsSanitizeNotesHtml(string $html): string
+    {
+        $withoutScripts = preg_replace('/<script\b[^>]*>.*?<\/script>/is', '', $html) ?? $html;
+        $withoutEventHandlers = preg_replace('/\s+on\w+\s*=\s*("|\').*?\1/i', '', $withoutScripts) ?? $withoutScripts;
+
+        return strip_tags($withoutEventHandlers, $this->ctsAllowedNotesHtmlTags());
+    }
+
+    protected function ctsNormalizeEmptyParagraphs(string $html): string
+    {
+        $normalised = preg_replace('/<p>\s*<\/p>/i', '<p><br></p>', $html) ?? $html;
+
+        return preg_replace('/<p><br\s*\/?>\s*<\/p>/i', '<p><br></p>', $normalised) ?? $normalised;
+    }
+
+    protected function ctsEscapePlainTextLineForEditor(string $line): string
+    {
+        $escaped = htmlspecialchars($line, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        while (str_contains($escaped, '  ')) {
+            $escaped = str_replace('  ', ' &nbsp;', $escaped);
+        }
+
+        return $escaped;
+    }
+
+    protected function ctsNotesContainHtmlMarkup(string $value): bool
+    {
+        return (bool) preg_match('/<[a-z][^>]*>/i', $value);
     }
 }

--- a/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
+++ b/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
@@ -94,7 +94,7 @@ trait InteractsWithCtsRichEditorNotes
 
     protected function ctsAllowedNotesHtmlTags(): string
     {
-        return '<p><br><strong><b><em><i><u><s><ul><ol><li>';
+        return '<p><br><h1><h2><h3><h4><h5><h6><strong><b><em><i><u><s><ul><ol><li>';
     }
 
     protected function ctsSanitizeNotesHtml(string $html): string

--- a/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
+++ b/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Concerns;
+
+use Filament\Forms\Components\RichEditor;
+
+trait InteractsWithCtsRichEditorNotes
+{
+    /**
+     * Notes editor styled like filed mentoring reports (borderless, full width).
+     */
+    protected function mentoringReportNotesEditor(RichEditor $editor): RichEditor
+    {
+        return $editor
+            ->hiddenLabel()
+            ->disableToolbarButtons(['attachFiles', 'blockquote'])
+            ->extraAttributes(['class' => 'mentoring-report-notes-editor'])
+            ->extraFieldWrapperAttributes(['class' => 'mentoring-report-notes-field']);
+    }
+
+    /**
+     * Filament v4 / Tiptap PHP parse HTML via DOMDocument::loadHTML; empty or whitespace-only strings
+     * yield no <body> node, so DOMParser::getDocumentBody() returns null and crashes.
+     */
+    protected function ctsRichEditorHtmlForHydration(mixed $html): mixed
+    {
+        if ($html === null || $html === '' || (is_string($html) && trim($html) === '')) {
+            return '<p></p>';
+        }
+
+        return $html;
+    }
+
+    /**
+     * CTS stores mentoring/exam notes as plain text; Filament RichEditor state is HTML.
+     *
+     * Returns null when the content is empty.
+     */
+    protected function ctsRichContentNotesForCts(mixed $html): ?string
+    {
+        if (! is_string($html) || trim($html) === '') {
+            return null;
+        }
+
+        $withNewlines = preg_replace('/<\/p>\s*<p>/i', "\n", $html);
+        $text = html_entity_decode(strip_tags($withNewlines), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $text = str_replace("\xc2\xa0", ' ', $text);
+        $text = trim($text);
+
+        return $text !== '' ? $text : null;
+    }
+}

--- a/app/Filament/Training/Pages/Exam/ConductExam.php
+++ b/app/Filament/Training/Pages/Exam/ConductExam.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Training\Pages\Exam;
 
 use App\Enums\ExamResultEnum;
+use App\Filament\Training\Concerns\InteractsWithCtsRichEditorNotes;
 use App\Models\Cts\ExamBooking;
 use App\Models\Cts\ExamCriteria;
 use App\Models\Cts\ExamCriteriaAssessment;
@@ -33,6 +34,7 @@ use Livewire\Attributes\Session;
 
 class ConductExam extends Page implements HasForms, HasInfolists
 {
+    use InteractsWithCtsRichEditorNotes;
     use InteractsWithForms, InteractsWithInfolists;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
@@ -116,7 +118,7 @@ class ConductExam extends Page implements HasForms, HasInfolists
                     return [
                         $item->id => [
                             'grade' => $existingAssessment['grade'] ?? 'N',
-                            'comments' => $this->richEditorHtmlForHydration($existingAssessment['comments'] ?? null),
+                            'comments' => $this->ctsRichEditorHtmlForHydration($existingAssessment['comments'] ?? null),
                         ],
                     ];
                 }
@@ -222,7 +224,7 @@ class ConductExam extends Page implements HasForms, HasInfolists
                         'style' => 'min-height: 200px;',
                     ])
                     ->afterStateHydrated(fn ($component) => $component->state(
-                        $this->richEditorHtmlForHydration($this->additionalComments)
+                        $this->ctsRichEditorHtmlForHydration($this->additionalComments)
                     ))
                     // save additional comments in session to persist in session in case navigation occurs
                     ->afterStateUpdated(fn ($state, $livewire) => ($this->additionalComments = $state)),
@@ -415,32 +417,8 @@ class ConductExam extends Page implements HasForms, HasInfolists
             })->get()->each->delete();
     }
 
-    /**
-     * Filament v4 / Tiptap PHP parse HTML via DOMDocument::loadHTML; empty or whitespace-only strings
-     * yield no &lt;body&gt; node, so DOMParser::getDocumentBody() returns null and crashes.
-     */
-    private function richEditorHtmlForHydration(mixed $html): mixed
-    {
-        if ($html === null || $html === '' || (is_string($html) && trim($html) === '')) {
-            return '<p></p>';
-        }
-
-        return $html;
-    }
-
-    /**
-     * CTS stores criteria / result notes as plain text; Filament RichEditor state is HTML.
-     */
     private function richContentNotesForCts(mixed $html): string
     {
-        if (! is_string($html) || trim($html) === '') {
-            return '';
-        }
-
-        $withNewlines = preg_replace('/<\/p>\s*<p>/i', "\n", $html);
-        $text = html_entity_decode(strip_tags($withNewlines), ENT_QUOTES | ENT_HTML5, 'UTF-8');
-        $text = str_replace("\xc2\xa0", ' ', $text);
-
-        return trim($text);
+        return $this->ctsRichContentNotesForCts($html) ?? '';
     }
 }

--- a/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
+++ b/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Pages\Mentor;
+
+use App\Enums\FieldScore;
+use App\Filament\Training\Concerns\InteractsWithCtsRichEditorNotes;
+use App\Filament\Training\Support\MentoringReportLayout;
+use App\Models\Cts\ProgSheetField;
+use App\Models\Cts\ReportSheet;
+use App\Models\Cts\Session;
+use App\Repositories\Cts\MentoringReportRepository;
+use App\Services\Training\MentoringReportService;
+use Filament\Actions\Action;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Concerns\InteractsWithInfolists;
+use Filament\Infolists\Contracts\HasInfolists;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Enums\Alignment;
+use Filament\Support\Enums\FontWeight;
+use Filament\Support\Enums\TextSize;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Session as LivewireSession;
+
+class ConductMentoringSession extends Page implements HasForms, HasInfolists
+{
+    use AuthorizesRequests;
+    use InteractsWithCtsRichEditorNotes;
+    use InteractsWithForms;
+    use InteractsWithInfolists;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    protected string $view = 'filament.training.pages.conduct-mentoring-session';
+
+    protected static ?string $slug = 'mentoring/conduct/{sessionId}';
+
+    public ?array $data = [];
+
+    public int $sessionId;
+
+    public Session $session;
+
+    /** @var array<int, FieldScore> */
+    public array $previousScores = [];
+
+    /** @var array<int, FieldScore> */
+    public array $bestScores = [];
+
+    public bool $hasUnsavedChanges = false;
+
+    public bool $isSaving = false;
+
+    public ?int $lastChangedAt = null;
+
+    public int $autosaveIdleSeconds = 1;
+
+    public int $autosaveMinInterval = 5;
+
+    public ?int $lastAutosaveAt = null;
+
+    #[LivewireSession('mentoringAdditionalComments.{sessionId}')]
+    public ?string $additionalComments = '';
+
+    protected function getForms(): array
+    {
+        return [
+            'form',
+            'additionalCommentsForm',
+        ];
+    }
+
+    public function mount(): void
+    {
+        try {
+            $this->session = Session::with(['student', 'mentor'])
+                ->findOrFail($this->sessionId);
+        } catch (ModelNotFoundException) {
+            abort(403, 'You do not have permission to conduct this mentoring session.');
+        }
+
+        $this->authorize('conduct', $this->session);
+
+        $repository = app(MentoringReportRepository::class);
+        $service = app(MentoringReportService::class);
+
+        $this->previousScores = $service->getPreviousScores($this->session);
+        $this->bestScores = $service->getBestScores($this->session);
+
+        $existingScores = $repository->getExistingScoresForSession($this->session);
+        $existingNotes = $this->existingNotesByField();
+
+        $criteriaData = $repository->getCriteriaFieldsForSession($this->session)
+            ->mapWithKeys(function (ProgSheetField $field) use ($existingScores, $existingNotes) {
+                $fieldId = $field->field_id;
+                $defaultScore = $existingScores[$fieldId]
+                    ?? $this->previousScores[$fieldId]
+                    ?? FieldScore::NOT_APPLICABLE;
+
+                return [
+                    $fieldId => [
+                        'score' => $defaultScore->value,
+                        'notes' => $this->ctsRichEditorHtmlForHydration($existingNotes[$fieldId] ?? null),
+                    ],
+                ];
+            })
+            ->all();
+
+        $this->form->fill(['criteria' => $criteriaData]);
+
+        $storedComments = $repository->getExistingAdditionalComments($this->session);
+        if ($storedComments !== null && $this->additionalComments === '') {
+            $this->additionalComments = $storedComments;
+        }
+
+        $this->additionalCommentsForm->fill();
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('save')
+                ->label(fn () => $this->hasUnsavedChanges ? 'Save' : 'Saved')
+                ->icon(fn () => $this->hasUnsavedChanges ? 'heroicon-o-exclamation-triangle' : 'heroicon-o-check')
+                ->action(fn () => $this->save()),
+            Action::make('markNoShow')
+                ->label('Mark no-show')
+                ->color('danger')
+                ->icon('heroicon-o-user-minus')
+                ->visible(fn () => app(MentoringReportService::class)->canMarkNoShow($this->session))
+                ->requiresConfirmation()
+                ->modalHeading('Mark session as no-show')
+                ->modalDescription(fn () => $this->noShowModalDescription())
+                ->schema(fn () => $this->noShowModalForm())
+                ->action(fn (array $data) => $this->markNoShow($data)),
+        ];
+    }
+
+    public function sessionDetailsInfolist(Schema $schema): Schema
+    {
+        return $schema
+            ->record($this->session)
+            ->components([
+                Section::make('Session Details')->columnSpanFull()->schema([
+                    TextEntry::make('student')
+                        ->label('Student')
+                        ->getStateUsing(fn () => "{$this->session->student->name} ({$this->session->student->cid})"),
+                    TextEntry::make('mentor')
+                        ->label('Mentor')
+                        ->getStateUsing(fn () => "{$this->session->mentor->name} ({$this->session->mentor->cid})"),
+                    TextEntry::make('position')
+                        ->label('Position'),
+                    TextEntry::make('schedule')
+                        ->label('Date & Time')
+                        ->getStateUsing(fn () => "{$this->session->taken_date} | {$this->session->taken_from} - {$this->session->taken_to}"),
+                ])->columns(2),
+            ]);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        $repository = app(MentoringReportRepository::class);
+        $fields = $repository->getCriteriaFieldsForSession($this->session);
+        $grouped = $fields->groupBy(fn (ProgSheetField $field) => $field->category?->catName ?? 'Uncategorized');
+
+        $categorySections = $grouped->map(function ($categoryFields, string $categoryName) {
+            $rows = $categoryFields->values()
+                ->map(fn (ProgSheetField $field) => $this->criterionEntryGrid($field))
+                ->all();
+
+            return Section::make(MentoringReportLayout::categorySectionTitle($categoryName))
+                ->schema($rows);
+        })->values()->all();
+
+        return $schema
+            ->components([
+                Section::make('Session Report')
+                    ->columnSpanFull()
+                    ->schema($categorySections),
+            ])
+            ->statePath('data');
+    }
+
+    public function additionalCommentsForm(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Additional Comments')
+                    ->columnSpanFull()
+                    ->schema([
+                        $this->mentoringReportNotesEditor(RichEditor::make('body'))
+                            ->columnSpanFull()
+                            ->live(debounce: 1000)
+                            ->extraInputAttributes(['style' => 'min-height: 200px;'])
+                            ->afterStateHydrated(fn ($component) => $component->state(
+                                $this->ctsRichEditorHtmlForHydration($this->additionalComments)
+                            ))
+                            ->afterStateUpdated(function ($state): void {
+                                $this->additionalComments = $state;
+                                $this->markDirty();
+                            }),
+                        Actions::make([
+                            Action::make('submit_report')
+                                ->label('Submit Report')
+                                ->icon('heroicon-o-check')
+                                ->color('primary')
+                                ->requiresConfirmation()
+                                ->action(fn () => $this->submitReport()),
+                        ])->alignment(Alignment::End)->columnSpanFull(),
+                    ]),
+            ]);
+    }
+
+    private function criterionEntryGrid(ProgSheetField $field): Grid
+    {
+        $fieldId = $field->field_id;
+        $best = $this->bestScores[$fieldId] ?? FieldScore::NOT_SCORED;
+        $previous = $this->previousScores[$fieldId] ?? FieldScore::NOT_SCORED;
+
+        return Grid::make(14)
+            ->schema([
+                TextEntry::make("criteria_display_{$fieldId}_name")
+                    ->state($field->field)
+                    ->hiddenLabel()
+                    ->size(TextSize::Large)
+                    ->weight(FontWeight::Bold)
+                    ->columnSpan(8),
+                TextEntry::make("criteria_display_{$fieldId}_best")
+                    ->label('Best')
+                    ->state($best)
+                    ->badge()
+                    ->icon('heroicon-m-trophy')
+                    ->columnSpan(2),
+                TextEntry::make("criteria_display_{$fieldId}_previous")
+                    ->label('Previous')
+                    ->state($previous)
+                    ->badge()
+                    ->icon('heroicon-m-clock')
+                    ->columnSpan(2),
+                Select::make("criteria.{$fieldId}.score")
+                    ->label('Current')
+                    ->options(FieldScore::mentoringConductOptions())
+                    ->required()
+                    ->columnSpan(2)
+                    ->live()
+                    ->afterStateUpdated(fn () => $this->save(withNotification: false)),
+                $this->mentoringReportNotesEditor(RichEditor::make("criteria.{$fieldId}.notes"))
+                    ->default('<p></p>')
+                    ->columnSpan(12)
+                    ->live(debounce: 500)
+                    ->extraInputAttributes(['style' => 'min-height: 150px;'])
+                    ->afterStateUpdated(fn () => $this->markDirty()),
+            ])
+            ->extraAttributes(['class' => MentoringReportLayout::CRITERION_ROW_CLASSES]);
+    }
+
+    public function save(bool $withNotification = true): void
+    {
+        $this->isSaving = true;
+
+        try {
+            $criteriaState = $this->form->getState()['criteria'] ?? [];
+            $criteriaData = collect($criteriaState)->mapWithKeys(function (array $item, $fieldId) {
+                return [
+                    (int) $fieldId => [
+                        'score' => FieldScore::from((int) $item['score']),
+                        'notes' => $this->ctsRichContentNotesForCts($item['notes'] ?? null),
+                    ],
+                ];
+            })->all();
+
+            app(MentoringReportService::class)->saveDraft(
+                $this->session,
+                $criteriaData,
+                $this->ctsRichContentNotesForCts($this->additionalComments),
+            );
+
+            $this->hasUnsavedChanges = false;
+
+            if ($withNotification) {
+                Notification::make()
+                    ->title('Mentoring report saved')
+                    ->success()
+                    ->send();
+            }
+        } finally {
+            $this->isSaving = false;
+        }
+    }
+
+    public function submitReport(): void
+    {
+        $this->save(withNotification: false);
+
+        try {
+            app(MentoringReportService::class)->submit($this->session->fresh());
+        } catch (ValidationException $exception) {
+            Notification::make()
+                ->title('Cannot submit mentoring report')
+                ->body(collect($exception->errors())->flatten()->first())
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        Notification::make()
+            ->title('Mentoring report submitted')
+            ->success()
+            ->send();
+
+        $this->redirect(ViewMentoringReport::getUrl(['sessionId' => $this->session->id]));
+    }
+
+    public function markNoShow(array $data): void
+    {
+        $wasShortNotice = app(MentoringReportService::class)->wasBookedWithShortNotice($this->session);
+        $confirmed = (bool) ($data['student_confirmed_discord'] ?? false);
+
+        try {
+            app(MentoringReportService::class)->markNoShow($this->session->fresh(), $confirmed);
+        } catch (ValidationException $exception) {
+            Notification::make()
+                ->title('Unable to mark no-show')
+                ->body(collect($exception->errors())->flatten()->first())
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        if ($wasShortNotice && ! $confirmed) {
+            Notification::make()
+                ->title('Session cancelled')
+                ->body('The session was cancelled on your behalf. No no-show has been recorded for the student.')
+                ->success()
+                ->send();
+        } else {
+            Notification::make()
+                ->title('Session marked as no-show')
+                ->success()
+                ->send();
+        }
+
+        $this->redirect(Mentoring::getUrl());
+    }
+
+    public function autosave(): void
+    {
+        if ($this->isSaving || ! $this->hasUnsavedChanges) {
+            return;
+        }
+
+        $now = now()->timestamp;
+
+        if ($this->lastChangedAt && ($now - $this->lastChangedAt) < $this->autosaveIdleSeconds) {
+            return;
+        }
+
+        if ($this->lastAutosaveAt && ($now - $this->lastAutosaveAt) < $this->autosaveMinInterval) {
+            return;
+        }
+
+        $this->lastAutosaveAt = $now;
+        $this->save(withNotification: false);
+    }
+
+    public function markDirty(): void
+    {
+        $this->hasUnsavedChanges = true;
+        $this->lastChangedAt = now()->timestamp;
+    }
+
+    private function noShowModalDescription(): string
+    {
+        if (app(MentoringReportService::class)->wasBookedWithShortNotice($this->session)) {
+            return 'This session was booked with less than 24 hours notice. Did the student confirm their non-attendance via Discord?';
+        }
+
+        return 'Are you sure you want to mark this session as a no-show? The report will be filed automatically.';
+    }
+
+    /**
+     * @return array<int, \Filament\Forms\Components\Component>
+     */
+    private function noShowModalForm(): array
+    {
+        if (! app(MentoringReportService::class)->wasBookedWithShortNotice($this->session)) {
+            return [];
+        }
+
+        return [
+            Toggle::make('student_confirmed_discord')
+                ->label('Student confirmed non-attendance via Discord')
+                ->required(),
+        ];
+    }
+
+    /**
+     * @return array<int, string|null>
+     */
+    private function existingNotesByField(): array
+    {
+        return ReportSheet::query()
+            ->where('seshid', $this->session->id)
+            ->where('field_id', '!=', 0)
+            ->pluck('notes', 'field_id')
+            ->all();
+    }
+}

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Training\Pages\Mentor;
 
+use App\Filament\Training\Concerns\InteractsWithCtsRichEditorNotes;
 use App\Filament\Training\Pages\TrainingPlace\ViewTrainingPlace;
 use App\Filament\Training\Support\MentoringReportLayout;
 use App\Filament\Training\Support\MentoringReportScores;
@@ -34,6 +35,7 @@ use Illuminate\Support\Collection;
 class ViewMentoringReport extends Page implements HasInfolists
 {
     use AuthorizesRequests;
+    use InteractsWithCtsRichEditorNotes;
     use InteractsWithInfolists;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
@@ -174,7 +176,9 @@ class ViewMentoringReport extends Page implements HasInfolists
                         ->hiddenLabel()
                         ->html()
                         ->columnSpanFull()
-                        ->state(fn (Session $record) => $record->reportSheets->firstWhere('field_id', 0)?->notes),
+                        ->state(fn (Session $record) => $this->ctsPlainNotesForHtmlDisplay(
+                            $record->reportSheets->firstWhere('field_id', 0)?->notes,
+                        )),
                 ]),
         ]);
     }
@@ -232,7 +236,7 @@ class ViewMentoringReport extends Page implements HasInfolists
 
                         TextEntry::make("field_notes_{$uniqueKey}")
                             ->label('Notes')
-                            ->state($sheet->notes)
+                            ->state($this->ctsPlainNotesForHtmlDisplay($sheet->notes))
                             ->hiddenLabel()
                             ->html()
                             ->extraAttributes(['style' => 'word-break:break-word'])

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -239,6 +239,7 @@ class ViewMentoringReport extends Page implements HasInfolists
                             ->state($this->ctsPlainNotesForHtmlDisplay($sheet->notes))
                             ->hiddenLabel()
                             ->html()
+                            ->prose()
                             ->extraAttributes(['style' => 'word-break:break-word'])
                             ->columnSpan(12)
                             ->hidden(blank($sheet->notes)),

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace App\Filament\Training\Pages\Mentor;
 
-use App\Enums\FieldScore;
 use App\Filament\Training\Pages\TrainingPlace\ViewTrainingPlace;
+use App\Filament\Training\Support\MentoringReportLayout;
+use App\Filament\Training\Support\MentoringReportScores;
 use App\Livewire\Training\CriteriaCategoryTable;
 use App\Livewire\Training\SessionCriteriaTable;
 use App\Models\Cts\Session;
@@ -29,7 +30,6 @@ use Filament\Support\Enums\FontWeight;
 use Filament\Support\Enums\TextSize;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Collection;
-use Illuminate\Support\HtmlString;
 
 class ViewMentoringReport extends Page implements HasInfolists
 {
@@ -181,12 +181,7 @@ class ViewMentoringReport extends Page implements HasInfolists
 
     public function reportInfolist(Schema $schema): Schema
     {
-        $scoreMap = [];
-        foreach ($this->allSessions as $sess) {
-            foreach ($sess->reportSheets as $s) {
-                $scoreMap[$s->field_id][$sess->id] = $s->field_score;
-            }
-        }
+        $scoreMap = MentoringReportScores::scoreMapForSessions($this->allSessions);
 
         $previousSession = $this->otherSessions
             ->where('taken_date', '<=', $this->session->taken_date)
@@ -199,22 +194,12 @@ class ViewMentoringReport extends Page implements HasInfolists
 
         foreach ($groupedSheets as $categoryName => $sheets) {
             $sheetRows = [];
-            $totalSheets = count($sheets);
-            $currentIndex = 0;
 
             foreach ($sheets as $index => $sheet) {
-                $currentIndex++;
-                $isLast = ($currentIndex === $totalSheets);
                 $uniqueKey = $sheet->field_id ?? $index;
 
-                $fieldScores = collect($scoreMap[$sheet->field_id] ?? []);
-                $previousScore = $previousSession ? ($fieldScores->get($previousSession->id) ?? FieldScore::NOT_SCORED) : FieldScore::NOT_SCORED;
-                $bestScore = $fieldScores->isNotEmpty() ? $fieldScores->sortByDesc(fn (FieldScore $s) => $s->value)->first() : FieldScore::NOT_SCORED;
-
-                $rowClasses = 'pb-4 mb-6';
-                if (! $isLast) {
-                    $rowClasses .= ' border-b border-gray-200 dark:border-white/10';
-                }
+                $previousScore = MentoringReportScores::previousScore($scoreMap, $sheet->field_id, $previousSession);
+                $bestScore = MentoringReportScores::bestScore($scoreMap, $sheet->field_id);
 
                 $sheetRows[] = Grid::make(14)
                     ->schema([
@@ -254,10 +239,10 @@ class ViewMentoringReport extends Page implements HasInfolists
                             ->columnSpan(12)
                             ->hidden(blank($sheet->notes)),
                     ])
-                    ->extraAttributes(['class' => $rowClasses]);
+                    ->extraAttributes(['class' => MentoringReportLayout::CRITERION_ROW_CLASSES]);
             }
 
-            $categorySections[] = Section::make(new HtmlString("<span class='text-2xl font-extrabold tracking-tight text-gray-900 dark:text-white'>{$categoryName}</span>"))
+            $categorySections[] = Section::make(MentoringReportLayout::categorySectionTitle($categoryName))
                 ->schema($sheetRows);
         }
 

--- a/app/Filament/Training/Support/MentoringReportLayout.php
+++ b/app/Filament/Training/Support/MentoringReportLayout.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Support;
+
+use Illuminate\Support\HtmlString;
+
+final class MentoringReportLayout
+{
+    /** Vertical rhythm between criteria rows (no border separators). */
+    public const CRITERION_ROW_CLASSES = 'mb-10 last:mb-0';
+
+    public static function categorySectionTitle(string $categoryName): HtmlString
+    {
+        return new HtmlString(
+            "<span class='text-2xl font-extrabold tracking-tight text-gray-900 dark:text-white'>".e($categoryName).'</span>'
+        );
+    }
+}

--- a/app/Filament/Training/Support/MentoringReportScores.php
+++ b/app/Filament/Training/Support/MentoringReportScores.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Support;
+
+use App\Enums\FieldScore;
+use App\Models\Cts\ReportSheet;
+use App\Models\Cts\Session;
+use Illuminate\Support\Collection;
+
+final class MentoringReportScores
+{
+    /**
+     * @param  Collection<int, Session>  $sessions
+     * @return array<int, array<int, FieldScore>> [field_id => [session_id => score]]
+     */
+    public static function scoreMapForSessions(Collection $sessions): array
+    {
+        $map = [];
+
+        foreach ($sessions as $session) {
+            foreach ($session->reportSheets as $sheet) {
+                if (! $sheet instanceof ReportSheet) {
+                    continue;
+                }
+
+                $map[$sheet->field_id][$session->id] = $sheet->field_score;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param  array<int, array<int, FieldScore>>  $scoreMap
+     */
+    public static function bestScore(array $scoreMap, int $fieldId): FieldScore
+    {
+        $fieldScores = collect($scoreMap[$fieldId] ?? []);
+
+        if ($fieldScores->isEmpty()) {
+            return FieldScore::NOT_SCORED;
+        }
+
+        return $fieldScores->sortByDesc(fn (FieldScore $s) => $s->value)->first() ?? FieldScore::NOT_SCORED;
+    }
+
+    /**
+     * @param  array<int, array<int, FieldScore>>  $scoreMap
+     */
+    public static function previousScore(array $scoreMap, int $fieldId, ?Session $previousSession): FieldScore
+    {
+        if (! $previousSession) {
+            return FieldScore::NOT_SCORED;
+        }
+
+        return $scoreMap[$fieldId][$previousSession->id] ?? FieldScore::NOT_SCORED;
+    }
+}

--- a/app/Livewire/Training/AcceptedMentoringSessionsTable.php
+++ b/app/Livewire/Training/AcceptedMentoringSessionsTable.php
@@ -2,17 +2,23 @@
 
 namespace App\Livewire\Training;
 
+use App\Filament\Training\Pages\Mentor\ConductMentoringSession;
 use App\Models\Cts\Session;
+use App\Services\Training\MentoringReportService;
 use Carbon\Carbon;
+use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 
 class AcceptedMentoringSessionsTable extends Component implements HasActions, HasForms, HasTable
@@ -61,7 +67,64 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
                         ->orderBy('taken_from', $direction)
                     ),
             ])
+            ->recordActions([
+                Action::make('conduct')
+                    ->label('Conduct')
+                    ->url(fn (Session $record): string => ConductMentoringSession::getUrl(['sessionId' => $record->id]))
+                    ->visible(fn (Session $record): bool => auth()->user()?->can('conduct', $record) ?? false),
+                $this->markNoShowTableAction(),
+            ])
             ->emptyStateHeading('No upcoming mentoring sessions found');
+    }
+
+    protected function markNoShowTableAction(): Action
+    {
+        return Action::make('markNoShow')
+            ->label('Mark no-show')
+            ->color('danger')
+            ->icon('heroicon-o-user-minus')
+            ->visible(fn (Session $record): bool => app(MentoringReportService::class)->canMarkNoShow($record))
+            ->requiresConfirmation()
+            ->modalHeading('Mark session as no-show')
+            ->modalDescription(fn (Session $record) => app(MentoringReportService::class)->wasBookedWithShortNotice($record)
+                ? 'This session was booked with less than 24 hours notice. Did the student confirm their non-attendance via Discord?'
+                : 'Are you sure you want to mark this session as a no-show? The report will be filed automatically.')
+            ->schema(fn (Session $record) => app(MentoringReportService::class)->wasBookedWithShortNotice($record)
+                ? [
+                    Toggle::make('student_confirmed_discord')
+                        ->label('Student confirmed non-attendance via Discord')
+                        ->required(),
+                ]
+                : [])
+            ->action(function (Session $record, array $data, MentoringReportService $service): void {
+                $wasShortNotice = $service->wasBookedWithShortNotice($record);
+                $confirmed = (bool) ($data['student_confirmed_discord'] ?? false);
+
+                try {
+                    $service->markNoShow($record, $confirmed);
+                } catch (ValidationException $exception) {
+                    Notification::make()
+                        ->title('Unable to mark no-show')
+                        ->body(collect($exception->errors())->flatten()->first())
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                if ($wasShortNotice && ! $confirmed) {
+                    Notification::make()
+                        ->title('Session cancelled')
+                        ->body('The session was cancelled on your behalf. No no-show has been recorded for the student.')
+                        ->success()
+                        ->send();
+                } else {
+                    Notification::make()
+                        ->title('Session marked as no-show')
+                        ->success()
+                        ->send();
+                }
+            });
     }
 
     public function render()

--- a/app/Livewire/Training/PendingMentoringReportsTable.php
+++ b/app/Livewire/Training/PendingMentoringReportsTable.php
@@ -4,19 +4,25 @@ declare(strict_types=1);
 
 namespace App\Livewire\Training;
 
+use App\Filament\Training\Pages\Mentor\ConductMentoringSession;
 use App\Models\Cts\Session;
 use App\Repositories\Cts\SessionRepository;
+use App\Services\Training\MentoringReportService;
 use App\Services\Training\MentorPermissionService;
 use Carbon\Carbon;
+use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 
 class PendingMentoringReportsTable extends Component implements HasActions, HasForms, HasTable
@@ -69,6 +75,59 @@ class PendingMentoringReportsTable extends Component implements HasActions, HasF
                         ->orderBy('taken_date', $direction)
                         ->orderBy('taken_from', $direction)
                     ),
+            ])
+            ->recordActions([
+                Action::make('conduct')
+                    ->label('Conduct')
+                    ->url(fn (Session $record): string => ConductMentoringSession::getUrl(['sessionId' => $record->id]))
+                    ->visible(fn (Session $record): bool => auth()->user()?->can('conduct', $record) ?? false),
+                Action::make('markNoShow')
+                    ->label('Mark no-show')
+                    ->color('danger')
+                    ->icon('heroicon-o-user-minus')
+                    ->visible(fn (Session $record): bool => auth()->user()?->can('markNoShow', $record)
+                        && app(MentoringReportService::class)->canMarkNoShow($record))
+                    ->requiresConfirmation()
+                    ->modalHeading('Mark session as no-show')
+                    ->modalDescription(fn (Session $record) => app(MentoringReportService::class)->wasBookedWithShortNotice($record)
+                        ? 'This session was booked with less than 24 hours notice. Did the student confirm their non-attendance via Discord?'
+                        : 'Are you sure you want to mark this session as a no-show? The report will be filed automatically.')
+                    ->schema(fn (Session $record) => app(MentoringReportService::class)->wasBookedWithShortNotice($record)
+                        ? [
+                            Toggle::make('student_confirmed_discord')
+                                ->label('Student confirmed non-attendance via Discord')
+                                ->required(),
+                        ]
+                        : [])
+                    ->action(function (Session $record, array $data, MentoringReportService $service): void {
+                        $wasShortNotice = $service->wasBookedWithShortNotice($record);
+                        $confirmed = (bool) ($data['student_confirmed_discord'] ?? false);
+
+                        try {
+                            $service->markNoShow($record, $confirmed);
+                        } catch (ValidationException $exception) {
+                            Notification::make()
+                                ->title('Unable to mark no-show')
+                                ->body(collect($exception->errors())->flatten()->first())
+                                ->danger()
+                                ->send();
+
+                            return;
+                        }
+
+                        if ($wasShortNotice && ! $confirmed) {
+                            Notification::make()
+                                ->title('Session cancelled')
+                                ->body('The session was cancelled on your behalf. No no-show has been recorded for the student.')
+                                ->success()
+                                ->send();
+                        } else {
+                            Notification::make()
+                                ->title('Session marked as no-show')
+                                ->success()
+                                ->send();
+                        }
+                    }),
             ])
             ->emptyStateHeading('No pending mentoring reports in this training group');
     }

--- a/app/Notifications/Training/MentoringReportFiled.php
+++ b/app/Notifications/Training/MentoringReportFiled.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications\Training;
+
+use App\Models\Cts\Session;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MentoringReportFiled extends Notification
+{
+    use Queueable;
+
+    public function __construct(public Session $session) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $subject = 'Session report finished';
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
+            ->subject($subject)
+            ->view('emails.training.mentoring_report_filed', [
+                'subject' => $subject,
+                'recipient' => $notifiable,
+                'session' => $this->session,
+            ]);
+    }
+}

--- a/app/Notifications/Training/MentoringReportFiled.php
+++ b/app/Notifications/Training/MentoringReportFiled.php
@@ -6,10 +6,11 @@ namespace App\Notifications\Training;
 
 use App\Models\Cts\Session;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class MentoringReportFiled extends Notification
+class MentoringReportFiled extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/Training/StudentMentoringNoShow.php
+++ b/app/Notifications/Training/StudentMentoringNoShow.php
@@ -6,10 +6,11 @@ namespace App\Notifications\Training;
 
 use App\Models\Cts\Session;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class StudentMentoringNoShow extends Notification
+class StudentMentoringNoShow extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/Training/StudentMentoringNoShow.php
+++ b/app/Notifications/Training/StudentMentoringNoShow.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications\Training;
+
+use App\Models\Cts\Session;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class StudentMentoringNoShow extends Notification
+{
+    use Queueable;
+
+    public function __construct(public Session $session) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $subject = 'Student mentoring session no-show';
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
+            ->subject($subject)
+            ->view('emails.training.student_mentoring_no_show', [
+                'subject' => $subject,
+                'recipient' => $notifiable,
+                'session' => $this->session,
+            ]);
+    }
+}

--- a/app/Policies/Training/Mentoring/MentoringPolicy.php
+++ b/app/Policies/Training/Mentoring/MentoringPolicy.php
@@ -75,10 +75,14 @@ class MentoringPolicy
     }
 
     /**
-     * View a mentoring session report.
+     * View a filed mentoring session report.
      */
     public function view(Account $user, Session $session): bool
     {
+        if ($session->filed === null) {
+            return false;
+        }
+
         // Students should always be able to view their own reports
         if ($session->student_id === $user->id) {
             return true;

--- a/app/Policies/Training/Mentoring/MentoringPolicy.php
+++ b/app/Policies/Training/Mentoring/MentoringPolicy.php
@@ -117,4 +117,40 @@ class MentoringPolicy
 
         return in_array($position, $user->getAllAssignedCallsigns(), true);
     }
+
+    /**
+     * Write or file a mentoring report for an assigned session.
+     */
+    public function conduct(Account $user, Session $session): bool
+    {
+        return $this->canManageOwnOpenSession($user, $session);
+    }
+
+    public function file(Account $user, Session $session): bool
+    {
+        return $this->conduct($user, $session);
+    }
+
+    public function markNoShow(Account $user, Session $session): bool
+    {
+        return $this->conduct($user, $session);
+    }
+
+    private function canManageOwnOpenSession(Account $user, Session $session): bool
+    {
+        // explicitly check the mentor's CID to avoid CTS member ID mismatch issues
+        if ($session->mentor?->cid !== $user->id) {
+            return false;
+        }
+
+        if ($session->session_done || $session->filed !== null) {
+            return false;
+        }
+
+        if ($session->cancelled_datetime !== null) {
+            return false;
+        }
+
+        return (int) $session->taken === 1;
+    }
 }

--- a/app/Repositories/Cts/MentoringReportRepository.php
+++ b/app/Repositories/Cts/MentoringReportRepository.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\Cts;
+
+use App\Enums\FieldScore;
+use App\Models\Cts\ProgSheetField;
+use App\Models\Cts\ReportSheet;
+use App\Models\Cts\Session;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use Illuminate\Support\Collection;
+
+class MentoringReportRepository
+{
+    public function upsertCriterion(
+        Session $session,
+        int $fieldId,
+        FieldScore $score,
+        ?string $notes = null,
+    ): void {
+        ReportSheet::updateOrCreate(
+            [
+                'seshid' => $session->id,
+                'field_id' => $fieldId,
+            ],
+            [
+                'student_id' => $session->student_id,
+                'prog_sheet_id' => $session->progress_sheet_id,
+                'field_score' => $score->value,
+                'notes' => $notes ?? '',
+            ],
+        );
+    }
+
+    public function upsertAdditionalComments(Session $session, ?string $notes): void
+    {
+        $this->upsertCriterion($session, 0, FieldScore::NOT_SCORED, $notes);
+    }
+
+    /**
+     * @return Collection<int, ProgSheetField>
+     */
+    public function getCriteriaFieldsForSession(Session $session): Collection
+    {
+        return ProgSheetField::query()
+            ->where('prog_sheet_id', $session->progress_sheet_id)
+            ->where('disabled', '!=', 1)
+            ->with('category')
+            ->orderBy('field_id')
+            ->get();
+    }
+
+    /**
+     * @return array<int, FieldScore>
+     */
+    public function getExistingScoresForSession(Session $session): array
+    {
+        return ReportSheet::query()
+            ->where('seshid', $session->id)
+            ->where('field_id', '!=', 0)
+            ->get()
+            ->mapWithKeys(fn (ReportSheet $sheet) => [$sheet->field_id => $sheet->field_score])
+            ->all();
+    }
+
+    public function getExistingAdditionalComments(Session $session): ?string
+    {
+        $notes = ReportSheet::query()
+            ->where('seshid', $session->id)
+            ->where('field_id', 0)
+            ->value('notes');
+
+        return $notes !== null && $notes !== '' ? $notes : null;
+    }
+
+    /**
+     * @return array<int, FieldScore>
+     */
+    public function getPreviousScoresForStudent(Session $session): array
+    {
+        $previousSession = $this->getPreviousFiledSession($session);
+
+        if (! $previousSession) {
+            return [];
+        }
+
+        return ReportSheet::query()
+            ->where('seshid', $previousSession->id)
+            ->where('field_id', '!=', 0)
+            ->get()
+            ->mapWithKeys(fn (ReportSheet $sheet) => [$sheet->field_id => $sheet->field_score])
+            ->all();
+    }
+
+    /**
+     * @return array<int, FieldScore>
+     */
+    public function getBestScoresForStudent(Session $session): array
+    {
+        $relatedPositions = $this->getRelatedPositions($session);
+
+        $sessionIds = Session::query()
+            ->where('student_id', $session->student_id)
+            ->whereIn('position', $relatedPositions)
+            ->where('progress_sheet_id', $session->progress_sheet_id)
+            ->whereNotNull('filed')
+            ->whereNull('cancelled_datetime')
+            ->where('noShow', 0)
+            ->where('id', '!=', $session->id)
+            ->pluck('id');
+
+        if ($sessionIds->isEmpty()) {
+            return [];
+        }
+
+        $bestScores = [];
+
+        ReportSheet::query()
+            ->whereIn('seshid', $sessionIds)
+            ->where('field_id', '!=', 0)
+            ->get()
+            ->each(function (ReportSheet $sheet) use (&$bestScores): void {
+                $fieldId = $sheet->field_id;
+                $score = $sheet->field_score;
+
+                if (! isset($bestScores[$fieldId]) || $score->value > $bestScores[$fieldId]->value) {
+                    $bestScores[$fieldId] = $score;
+                }
+            });
+
+        return $bestScores;
+    }
+
+    public function getPreviousFiledSession(Session $session): ?Session
+    {
+        $relatedPositions = $this->getRelatedPositions($session);
+
+        return Session::query()
+            ->where('student_id', $session->student_id)
+            ->whereIn('position', $relatedPositions)
+            ->where('progress_sheet_id', $session->progress_sheet_id)
+            ->whereNotNull('filed')
+            ->whereNull('cancelled_datetime')
+            ->where('noShow', 0)
+            ->where('id', '!=', $session->id)
+            ->where(function ($query) use ($session): void {
+                $query->where('taken_date', '<', $session->taken_date)
+                    ->orWhere(function ($inner) use ($session) {
+                        $inner->where('taken_date', $session->taken_date)
+                            ->where('taken_from', '<', $session->taken_from);
+                    });
+            })
+            ->orderByDesc('taken_date')
+            ->orderByDesc('taken_from')
+            ->first();
+    }
+
+    public function getPrimaryPosition(string $position): string
+    {
+        $callsigns = TrainingPosition::query()
+            ->whereJsonContains('cts_positions', $position)
+            ->get()
+            ->flatMap(fn (TrainingPosition $trainingPosition) => $trainingPosition->cts_positions ?? [])
+            ->unique()
+            ->filter()
+            ->values()
+            ->all();
+
+        return $callsigns[0] ?? $position;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getRelatedPositions(Session $session): array
+    {
+        $callsigns = TrainingPosition::query()
+            ->whereJsonContains('cts_positions', $session->position)
+            ->get()
+            ->flatMap(fn (TrainingPosition $position) => $position->cts_positions ?? [])
+            ->unique()
+            ->filter()
+            ->values()
+            ->all();
+
+        if ($callsigns === []) {
+            return [$session->position];
+        }
+
+        return $callsigns;
+    }
+
+    public function fileSession(Session $session, bool $noShow = false): void
+    {
+        $session->update([
+            'session_done' => 1,
+            'book_done' => 1,
+            'filed' => now(),
+            'noShow' => $noShow ? 1 : 0,
+        ]);
+    }
+}

--- a/app/Repositories/Cts/MentoringReportRepository.php
+++ b/app/Repositories/Cts/MentoringReportRepository.php
@@ -158,16 +158,19 @@ class MentoringReportRepository
 
     public function getPrimaryPosition(string $position): string
     {
-        $callsigns = TrainingPosition::query()
+        $trainingPositions = TrainingPosition::query()
             ->whereJsonContains('cts_positions', $position)
-            ->get()
-            ->flatMap(fn (TrainingPosition $trainingPosition) => $trainingPosition->cts_positions ?? [])
-            ->unique()
-            ->filter()
-            ->values()
-            ->all();
+            ->get();
 
-        return $callsigns[0] ?? $position;
+        foreach ($trainingPositions as $trainingPosition) {
+            $primary = $trainingPosition->cts_primary_position;
+
+            if (is_string($primary) && trim($primary) !== '') {
+                return trim($primary);
+            }
+        }
+
+        return $position;
     }
 
     /**

--- a/app/Services/Training/MentoringReportService.php
+++ b/app/Services/Training/MentoringReportService.php
@@ -64,13 +64,13 @@ class MentoringReportService
 
         DB::connection('cts')->transaction(function () use ($session): void {
             $this->repository->fileSession($session);
-
-            $studentAccount = $session->student?->account;
-
-            if ($studentAccount) {
-                $studentAccount->notify(new MentoringReportFiled($session));
-            }
         });
+
+        $studentAccount = $session->student?->account;
+
+        if ($studentAccount) {
+            $studentAccount->notify(new MentoringReportFiled($session));
+        }
     }
 
     public function canMarkNoShow(Session $session): bool
@@ -134,9 +134,9 @@ class MentoringReportService
 
             $this->repository->upsertAdditionalComments($session, null);
             $this->repository->fileSession($session, noShow: true);
-
-            $this->notifyTgisOfNoShow($session);
         });
+
+        $this->notifyTgisOfNoShow($session);
     }
 
     public function cancelSessionAsMentor(Session $session, string $reason): void

--- a/app/Services/Training/MentoringReportService.php
+++ b/app/Services/Training/MentoringReportService.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Training;
+
+use App\Enums\FieldScore;
+use App\Models\Cts\CancelReason;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use App\Notifications\Training\MentoringReportFiled;
+use App\Notifications\Training\StudentMentoringNoShow;
+use App\Repositories\Cts\MentoringReportRepository;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class MentoringReportService
+{
+    public function __construct(
+        private readonly MentoringReportRepository $repository,
+        private readonly MentorPermissionService $mentorPermissionService,
+    ) {}
+
+    /**
+     * @param  array<int, array{score: FieldScore, notes: ?string}>  $criteriaData
+     */
+    public function saveDraft(Session $session, array $criteriaData, ?string $additionalComments): void
+    {
+        DB::connection('cts')->transaction(function () use ($session, $criteriaData, $additionalComments): void {
+            foreach ($criteriaData as $fieldId => $data) {
+                $this->repository->upsertCriterion(
+                    $session,
+                    (int) $fieldId,
+                    $data['score'],
+                    $data['notes'],
+                );
+            }
+
+            if ($additionalComments !== null) {
+                $this->repository->upsertAdditionalComments($session, $additionalComments);
+            }
+        });
+    }
+
+    public function submit(Session $session): void
+    {
+        $this->assertCanConduct($session);
+
+        $fields = $this->repository->getCriteriaFieldsForSession($session);
+        $existingScores = $this->repository->getExistingScoresForSession($session);
+
+        $unscoredFields = $fields->filter(function ($field) use ($existingScores) {
+            $score = $existingScores[$field->field_id] ?? FieldScore::NOT_SCORED;
+
+            return $score === FieldScore::NOT_SCORED;
+        });
+
+        if ($unscoredFields->isNotEmpty()) {
+            throw ValidationException::withMessages([
+                'criteria' => 'You must select a score for every criteria before submitting the report.',
+            ]);
+        }
+
+        DB::connection('cts')->transaction(function () use ($session): void {
+            $this->repository->fileSession($session);
+
+            $studentAccount = $session->student?->account;
+
+            if ($studentAccount) {
+                $studentAccount->notify(new MentoringReportFiled($session));
+            }
+        });
+    }
+
+    public function canMarkNoShow(Session $session): bool
+    {
+        if ($session->session_done || $session->filed || $session->cancelled_datetime || $session->noShow) {
+            return false;
+        }
+
+        $sessionStart = Carbon::parse("{$session->taken_date} {$session->taken_from}");
+        $delayMinutes = config('training.mentoring.no_show_delay_minutes', 5);
+
+        return now()->greaterThanOrEqualTo($sessionStart->copy()->addMinutes($delayMinutes));
+    }
+
+    public function wasBookedWithShortNotice(Session $session): bool
+    {
+        if (! $session->taken_time) {
+            return false;
+        }
+
+        $sessionStart = Carbon::parse("{$session->taken_date} {$session->taken_from}");
+        $bookedAt = Carbon::parse($session->taken_time);
+        $shortNoticeHours = config('training.mentoring.short_notice_hours', 24);
+
+        return $bookedAt->diffInHours($sessionStart, false) < $shortNoticeHours;
+    }
+
+    public function markNoShow(Session $session, bool $studentConfirmedDiscordOnShortNotice): void
+    {
+        $this->assertCanConduct($session);
+
+        if (! $this->canMarkNoShow($session)) {
+            throw ValidationException::withMessages([
+                'no_show' => 'This session cannot be marked as a no-show yet.',
+            ]);
+        }
+
+        if ($this->wasBookedWithShortNotice($session) && ! $studentConfirmedDiscordOnShortNotice) {
+            $this->cancelSessionAsMentor(
+                $session,
+                'Session cancelled: student did not confirm attendance via Discord for a short-notice booking.',
+            );
+
+            return;
+        }
+
+        DB::connection('cts')->transaction(function () use ($session): void {
+            $previousScores = $this->repository->getPreviousScoresForStudent($session);
+            $fields = $this->repository->getCriteriaFieldsForSession($session);
+
+            foreach ($fields as $field) {
+                $score = $previousScores[$field->field_id] ?? FieldScore::NOT_APPLICABLE;
+
+                $this->repository->upsertCriterion(
+                    $session,
+                    $field->field_id,
+                    $score,
+                    null,
+                );
+            }
+
+            $this->repository->upsertAdditionalComments($session, null);
+            $this->repository->fileSession($session, noShow: true);
+
+            $this->notifyTgisOfNoShow($session);
+        });
+    }
+
+    public function cancelSessionAsMentor(Session $session, string $reason): void
+    {
+        $this->assertCanConduct($session);
+
+        DB::connection('cts')->transaction(function () use ($session, $reason): void {
+            $mentorId = $session->mentor_id;
+
+            CancelReason::create([
+                'sesh_id' => $session->id,
+                'sesh_type' => 'ME',
+                'reason' => $reason,
+                'reason_by' => $mentorId,
+                'date' => now(),
+            ]);
+
+            $primaryPosition = $this->repository->getPrimaryPosition($session->position);
+
+            $session->update([
+                'position' => $primaryPosition,
+                'taken' => 0,
+                'mentor_id' => null,
+                'mentor_rating' => null,
+                'taken_date' => null,
+                'taken_from' => null,
+                'taken_to' => null,
+                'taken_time' => null,
+            ]);
+        });
+    }
+
+    /**
+     * @return array<int, FieldScore>
+     */
+    public function getPreviousScores(Session $session): array
+    {
+        return $this->repository->getPreviousScoresForStudent($session);
+    }
+
+    /**
+     * @return array<int, FieldScore>
+     */
+    public function getBestScores(Session $session): array
+    {
+        return $this->repository->getBestScoresForStudent($session);
+    }
+
+    private function assertCanConduct(Session $session): void
+    {
+        if ($session->session_done || $session->filed) {
+            throw ValidationException::withMessages([
+                'session' => 'This session report has already been filed.',
+            ]);
+        }
+
+        if ($session->cancelled_datetime) {
+            throw ValidationException::withMessages([
+                'session' => 'This session has been cancelled.',
+            ]);
+        }
+    }
+
+    private function notifyTgisOfNoShow(Session $session): void
+    {
+        $category = $this->resolveCategoryForPosition($session->position);
+
+        if (! $category) {
+            return;
+        }
+
+        $permissionName = 'training.mentors.manage.'.MentorPermissionService::categoryType($category);
+
+        $recipients = Account::permission($permissionName)->get();
+
+        foreach ($recipients as $recipient) {
+            $recipient->notify(new StudentMentoringNoShow($session));
+        }
+    }
+
+    private function resolveCategoryForPosition(string $position): ?string
+    {
+        foreach (array_merge(MentorPermissionService::atcCategories(), MentorPermissionService::pilotCategories()) as $category) {
+            if (in_array($position, $this->mentorPermissionService->getAllCtsCallsignsForCategory($category), true)) {
+                return $category;
+            }
+        }
+
+        return null;
+    }
+}

--- a/config/training.php
+++ b/config/training.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'mentoring' => [
+        'no_show_delay_minutes' => (int) env('TRAINING_MENTORING_NO_SHOW_DELAY_MINUTES', 5),
+        'short_notice_hours' => (int) env('TRAINING_MENTORING_SHORT_NOTICE_HOURS', 24),
+    ],
+
     'discord' => [
         'exam_announce_channel_id' => env('DISCORD_EXAM_ANNOUNCE_CHANNEL_ID', 1086017278988013609),
         'exam_pilot_role_id' => env('DISCORD_EXAM_PILOT_ROLE_ID', 1086016803047747675),

--- a/database/factories/Cts/MemberFactory.php
+++ b/database/factories/Cts/MemberFactory.php
@@ -13,10 +13,11 @@ class MemberFactory extends Factory
     public function definition(): array
     {
         $joined = Carbon::now();
+        $cid = $this->faker->unique()->numberBetween(810000, 1400000);
 
         return [
-            'id' => rand(810000, 1400000),
-            'cid' => rand(810000, 1400000),
+            'id' => $cid,
+            'cid' => $cid,
             'name' => $this->faker->name,
             'joined' => $joined,
             'joined_div' => $joined->addDays(rand(-240, 0)),

--- a/database/factories/Cts/SessionFactory.php
+++ b/database/factories/Cts/SessionFactory.php
@@ -30,6 +30,7 @@ class SessionFactory extends Factory
     public function accepted(): Factory
     {
         return $this->state([
+            'taken' => 1,
             'mentor_id' => Member::Factory()->create()->id,
             'mentor_rating' => 5,
             'taken_time' => now(),

--- a/database/seeders/LocalDevelopment/Training/Concerns/SeedsDevMentoringSessions.php
+++ b/database/seeders/LocalDevelopment/Training/Concerns/SeedsDevMentoringSessions.php
@@ -152,6 +152,34 @@ trait SeedsDevMentoringSessions
     }
 
     /**
+     * Accepted session past its scheduled time, awaiting a filed report (conduct page).
+     */
+    protected function seedDevPendingConductSession(Member $student, Member $mentor, string $position, int $progressSheetId = 1): Session
+    {
+        return $this->upsertDevMentoringSession(
+            [
+                'student_id' => $student->id,
+                'position' => $position,
+                'mentor_id' => $mentor->id,
+                'taken_date' => now()->subDay()->format('Y-m-d'),
+            ],
+            [
+                'mentor_rating' => 3,
+                'taken' => 1,
+                'session_done' => 0,
+                'filed' => null,
+                'taken_time' => now()->subDays(3),
+                'taken_from' => '18:00:00',
+                'taken_to' => '20:00:00',
+                'cancelled_datetime' => null,
+                'noShow' => 0,
+                'request_time' => now()->subDays(10),
+                'progress_sheet_id' => $progressSheetId,
+            ],
+        );
+    }
+
+    /**
      * @param  array<string, mixed>  $match
      * @param  array<string, mixed>  $attributes
      */

--- a/database/seeders/LocalDevelopment/Training/Concerns/SeedsDevProgSheet.php
+++ b/database/seeders/LocalDevelopment/Training/Concerns/SeedsDevProgSheet.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\LocalDevelopment\Training\Concerns;
+
+use App\Models\Cts\ProgSheet;
+use App\Models\Cts\ProgSheetCategory;
+use App\Models\Cts\ProgSheetField;
+
+/**
+ * Idempotent progress sheet fixtures for local mentoring conduct testing.
+ */
+trait SeedsDevProgSheet
+{
+    protected function seedDevProgSheet(int $progSheetId = 1): void
+    {
+        ProgSheet::query()->updateOrCreate(
+            ['prog_sheet_id' => $progSheetId],
+            [
+                'name' => 'Dev TWR Progress Sheet',
+                'created_by' => 0,
+                'created_date' => now(),
+                'disabled' => 0,
+            ],
+        );
+
+        $category = ProgSheetCategory::query()->updateOrCreate(
+            [
+                'prog_sheet_id' => $progSheetId,
+                'catName' => 'General Control',
+            ],
+            [
+                'disabled' => 0,
+            ],
+        );
+
+        ProgSheetField::query()->updateOrCreate(
+            [
+                'prog_sheet_id' => $progSheetId,
+                'field' => 'Radio telephony',
+            ],
+            [
+                'catId' => $category->catId,
+                'groupId' => 1,
+                'created_by' => 0,
+                'created_date' => now(),
+                'disabled' => 0,
+            ],
+        );
+
+        ProgSheetField::query()->updateOrCreate(
+            [
+                'prog_sheet_id' => $progSheetId,
+                'field' => 'Separation standards',
+            ],
+            [
+                'catId' => $category->catId,
+                'groupId' => 2,
+                'created_by' => 0,
+                'created_date' => now(),
+                'disabled' => 0,
+            ],
+        );
+    }
+}

--- a/database/seeders/LocalDevelopment/Training/DevMentorConductSeeder.php
+++ b/database/seeders/LocalDevelopment/Training/DevMentorConductSeeder.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\LocalDevelopment\Training;
+
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\MentorPermissionService;
+use Database\Seeders\LocalDevelopment\Training\Concerns\CreatesLinkedAccount;
+use Database\Seeders\LocalDevelopment\Training\Concerns\SeedsDevMentoringSessions;
+use Database\Seeders\LocalDevelopment\Training\Concerns\SeedsDevProgSheet;
+use Illuminate\Database\Seeder;
+use RuntimeException;
+
+/**
+ * Seeds mentoring conduct fixtures for a real local login account (default CID 10000005).
+ *
+ * @see database/seeders/LocalDevelopment/README.md
+ */
+class DevMentorConductSeeder extends Seeder
+{
+    use CreatesLinkedAccount;
+    use SeedsDevMentoringSessions;
+    use SeedsDevProgSheet;
+
+    public function run(): void
+    {
+        $this->ensurePrerequisites();
+
+        $mentor = $this->resolveMentorAccount();
+        $mentorMember = Member::query()->where('cid', $mentor->id)->firstOrFail();
+        $studentMember = Member::query()->where('cid', DevTrainingPersonas::STUDENT_EXAMS_CID)->firstOrFail();
+
+        $this->seedDevProgSheet();
+
+        $mentor->givePermissionTo([
+            'training.access',
+            'training.beta',
+            'training.mentors.view.atc',
+        ]);
+
+        $trainingPosition = DevTrainingFoundation::$trainingPositionsByCallsign['EGKK_TWR']
+            ?? TrainingPosition::query()->where('cts_primary_position', 'EGKK_TWR')->firstOrFail();
+
+        app(MentorPermissionService::class)->assignToMentorable(
+            $mentor,
+            $trainingPosition,
+            $mentor,
+            'S2 Training',
+        );
+
+        $session = $this->seedDevPendingConductSession($studentMember, $mentorMember, 'EGKK_TWR');
+
+        $this->command?->info("Mentor conduct fixtures seeded for CID {$mentor->id}.");
+        $this->command?->line("Conduct URL: /training/mentoring/conduct/{$session->id}");
+        $this->command?->line('Training panel → Mentoring → Accepted Mentoring Sessions → Conduct');
+    }
+
+    private function resolveMentorAccount(): Account
+    {
+        $existing = Account::query()->find(DevTrainingPersonas::MENTOR_CONDUCT_CID);
+
+        if ($existing !== null) {
+            Member::query()->firstOrCreate(
+                ['cid' => $existing->id],
+                [
+                    'id' => $existing->id,
+                    'name' => $existing->name,
+                    'joined' => now(),
+                    'joined_div' => now(),
+                ],
+            );
+
+            return $existing->fresh();
+        }
+
+        return $this->createLinkedAccount(
+            DevTrainingPersonas::MENTOR_CONDUCT_CID,
+            'Dev',
+            'Mentor Conduct',
+            'dev-mentor-conduct@example.test',
+        );
+    }
+
+    private function ensurePrerequisites(): void
+    {
+        if (TrainingPosition::query()->where('cts_primary_position', 'EGKK_TWR')->doesntExist()) {
+            throw new RuntimeException(
+                'Run AtcAndCtsTrainingPositionsSeeder (or LocalDevelopmentTrainingSeeder) before DevMentorConductSeeder.',
+            );
+        }
+
+        if (Member::query()->where('cid', DevTrainingPersonas::STUDENT_EXAMS_CID)->doesntExist()) {
+            throw new RuntimeException(
+                'Run CtsExamsAndMentoringSeeder (or LocalDevelopmentTrainingSeeder) before DevMentorConductSeeder.',
+            );
+        }
+    }
+}

--- a/database/seeders/LocalDevelopment/Training/DevTrainingPersonas.php
+++ b/database/seeders/LocalDevelopment/Training/DevTrainingPersonas.php
@@ -61,6 +61,9 @@ final class DevTrainingPersonas
 
     public const STUDENT_EXAMS_CID = 9000012;
 
+    /** Sandbox / local mentor account for conduct-session testing. */
+    public const MENTOR_CONDUCT_CID = 10000005;
+
     public const STAFF_EMAIL = 'dev-training-staff@example.test';
 
     public const STUDENT_EMAIL = 'dev-training-student@example.test';

--- a/database/seeders/LocalDevelopmentTrainingSeeder.php
+++ b/database/seeders/LocalDevelopmentTrainingSeeder.php
@@ -6,6 +6,7 @@ namespace Database\Seeders;
 
 use Database\Seeders\LocalDevelopment\Training\AtcAndCtsTrainingPositionsSeeder;
 use Database\Seeders\LocalDevelopment\Training\CtsExamsAndMentoringSeeder;
+use Database\Seeders\LocalDevelopment\Training\DevMentorConductSeeder;
 use Database\Seeders\LocalDevelopment\Training\DevTrainingFoundation;
 use Database\Seeders\LocalDevelopment\Training\DevTrainingPersonas;
 use Database\Seeders\LocalDevelopment\Training\DevTrainingPersonasSeeder;
@@ -36,6 +37,7 @@ class LocalDevelopmentTrainingSeeder extends Seeder
             DevTrainingPersonasSeeder::class,
             TrainingPlaceAvailabilitySeeder::class,
             CtsExamsAndMentoringSeeder::class,
+            DevMentorConductSeeder::class,
         ]);
 
         $this->printSummary();
@@ -77,6 +79,12 @@ class LocalDevelopmentTrainingSeeder extends Seeder
                     (string) DevTrainingPersonas::STUDENT_EXAMS_CID,
                     DevTrainingPersonas::STUDENT_EXAMS_EMAIL,
                     'Exams + mentoring history; open mentoring request',
+                ],
+                [
+                    'Mentor (conduct)',
+                    (string) DevTrainingPersonas::MENTOR_CONDUCT_CID,
+                    '(your sandbox account if present)',
+                    'Pending conduct session on EGKK_TWR — log in as this CID',
                 ],
             ],
         );

--- a/resources/assets/css/tailwind.css
+++ b/resources/assets/css/tailwind.css
@@ -1,4 +1,5 @@
 @import '../../../vendor/filament/filament/resources/css/theme.css';
+@import '../../css/filament/training/notes.css';
 
 @config '../../../tailwind.config.js';
 

--- a/resources/css/filament/training/notes.css
+++ b/resources/css/filament/training/notes.css
@@ -1,0 +1,44 @@
+@layer components {
+    /* Conduct mentoring: notes area matches filed report (no input box chrome). */
+    .fi-fo-field.mentoring-report-notes-field .fi-input-wrp.fi-fo-rich-editor {
+        @apply rounded-none bg-transparent shadow-none ring-0 dark:bg-transparent;
+    }
+
+    .fi-fo-field.mentoring-report-notes-field .fi-fo-rich-editor-toolbar {
+        @apply border-0 bg-transparent px-0 pt-0;
+    }
+
+    .fi-fo-field.mentoring-report-notes-field .fi-fo-rich-editor-content {
+        @apply px-0;
+    }
+
+    .cts-notes-content h1,
+    .cts-notes-content h2,
+    .cts-notes-content h3,
+    .cts-notes-content h4,
+    .cts-notes-content h5,
+    .cts-notes-content h6 {
+        @apply font-semibold leading-tight;
+    }
+
+    .cts-notes-content h1 {
+        @apply text-2xl;
+    }
+
+    .cts-notes-content h2 {
+        @apply text-xl;
+    }
+
+    .cts-notes-content h3 {
+        @apply text-lg;
+    }
+
+    .cts-notes-content h4 {
+        @apply text-base;
+    }
+
+    .cts-notes-content h5,
+    .cts-notes-content h6 {
+        @apply text-sm;
+    }
+}

--- a/resources/css/filament/training/theme.css
+++ b/resources/css/filament/training/theme.css
@@ -2,3 +2,18 @@
 
 @source '../../../../app/Filament/Training/**/*';
 @source '../../../../resources/views/filament/training/**/*';
+
+@layer components {
+    /* Conduct mentoring: notes area matches filed report (no input box chrome). */
+    .fi-fo-field.mentoring-report-notes-field .fi-input-wrp.fi-fo-rich-editor {
+        @apply rounded-none bg-transparent shadow-none ring-0 dark:bg-transparent;
+    }
+
+    .fi-fo-field.mentoring-report-notes-field .fi-fo-rich-editor-toolbar {
+        @apply border-0 bg-transparent px-0 pt-0;
+    }
+
+    .fi-fo-field.mentoring-report-notes-field .fi-fo-rich-editor-content {
+        @apply px-0;
+    }
+}

--- a/resources/css/filament/training/theme.css
+++ b/resources/css/filament/training/theme.css
@@ -3,47 +3,4 @@
 @source '../../../../app/Filament/Training/**/*';
 @source '../../../../resources/views/filament/training/**/*';
 
-@layer components {
-    /* Conduct mentoring: notes area matches filed report (no input box chrome). */
-    .fi-fo-field.mentoring-report-notes-field .fi-input-wrp.fi-fo-rich-editor {
-        @apply rounded-none bg-transparent shadow-none ring-0 dark:bg-transparent;
-    }
-
-    .fi-fo-field.mentoring-report-notes-field .fi-fo-rich-editor-toolbar {
-        @apply border-0 bg-transparent px-0 pt-0;
-    }
-
-    .fi-fo-field.mentoring-report-notes-field .fi-fo-rich-editor-content {
-        @apply px-0;
-    }
-
-    .cts-notes-content h1,
-    .cts-notes-content h2,
-    .cts-notes-content h3,
-    .cts-notes-content h4,
-    .cts-notes-content h5,
-    .cts-notes-content h6 {
-        @apply font-semibold leading-tight;
-    }
-
-    .cts-notes-content h1 {
-        @apply text-2xl;
-    }
-
-    .cts-notes-content h2 {
-        @apply text-xl;
-    }
-
-    .cts-notes-content h3 {
-        @apply text-lg;
-    }
-
-    .cts-notes-content h4 {
-        @apply text-base;
-    }
-
-    .cts-notes-content h5,
-    .cts-notes-content h6 {
-        @apply text-sm;
-    }
-}
+@import './notes.css';

--- a/resources/css/filament/training/theme.css
+++ b/resources/css/filament/training/theme.css
@@ -16,4 +16,34 @@
     .fi-fo-field.mentoring-report-notes-field .fi-fo-rich-editor-content {
         @apply px-0;
     }
+
+    .cts-notes-content h1,
+    .cts-notes-content h2,
+    .cts-notes-content h3,
+    .cts-notes-content h4,
+    .cts-notes-content h5,
+    .cts-notes-content h6 {
+        @apply font-semibold leading-tight;
+    }
+
+    .cts-notes-content h1 {
+        @apply text-2xl;
+    }
+
+    .cts-notes-content h2 {
+        @apply text-xl;
+    }
+
+    .cts-notes-content h3 {
+        @apply text-lg;
+    }
+
+    .cts-notes-content h4 {
+        @apply text-base;
+    }
+
+    .cts-notes-content h5,
+    .cts-notes-content h6 {
+        @apply text-sm;
+    }
 }

--- a/resources/views/emails/training/mentoring_report_filed.blade.php
+++ b/resources/views/emails/training/mentoring_report_filed.blade.php
@@ -1,0 +1,13 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>
+        This is a notification that your mentor has finished your report.<br>
+        Position: {{ $session->position }}<br>
+        Session date: {{ $session->taken_date }} {{ $session->taken_from }} - {{ $session->taken_to }}
+    </p>
+@stop
+
+@section('signature')
+    VATSIM UK Training Department
+@stop

--- a/resources/views/emails/training/student_mentoring_no_show.blade.php
+++ b/resources/views/emails/training/student_mentoring_no_show.blade.php
@@ -1,0 +1,21 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>
+        A student has been marked as a no-show for a mentoring session in your training group.
+    </p>
+
+    <h4>Session Details:</h4>
+    <ul>
+        <li><strong>Student:</strong> {{ $session->student?->name ?? 'Unknown student' }}
+            ({{ $session->student?->cid ?? 'Unknown' }})</li>
+        <li><strong>Position:</strong> {{ $session->position }}</li>
+        <li><strong>Date &amp; Time:</strong> {{ \Carbon\Carbon::parse($session->taken_date)->format('d/m/Y') }}
+            {{ \Carbon\Carbon::parse($session->taken_from)->format('H:i') }} &ndash;
+            {{ \Carbon\Carbon::parse($session->taken_to)->format('H:i') }}</li>
+    </ul>
+@stop
+
+@section('signature')
+    VATSIM UK Training Department
+@stop

--- a/resources/views/filament/training/pages/conduct-mentoring-session.blade.php
+++ b/resources/views/filament/training/pages/conduct-mentoring-session.blade.php
@@ -1,0 +1,8 @@
+<x-filament-panels::page>
+	<div wire:poll.5s="autosave"></div>
+	{{ $this->sessionDetailsInfolist }}
+
+	{{ $this->form }}
+
+	{{ $this->additionalCommentsForm }}
+</x-filament-panels::page>

--- a/tests/Feature/Seeders/LocalDevelopmentTrainingSeederTest.php
+++ b/tests/Feature/Seeders/LocalDevelopmentTrainingSeederTest.php
@@ -129,6 +129,20 @@ class LocalDevelopmentTrainingSeederTest extends TestCase
         $this->assertTrue(
             MentorTrainingPosition::query()->where('account_id', DevTrainingPersonas::STAFF_CID)->exists()
         );
+
+        $mentorMemberId = Member::query()->where('cid', DevTrainingPersonas::MENTOR_CONDUCT_CID)->value('id');
+        $this->assertNotNull($mentorMemberId);
+        $this->assertTrue(
+            Session::query()
+                ->where('mentor_id', $mentorMemberId)
+                ->where('position', 'EGKK_TWR')
+                ->whereNull('filed')
+                ->where('taken', 1)
+                ->exists(),
+        );
+        $this->assertTrue(
+            Account::findOrFail(DevTrainingPersonas::MENTOR_CONDUCT_CID)->hasPermissionTo('training.beta'),
+        );
     }
 
     #[Test]

--- a/tests/Feature/TrainingPanel/Exams/ConductExamPilotTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ConductExamPilotTest.php
@@ -128,7 +128,7 @@ class ConductExamPilotTest extends BaseTrainingPanelTestCase
             'examid' => $exam->id,
             'student_id' => $student->id,
             'result' => ExamResultEnum::Pass->value,
-            'notes' => 'Student passed all sections.',
+            'notes' => '<p>Student passed all sections.</p>',
             'exam' => 'P1',
         ]);
 

--- a/tests/Feature/TrainingPanel/Exams/ConductExamTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ConductExamTest.php
@@ -161,7 +161,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         $this->assertDatabaseHas('practical_criteria_assess', connection: 'cts', data: [
             'examid' => $exam->id,
             'criteria_id' => $examCriteria->id,
-            'notes' => 'Test comment for test criteria',
+            'notes' => '<p>Test comment for test criteria</p>',
             'result' => ExamResultEnum::Incomplete->value,
         ]);
     }
@@ -252,7 +252,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
             'examid' => $exam->id,
             'student_id' => $student->id,
             'result' => 'P',
-            'notes' => 'Test notes for test result',
+            'notes' => '<p>Test notes for test result</p>',
             'date' => now(),
             'exam' => 'TWR',
         ], connection: 'cts');

--- a/tests/Feature/TrainingPanel/Mentor/ConductMentoringSessionTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ConductMentoringSessionTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\Mentor;
+
+use App\Enums\FieldScore;
+use App\Filament\Training\Pages\Mentor\ConductMentoringSession;
+use App\Livewire\Training\AcceptedMentoringSessionsTable;
+use App\Livewire\Training\PendingMentoringReportsTable;
+use App\Models\Cts\Member;
+use App\Models\Cts\ProgSheet;
+use App\Models\Cts\ProgSheetCategory;
+use App\Models\Cts\ProgSheetField;
+use App\Models\Cts\ReportSheet;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use App\Models\Training\Mentoring\MentorTrainingPosition;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Notifications\Training\MentoringReportFiled;
+use App\Notifications\Training\StudentMentoringNoShow;
+use App\Services\Training\MentoringReportService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class ConductMentoringSessionTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    protected Account $mentor;
+
+    protected Member $mentorMember;
+
+    protected Account $student;
+
+    protected Member $studentMember;
+
+    protected Session $session;
+
+    protected ProgSheetField $field;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mentor = Account::factory()->create();
+        $this->mentorMember = Member::factory()->create([
+            'id' => $this->mentor->id,
+            'cid' => $this->mentor->id,
+        ]);
+
+        $this->student = Account::factory()->create();
+        $this->studentMember = Member::factory()->create([
+            'id' => $this->student->id,
+            'cid' => $this->student->id,
+        ]);
+
+        $trainingPosition = TrainingPosition::factory()->create([
+            'cts_positions' => ['EGLL_APP'],
+            'category' => 'S3 Training',
+        ]);
+
+        MentorTrainingPosition::create([
+            'account_id' => $this->mentor->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $trainingPosition->id,
+            'created_by' => $this->mentor->id,
+        ]);
+
+        $progSheet = ProgSheet::factory()->create();
+        $category = ProgSheetCategory::factory()
+            ->forProgSheet($progSheet->prog_sheet_id)
+            ->create(['catName' => 'General Control']);
+
+        $this->field = ProgSheetField::factory()
+            ->forProgSheet($progSheet->prog_sheet_id)
+            ->forCategory($category->catId)
+            ->create(['field' => 'Radio Telephony']);
+
+        $this->session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'progress_sheet_id' => $progSheet->prog_sheet_id,
+            'taken' => 1,
+            'taken_date' => now()->subHour()->format('Y-m-d'),
+            'taken_from' => now()->subHour()->format('H:i:s'),
+            'taken_to' => now()->format('H:i:s'),
+            'taken_time' => now()->subDays(3),
+            'session_done' => 0,
+            'filed' => null,
+        ]);
+    }
+
+    #[Test]
+    public function mentor_can_access_conduct_page_for_their_session(): void
+    {
+        Livewire::actingAs($this->mentor)
+            ->test(ConductMentoringSession::class, ['sessionId' => $this->session->id])
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function non_assigned_mentor_cannot_access_conduct_page(): void
+    {
+        $otherMentor = Account::factory()->create();
+        Member::factory()->create(['id' => $otherMentor->id, 'cid' => $otherMentor->id]);
+
+        Livewire::actingAs($otherMentor)
+            ->test(ConductMentoringSession::class, ['sessionId' => $this->session->id])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function save_persists_criteria_to_report_sheet(): void
+    {
+        Livewire::actingAs($this->mentor)
+            ->test(ConductMentoringSession::class, ['sessionId' => $this->session->id])
+            ->set('data.criteria.'.$this->field->field_id.'.score', FieldScore::GOOD->value)
+            ->set('data.criteria.'.$this->field->field_id.'.notes', '<p>Strong performance</p>')
+            ->call('save');
+
+        $this->assertDatabaseHas('report_sheet', [
+            'seshid' => $this->session->id,
+            'field_id' => $this->field->field_id,
+            'field_score' => FieldScore::GOOD->value,
+        ], 'cts');
+    }
+
+    #[Test]
+    public function submit_files_session_and_notifies_student(): void
+    {
+        Notification::fake();
+
+        Livewire::actingAs($this->mentor)
+            ->test(ConductMentoringSession::class, ['sessionId' => $this->session->id])
+            ->set('data.criteria.'.$this->field->field_id.'.score', FieldScore::GOOD->value)
+            ->call('submitReport');
+
+        $this->session->refresh();
+
+        $this->assertNotNull($this->session->filed);
+        $this->assertSame(1, (int) $this->session->session_done);
+
+        Notification::assertSentTo($this->student, MentoringReportFiled::class);
+    }
+
+    #[Test]
+    public function submit_is_blocked_when_criteria_are_unscored(): void
+    {
+        Livewire::actingAs($this->mentor)
+            ->test(ConductMentoringSession::class, ['sessionId' => $this->session->id])
+            ->set('data.criteria.'.$this->field->field_id.'.score', FieldScore::NOT_SCORED->value)
+            ->call('submitReport');
+
+        $this->session->refresh();
+        $this->assertNull($this->session->filed);
+    }
+
+    #[Test]
+    public function mark_no_show_files_session_with_previous_scores(): void
+    {
+        Notification::fake();
+
+        $previousSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'progress_sheet_id' => $this->session->progress_sheet_id,
+            'taken' => 1,
+            'taken_date' => now()->subDays(7)->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'session_done' => 1,
+            'filed' => now()->subDays(7),
+        ]);
+
+        ReportSheet::factory()
+            ->forSession($previousSession->id)
+            ->forStudent($this->studentMember->id)
+            ->forField($this->field->field_id)
+            ->create([
+                'prog_sheet_id' => $this->session->progress_sheet_id,
+                'field_score' => FieldScore::DEVELOPING->value,
+            ]);
+
+        Carbon::setTestNow(now()->parse($this->session->taken_date.' '.$this->session->taken_from)->addMinutes(6));
+
+        $tgi = Account::factory()->create();
+        $tgi->givePermissionTo('training.mentors.manage.atc');
+
+        app(MentoringReportService::class)->markNoShow($this->session->fresh(), false);
+
+        $this->session->refresh();
+
+        $this->assertSame(1, (int) $this->session->noShow);
+        $this->assertNotNull($this->session->filed);
+
+        $this->assertDatabaseHas('report_sheet', [
+            'seshid' => $this->session->id,
+            'field_id' => $this->field->field_id,
+            'field_score' => FieldScore::DEVELOPING->value,
+        ], 'cts');
+
+        Notification::assertSentTo($tgi, StudentMentoringNoShow::class);
+
+        Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function short_notice_no_show_without_discord_confirmation_cancels_session(): void
+    {
+        $this->session->update([
+            'taken_time' => now()->subHours(12),
+            'taken_date' => now()->addHours(6)->format('Y-m-d'),
+            'taken_from' => now()->addHours(6)->format('H:i:s'),
+            'taken_to' => now()->addHours(8)->format('H:i:s'),
+        ]);
+
+        Carbon::setTestNow(now()->addHours(6)->addMinutes(6));
+
+        app(MentoringReportService::class)->markNoShow($this->session->fresh(), false);
+
+        $this->session->refresh();
+
+        $this->assertSame(0, (int) $this->session->taken);
+        $this->assertNull($this->session->mentor_id);
+        $this->assertSame(0, (int) $this->session->noShow);
+
+        Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function accepted_sessions_table_shows_conduct_action(): void
+    {
+        Livewire::actingAs($this->mentor)
+            ->test(AcceptedMentoringSessionsTable::class)
+            ->assertTableActionVisible('conduct', $this->session);
+    }
+
+    #[Test]
+    public function pending_reports_table_shows_conduct_action_for_assigned_mentor(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        Livewire::actingAs($this->mentor)
+            ->test(PendingMentoringReportsTable::class, ['category' => 'S3 Training'])
+            ->assertTableActionVisible('conduct', $this->session);
+    }
+}

--- a/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
@@ -132,6 +132,29 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
+    public function it_denies_viewing_an_unfiled_report(): void
+    {
+        $unfiledSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'progress_sheet_id' => $this->progSheet->prog_sheet_id,
+            'taken_date' => '2025-03-10',
+            'taken_from' => '18:00',
+            'taken_to' => '20:00',
+            'filed' => null,
+        ]);
+
+        Livewire::actingAs($this->student)
+            ->test(ViewMentoringReport::class, ['sessionId' => $unfiledSession->id])
+            ->assertForbidden();
+
+        Livewire::actingAs($this->mentor)
+            ->test(ViewMentoringReport::class, ['sessionId' => $unfiledSession->id])
+            ->assertForbidden();
+    }
+
+    #[Test]
     public function it_denies_an_entirely_unrelated_user(): void
     {
         $unrelatedUser = Account::factory()->create();

--- a/tests/Unit/Notifications/Training/MentoringSessionNotificationsTest.php
+++ b/tests/Unit/Notifications/Training/MentoringSessionNotificationsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications\Training;
+
+use App\Models\Cts\Member;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use App\Notifications\Training\MentoringReportFiled;
+use App\Notifications\Training\StudentMentoringNoShow;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\View;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MentoringSessionNotificationsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Account $studentAccount;
+
+    private Account $tgiAccount;
+
+    private Session $session;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->studentAccount = Account::factory()->create([
+            'name_first' => 'Alex',
+            'name_last' => 'Student',
+        ]);
+
+        $studentMember = Member::factory()->create([
+            'id' => $this->studentAccount->id,
+            'cid' => $this->studentAccount->id,
+            'name' => 'Alex Student',
+        ]);
+
+        $this->tgiAccount = Account::factory()->create([
+            'name_first' => 'Taylor',
+            'name_last' => 'Instructor',
+        ]);
+
+        $this->session = Session::factory()->accepted()->create([
+            'student_id' => $studentMember->id,
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-05-20',
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+        ]);
+
+        $this->session->load('student');
+    }
+
+    #[Test]
+    public function mentoring_report_filed_uses_expected_subject_view_and_content(): void
+    {
+        $notification = new MentoringReportFiled($this->session);
+        $mail = $notification->toMail($this->studentAccount);
+
+        $this->assertContains('mail', $notification->via($this->studentAccount));
+        $this->assertSame('Session report finished', $mail->subject);
+        $this->assertSame('emails.training.mentoring_report_filed', $mail->view);
+        $this->assertSame(
+            ['subject', 'recipient', 'session'],
+            array_keys($mail->viewData),
+        );
+        $this->assertSame($this->session->id, $mail->viewData['session']->id);
+
+        $html = View::make($mail->view, $mail->data())->render();
+
+        $this->assertStringContainsString('Dear Alex Student', $html);
+        $this->assertStringContainsString('your mentor has finished your report', $html);
+        $this->assertStringContainsString('Position: EGKK_TWR', $html);
+        $this->assertStringContainsString('Session date: 2026-05-20 14:00:00 - 16:00:00', $html);
+        $this->assertStringContainsString('VATSIM UK Training Department', $html);
+    }
+
+    #[Test]
+    public function student_mentoring_no_show_uses_expected_subject_view_and_content(): void
+    {
+        $notification = new StudentMentoringNoShow($this->session);
+        $mail = $notification->toMail($this->tgiAccount);
+
+        $this->assertContains('mail', $notification->via($this->tgiAccount));
+        $this->assertSame('Student mentoring session no-show', $mail->subject);
+        $this->assertSame('emails.training.student_mentoring_no_show', $mail->view);
+        $this->assertSame(
+            ['subject', 'recipient', 'session'],
+            array_keys($mail->viewData),
+        );
+        $this->assertSame($this->session->id, $mail->viewData['session']->id);
+
+        $html = View::make($mail->view, $mail->data())->render();
+
+        $this->assertStringContainsString('Dear Taylor Instructor', $html);
+        $this->assertStringContainsString('marked as a no-show', $html);
+        $this->assertStringContainsString('Alex Student', $html);
+        $this->assertStringContainsString('EGKK_TWR', $html);
+        $this->assertStringContainsString('VATSIM UK Training Department', $html);
+    }
+}

--- a/tests/Unit/Training/CtsRichEditorNotesTest.php
+++ b/tests/Unit/Training/CtsRichEditorNotesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Training;
+
+use App\Filament\Training\Concerns\InteractsWithCtsRichEditorNotes;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CtsRichEditorNotesTest extends TestCase
+{
+    use InteractsWithCtsRichEditorNotes;
+
+    #[Test]
+    public function it_preserves_allowed_rich_text_formatting_when_saving(): void
+    {
+        $html = '<p><strong>Bold</strong> and <em>italic</em> with <u>underline</u></p>';
+
+        $saved = $this->ctsRichContentNotesForCts($html);
+
+        $this->assertStringContainsString('<strong>Bold</strong>', $saved);
+        $this->assertStringContainsString('<em>italic</em>', $saved);
+        $this->assertStringContainsString('<u>underline</u>', $saved);
+    }
+
+    #[Test]
+    public function it_preserves_paragraphs_and_line_breaks_when_saving(): void
+    {
+        $html = '<p>First line</p><p>Second line</p><p>Third with<br>break</p>';
+
+        $saved = $this->ctsRichContentNotesForCts($html);
+
+        $this->assertStringContainsString('<p>First line</p>', $saved);
+        $this->assertStringContainsString('<p>Second line</p>', $saved);
+        $this->assertStringContainsString('<br>', $saved);
+    }
+
+    #[Test]
+    public function it_normalizes_empty_paragraphs_when_saving(): void
+    {
+        $html = '<p>Before</p><p></p><p>After</p>';
+
+        $saved = $this->ctsRichContentNotesForCts($html);
+
+        $this->assertStringContainsString('<p><br></p>', $saved);
+    }
+
+    #[Test]
+    public function it_strips_disallowed_tags_and_attributes_when_saving(): void
+    {
+        $html = '<p onclick="alert(1)">Hello<script>alert(1)</script> <a href="https://evil.test">link</a></p>';
+
+        $saved = $this->ctsRichContentNotesForCts($html);
+
+        $this->assertSame('<p>Hello link</p>', $saved);
+    }
+
+    #[Test]
+    public function it_hydrates_plain_text_notes_as_paragraph_html(): void
+    {
+        $this->assertSame(
+            '<p>Line one</p><p><br></p><p>Line three</p>',
+            $this->ctsRichEditorHtmlForHydration("Line one\n\nLine three"),
+        );
+    }
+
+    #[Test]
+    public function it_renders_plain_text_whitespace_for_display(): void
+    {
+        $display = $this->ctsPlainNotesForHtmlDisplay("Line one\n\nLine  with  spaces");
+
+        $this->assertStringContainsString('white-space:pre-wrap', $display);
+        $this->assertStringContainsString("Line one\n\nLine  with  spaces", $display);
+    }
+
+    #[Test]
+    public function it_renders_sanitized_html_notes_for_display(): void
+    {
+        $html = '<p><strong>Legacy</strong></p><p></p><p>content</p>';
+
+        $display = $this->ctsPlainNotesForHtmlDisplay($html);
+
+        $this->assertStringContainsString('<strong>Legacy</strong>', $display);
+        $this->assertStringContainsString('<p><br></p>', $display);
+        $this->assertStringContainsString('white-space:pre-wrap', $display);
+    }
+}

--- a/tests/Unit/Training/CtsRichEditorNotesTest.php
+++ b/tests/Unit/Training/CtsRichEditorNotesTest.php
@@ -25,6 +25,17 @@ class CtsRichEditorNotesTest extends TestCase
     }
 
     #[Test]
+    public function it_preserves_heading_tags_when_saving(): void
+    {
+        $html = '<h2>Section title</h2><p>Body text</p>';
+
+        $saved = $this->ctsRichContentNotesForCts($html);
+
+        $this->assertStringContainsString('<h2>Section title</h2>', $saved);
+        $this->assertStringContainsString('<p>Body text</p>', $saved);
+    }
+
+    #[Test]
     public function it_preserves_paragraphs_and_line_breaks_when_saving(): void
     {
         $html = '<p>First line</p><p>Second line</p><p>Third with<br>break</p>';
@@ -84,5 +95,16 @@ class CtsRichEditorNotesTest extends TestCase
         $this->assertStringContainsString('<strong>Legacy</strong>', $display);
         $this->assertStringContainsString('<p><br></p>', $display);
         $this->assertStringContainsString('white-space:pre-wrap', $display);
+    }
+
+    #[Test]
+    public function it_renders_heading_tags_for_display(): void
+    {
+        $html = '<h3>Criteria</h3><p>Details</p>';
+
+        $display = $this->ctsPlainNotesForHtmlDisplay($html);
+
+        $this->assertStringContainsString('<h3>Criteria</h3>', $display);
+        $this->assertStringContainsString('<p>Details</p>', $display);
     }
 }

--- a/tests/Unit/Training/Mentoring/MentoringPolicyTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringPolicyTest.php
@@ -57,7 +57,7 @@ class MentoringPolicyTest extends TestCase
     public function view_allows_the_student_who_attended_the_session(): void
     {
         $student = Account::factory()->create();
-        $session = $this->createSessionForStudent($student);
+        $session = $this->createSessionForStudent($student, filed: now());
 
         $this->assertTrue($this->policy->view($student, $session));
     }
@@ -67,7 +67,10 @@ class MentoringPolicyTest extends TestCase
     {
         $mentor = Account::factory()->create();
         $mentorMember = Member::factory()->create(['id' => $mentor->id, 'cid' => $mentor->id]);
-        $session = Session::factory()->create(['mentor_id' => $mentorMember->id]);
+        $session = Session::factory()->create([
+            'mentor_id' => $mentorMember->id,
+            'filed' => now(),
+        ]);
 
         $this->assertTrue($this->policy->view($mentor, $session));
     }
@@ -76,16 +79,51 @@ class MentoringPolicyTest extends TestCase
     public function view_allows_a_mentor_with_permission_for_the_session_position(): void
     {
         $mentor = $this->createMentorWithPosition('EGLL_APP');
-        $session = Session::factory()->create(['position' => 'EGLL_APP']);
+        $session = Session::factory()->create([
+            'position' => 'EGLL_APP',
+            'filed' => now(),
+        ]);
 
         $this->assertTrue($this->policy->view($mentor, $session));
+    }
+
+    #[Test]
+    public function view_denies_unfiled_reports_even_for_the_student(): void
+    {
+        $student = Account::factory()->create();
+        $session = $this->createSessionForStudent($student);
+
+        $this->assertFalse($this->policy->view($student, $session));
+    }
+
+    #[Test]
+    public function view_denies_unfiled_reports_even_for_the_mentor(): void
+    {
+        $mentor = Account::factory()->create();
+        $mentorMember = Member::factory()->create(['id' => $mentor->id, 'cid' => $mentor->id]);
+        $session = Session::factory()->create(['mentor_id' => $mentorMember->id]);
+
+        $this->assertFalse($this->policy->view($mentor, $session));
+    }
+
+    #[Test]
+    public function view_denies_unfiled_reports_even_for_view_all_users(): void
+    {
+        $admin = Account::factory()->create();
+        $admin->givePermissionTo('training.mentoring.view.*');
+        $session = Session::factory()->create(['position' => 'EGLL_APP']);
+
+        $this->assertFalse($this->policy->view($admin, $session));
     }
 
     #[Test]
     public function view_denies_unrelated_users(): void
     {
         $account = Account::factory()->create();
-        $session = Session::factory()->create(['position' => 'EGLL_APP']);
+        $session = Session::factory()->create([
+            'position' => 'EGLL_APP',
+            'filed' => now(),
+        ]);
 
         $this->assertFalse($this->policy->view($account, $session));
     }
@@ -142,13 +180,16 @@ class MentoringPolicyTest extends TestCase
         return $account;
     }
 
-    private function createSessionForStudent(Account $student): Session
+    private function createSessionForStudent(Account $student, ?\DateTimeInterface $filed = null): Session
     {
         $studentMember = Member::factory()->create([
             'id' => $student->id,
             'cid' => $student->id,
         ]);
 
-        return Session::factory()->create(['student_id' => $studentMember->id]);
+        return Session::factory()->create([
+            'student_id' => $studentMember->id,
+            'filed' => $filed,
+        ]);
     }
 }

--- a/tests/Unit/Training/Mentoring/MentoringReportRepositoryTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringReportRepositoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Training\Mentoring;
+
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Repositories\Cts\MentoringReportRepository;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MentoringReportRepositoryTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private MentoringReportRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = app(MentoringReportRepository::class);
+    }
+
+    #[Test]
+    public function get_primary_position_returns_cts_primary_position_not_first_related_callsign(): void
+    {
+        TrainingPosition::factory()->create([
+            'cts_positions' => ['EGLL_S_APP', 'EGLL_N_APP'],
+            'cts_primary_position' => 'EGLL_N_APP',
+        ]);
+
+        $this->assertSame('EGLL_N_APP', $this->repository->getPrimaryPosition('EGLL_S_APP'));
+        $this->assertSame('EGLL_N_APP', $this->repository->getPrimaryPosition('EGLL_N_APP'));
+    }
+
+    #[Test]
+    public function get_primary_position_falls_back_to_session_position_when_training_position_not_found(): void
+    {
+        $this->assertSame('EGKK_TWR', $this->repository->getPrimaryPosition('EGKK_TWR'));
+    }
+
+    #[Test]
+    public function get_primary_position_falls_back_to_session_position_when_cts_primary_position_is_empty(): void
+    {
+        TrainingPosition::factory()->create([
+            'cts_positions' => ['EGLL_APP'],
+            'cts_primary_position' => null,
+        ]);
+
+        $this->assertSame('EGLL_APP', $this->repository->getPrimaryPosition('EGLL_APP'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements **TECH-621**: mentors can conduct and file mentoring session reports from the training panel, with draft saving, rich-text notes, no-show handling, and notifications.

- Adds **`ConductMentoringSession`** (`/mentoring/conduct/{sessionId}`) for scoring criteria, per-field notes, additional comments, autosave, and report submission. Redirects to the filed report view on success.
- Introduces **`MentoringReportService`** and **`MentoringReportRepository`** for draft persistence, validation (all criteria scored before submit), filing, no-show filing (with short-notice Discord confirmation flow), and mentor-initiated cancellation.
- Adds **`InteractsWithCtsRichEditorNotes`** shared by mentoring and exam conduct pages: hydrates legacy plain-text CTS notes for Filament/Tiptap, sanitises and persists HTML (paragraphs, headings, lists, inline formatting), and renders notes on **`ViewMentoringReport`** (including Filament `prose()` styling).
- Wires **Pending Reports** and **Accepted Sessions** tables to the conduct page; adds email notifications when a report is filed and when a student no-show is recorded.
- **Security:** `MentoringPolicy::view` now requires `filed` to be set, so draft reports are not viewable by URL alone.
- **Local dev:** `DevMentorConductSeeder` and related seed helpers for exercising the conduct flow locally.
- **Config:** `training.mentoring.no_show_delay_minutes` and `training.mentoring.short_notice_hours` (env-overridable).

## Notable behaviour

| Area | Detail |
|------|--------|
| Draft vs filed | Drafts editable via conduct page; view page only for filed sessions |
| No-show | Available after session start + delay; short-notice bookings may cancel instead if Discord not confirmed |
| Rich text | Headings and formatting preserved through save/sanitise/display pipeline |
| Exams | `ConductExam` uses the same notes trait; feature tests updated for `<p>`-wrapped editor output |
