### PR TITLE
Add manual code for 2FA setup and UX fixes

### DIFF
--- a/app/Models/Mship/Concerns/HasTwoFactor.php
+++ b/app/Models/Mship/Concerns/HasTwoFactor.php
@@ -2,6 +2,8 @@
 
 namespace App\Models\Mship\Concerns;
 
+use Laravel\Fortify\Fortify;
+
 trait HasTwoFactor
 {
     public function getMandatoryTwoFactorAttribute(): bool
@@ -23,5 +25,14 @@ trait HasTwoFactor
     public function requiresTwoFactorChallenge(): bool
     {
         return $this->hasEnabledTwoFactorAuthentication();
+    }
+
+    public function twoFactorSecretKey(): ?string
+    {
+        if ($this->two_factor_secret === null) {
+            return null;
+        }
+
+        return Fortify::currentEncrypter()->decrypt($this->two_factor_secret);
     }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,6 +1,7 @@
 import "@fortawesome/fontawesome-free/js/fontawesome";
 import "@fortawesome/fontawesome-free/js/solid";
 import "@fortawesome/fontawesome-free/js/brands";
+import "./mobile-fixed-nav-height";
 
 $("body").scrollspy({
     target: ".navbar-fixed-top",

--- a/resources/assets/js/mobile-fixed-nav-height.js
+++ b/resources/assets/js/mobile-fixed-nav-height.js
@@ -1,0 +1,100 @@
+const MOBILE_NAV_MAX_WIDTH = 992;
+const MOBILE_NAV_MEDIA = `(max-width: ${MOBILE_NAV_MAX_WIDTH}px)`;
+
+function isMobileNavLayout() {
+    return window.matchMedia(MOBILE_NAV_MEDIA).matches;
+}
+
+function isNavMenuExpanded() {
+    const collapse = document.getElementById("nav-inner");
+
+    return (
+        collapse?.classList.contains("in") ||
+        collapse?.classList.contains("collapsing")
+    );
+}
+
+function navClearanceBufferPx() {
+    const value = getComputedStyle(document.documentElement)
+        .getPropertyValue("--nav-clearance-buffer")
+        .trim();
+
+    const parsed = parseInt(value, 10);
+
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function measureMobileFixedNavClearancePx(nav) {
+    // Use bottom edge from viewport top so safe-area padding and fixed offsets
+    // are included (height alone misses inset when the nav is offset from top: 0).
+    const { bottom } = nav.getBoundingClientRect();
+
+    return Math.ceil(bottom) + navClearanceBufferPx();
+}
+
+function updateMobileFixedNavHeight() {
+    const nav = document.getElementById("nav");
+
+    if (!nav || !isMobileNavLayout() || isNavMenuExpanded()) {
+        return;
+    }
+
+    document.documentElement.style.setProperty(
+        "--mobile-fixed-nav-height",
+        `${measureMobileFixedNavClearancePx(nav)}px`,
+    );
+}
+
+function clearMobileFixedNavHeight() {
+    document.documentElement.style.removeProperty("--mobile-fixed-nav-height");
+}
+
+function syncMobileFixedNavHeight() {
+    if (isMobileNavLayout()) {
+        updateMobileFixedNavHeight();
+    } else {
+        clearMobileFixedNavHeight();
+    }
+}
+
+function initMobileFixedNavHeight() {
+    syncMobileFixedNavHeight();
+
+    window.addEventListener("resize", syncMobileFixedNavHeight);
+    window.addEventListener("load", updateMobileFixedNavHeight);
+    window.addEventListener("orientationchange", updateMobileFixedNavHeight);
+
+    if (window.visualViewport) {
+        window.visualViewport.addEventListener(
+            "resize",
+            updateMobileFixedNavHeight,
+        );
+    }
+
+    if (document.fonts?.ready) {
+        document.fonts.ready.then(updateMobileFixedNavHeight);
+    }
+
+    const nav = document.getElementById("nav");
+    const collapse = document.getElementById("nav-inner");
+
+    if (collapse) {
+        $(collapse).on("hidden.bs.collapse", updateMobileFixedNavHeight);
+    }
+
+    if (nav && typeof ResizeObserver !== "undefined") {
+        const observer = new ResizeObserver(() => {
+            if (!isNavMenuExpanded()) {
+                updateMobileFixedNavHeight();
+            }
+        });
+
+        observer.observe(nav);
+    }
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initMobileFixedNavHeight);
+} else {
+    initMobileFixedNavHeight();
+}

--- a/resources/assets/sass/_nav.scss
+++ b/resources/assets/sass/_nav.scss
@@ -1,5 +1,20 @@
 @import "bootstrap-sass/assets/stylesheets/bootstrap/variables";
 
+$nav-clearance-buffer: 8px;
+$mobile-page-content-padding-top: 40px;
+$mobile-fixed-nav-height-fallback: 90px;
+
+$nav-top-section-padding-y: 10px;
+$nav-top-section-border-bottom-width: 5px;
+$nav-link-padding-y: 16px;
+$nav-link-font-size: 16px;
+
+$nav-toggle-margin-top: 13px;
+$nav-toggle-padding-y: 9px;
+$nav-toggle-bar-height: 2px;
+$nav-toggle-bar-spacing: 6px;
+$nav-secondary-border-bottom-width: 1px;
+
 .navbar {
   color: white;
 }
@@ -22,7 +37,7 @@
   display: block;
   width: 100%;
   background-color: #0f131a;
-  border-bottom: 1px solid #666;
+  border-bottom: $nav-secondary-border-bottom-width solid #666;
 
   .nav_upper_container {
     margin: 0 auto;
@@ -31,8 +46,8 @@
 }
 
 .navbar-toggle {
-  margin-top: 13px;
-  padding: 9px 10px !important;
+  margin-top: $nav-toggle-margin-top;
+  padding: $nav-toggle-padding-y 10px !important;
 }
 
 
@@ -51,14 +66,14 @@
 }
 
 .nav_top_section {
-  border-bottom: 5px solid #00b0f0;
+  border-bottom: $nav-top-section-border-bottom-width solid #00b0f0;
   margin-bottom: 0;
 
   .nav_upper_container {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 10px 0;
+    padding: $nav-top-section-padding-y 0;
   }
 
   .navbar-header {
@@ -170,8 +185,8 @@
 }
 
 .navcustom > li > a {
-  padding: 16px 15px;
-  font-size: 16px;
+  padding: $nav-link-padding-y 15px;
+  font-size: $nav-link-font-size;
   color: #fff;
   display: block;
 }
@@ -240,8 +255,8 @@
 .nav-collapsed-icon {
   display: block;
   width: 27px;
-  height: 2px;
-  margin: 6px 0;
+  height: $nav-toggle-bar-height;
+  margin: $nav-toggle-bar-spacing 0;
   border-radius: 1px;
   background-color: #fff;
 }
@@ -259,7 +274,21 @@ Nav Collapse Breakpoint
   }
 }
 
+:root {
+  --nav-clearance-buffer: #{$nav-clearance-buffer};
+  --mobile-page-content-padding-top: #{$mobile-page-content-padding-top};
+  --mobile-fixed-nav-height: #{$mobile-fixed-nav-height-fallback};
+}
+
 @media (max-width: $screen-md-min) {
+  html {
+    scroll-padding-top: var(--mobile-fixed-nav-height);
+  }
+
+  #nav.navbar-fixed-top {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+
   #nav-inner {
     overflow-y: scroll !important;
     overflow-x: hidden !important;

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -40,7 +40,7 @@ body, html {
 }
 
 .dev_environment_notification {
-    height: 20px;
+    padding: 0.35em 0;
     background-color: red;
     text-align: center;
 }
@@ -130,11 +130,16 @@ body, html {
 
 .banner_breadcrumb_spacer {
   height: 90px;
+
+  @media (max-width: $screen-md-min) {
+    // Spacer + .page_content padding-top must equal --mobile-fixed-nav-height (set at runtime).
+    height: calc(var(--mobile-fixed-nav-height) - var(--mobile-page-content-padding-top));
+  }
 }
 
 .page_content {
   margin: 0 auto;
-  padding-top: 40px;
+  padding-top: var(--mobile-page-content-padding-top);
   width: 90%;
 }
 

--- a/resources/views/auth/two-factor/partials/authenticator-faqs.blade.php
+++ b/resources/views/auth/two-factor/partials/authenticator-faqs.blade.php
@@ -1,0 +1,42 @@
+@php
+	$authenticatorFaqs = [
+	    [
+	        'title' => 'Google Authenticator',
+	        'body' =>
+	            'Tap +, then choose Scan a QR code or Enter a setup key. Use the QR code on the right, or paste the manual setup code if scanning is not available.',
+	    ],
+	    [
+	        'title' => 'Microsoft Authenticator',
+	        'body' =>
+	            'Tap + and choose Other account (Google, Facebook, etc.). Scan the QR code, or choose Enter code manually and paste the setup key shown on this page.',
+	    ],
+	    [
+	        'title' => 'Authy',
+	        'body' =>
+	            'Tap +, then Scan QR Code or Enter key manually. Give the account a name, paste the setup key if needed, and leave the token type as Time-based.',
+	    ],
+	    [
+	        'title' => '1Password',
+	        'body' =>
+	            'Open 1Password, add a One-Time Password item, and scan the QR code. If you cannot scan, choose Enter setup key and paste the manual code from this page.',
+	    ],
+	];
+@endphp
+
+<div class="two-factor-setup-faqs" x-data="{ expanded: false }">
+	<button type="button" class="two-factor-setup-faqs-toggle" @click="expanded = ! expanded" :aria-expanded="expanded">
+		<i class="fa fa-chevron-right two-factor-setup-faqs-chevron"
+			:class="{ 'two-factor-setup-faqs-chevron--expanded': expanded }" aria-hidden="true"></i>
+		<strong>Common authenticator apps</strong>
+		<span class="text-muted" x-text="expanded ? '(Hide help)' : '(Show help)'">(Show help)</span>
+	</button>
+
+	<div x-show="expanded" x-collapse x-cloak style="display: none;">
+		@foreach ($authenticatorFaqs as $faq)
+			<div class="two-factor-setup-faq">
+				<p style="margin-bottom: 0.25em;"><strong>{{ $faq['title'] }}</strong></p>
+				<p class="text-muted" style="margin-bottom: 1em;">{{ $faq['body'] }}</p>
+			</div>
+		@endforeach
+	</div>
+</div>

--- a/resources/views/auth/two-factor/partials/mfa-explainer.blade.php
+++ b/resources/views/auth/two-factor/partials/mfa-explainer.blade.php
@@ -1,0 +1,17 @@
+<div class="two-factor-setup-faqs" x-data="{ expanded: false }">
+	<button type="button" class="two-factor-setup-faqs-toggle" @click="expanded = ! expanded" :aria-expanded="expanded">
+		<i class="fa fa-chevron-right two-factor-setup-faqs-chevron"
+			:class="{ 'two-factor-setup-faqs-chevron--expanded': expanded }" aria-hidden="true"></i>
+		<strong>What is two-factor authentication?</strong>
+		<span class="text-muted" x-text="expanded ? '(Hide help)' : '(Show help)'">(Show help)</span>
+	</button>
+
+	<div x-show="expanded" x-collapse x-cloak style="display: none;">
+		<div class="two-factor-setup-faq">
+			<p class="text-muted" style="margin-bottom: 0;">Two-factor authentication (also called MFA) adds a second check when
+				you sign in. Along with your password, you enter a short code from an authenticator app on your phone. This helps
+				protect your VATSIM UK account if your password is ever compromised. You will need to install an authenticator app
+				to complete setup.</p>
+		</div>
+	</div>
+</div>

--- a/resources/views/auth/two-factor/partials/why-mfa-required.blade.php
+++ b/resources/views/auth/two-factor/partials/why-mfa-required.blade.php
@@ -1,0 +1,27 @@
+<div class="two-factor-setup-faqs" x-data="{ expanded: false }">
+	<button type="button" class="two-factor-setup-faqs-toggle" @click="expanded = ! expanded" :aria-expanded="expanded">
+		<i class="fa fa-chevron-right two-factor-setup-faqs-chevron"
+			:class="{ 'two-factor-setup-faqs-chevron--expanded': expanded }" aria-hidden="true"></i>
+		@if (Auth::user()->mandatory_two_factor)
+			<strong>Why is this required?</strong>
+		@else
+			<strong>Why use two-factor authentication?</strong>
+		@endif
+		<span class="text-muted" x-text="expanded ? '(Hide help)' : '(Show help)'">(Show help)</span>
+	</button>
+
+	<div x-show="expanded" x-collapse x-cloak style="display: none;">
+		<div class="two-factor-setup-faq">
+			@if (Auth::user()->mandatory_two_factor)
+				<p class="text-muted" style="margin-bottom: 0;">Your account role requires two-factor authentication as part of
+					VATSIM UK security policy. This helps protect member accounts and sensitive systems from unauthorised access, even
+					if a password is compromised. You must complete setup before you can access VATSIM UK services.</p>
+			@else
+				<p class="text-muted" style="margin-bottom: 0;">Two-factor authentication is strongly recommended for all VATSIM UK
+					members. It adds an extra layer of protection to your account and helps keep member data safe if your password is
+					ever compromised. While your role does not require it, enabling 2FA is one of the simplest ways to improve your
+					account security.</p>
+			@endif
+		</div>
+	</div>
+</div>

--- a/resources/views/auth/two-factor/setup.blade.php
+++ b/resources/views/auth/two-factor/setup.blade.php
@@ -1,5 +1,96 @@
 @extends('layout')
 
+@section('styles')
+	<style type="text/css">
+		.two-factor-setup-secret-well {
+			display: inline-block;
+			max-width: 100%;
+			margin-bottom: 0.75em;
+			text-align: left;
+		}
+
+		.two-factor-setup-secret {
+			display: inline-block;
+			padding: 0.5em 0.75em;
+			font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+			font-size: 1.15em;
+			letter-spacing: 0.12em;
+			color: #333;
+			background-color: #f9f2f4;
+			border: 1px solid #ddd;
+			word-break: break-all;
+		}
+
+		[x-cloak] {
+			display: none !important;
+		}
+
+		.two-factor-setup-faqs {
+			margin-top: 1.5em;
+		}
+
+		.two-factor-setup-faqs-toggle {
+			display: block;
+			width: 100%;
+			margin: 0;
+			padding: 0;
+			text-align: left;
+			background: none;
+			border: none;
+			color: inherit;
+			cursor: pointer;
+		}
+
+		.two-factor-setup-faqs-toggle:hover,
+		.two-factor-setup-faqs-toggle:focus {
+			color: inherit;
+			text-decoration: none;
+			outline: none;
+		}
+
+		.two-factor-setup-faqs-chevron {
+			display: inline-block;
+			margin-right: 0.35em;
+			transition: transform 0.2s ease;
+		}
+
+		.two-factor-setup-faqs-chevron--expanded {
+			transform: rotate(90deg);
+		}
+
+		.two-factor-setup-faq:last-child p:last-child {
+			margin-bottom: 0;
+		}
+
+		@media (min-width: 992px) {
+			.two-factor-setup-row {
+				display: flex;
+				align-items: flex-start;
+			}
+
+			.two-factor-setup-main {
+				border-right: 1px solid #ddd;
+				padding-right: 2em;
+			}
+
+			.two-factor-setup-qr {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				padding-left: 2em;
+			}
+		}
+
+		@media (max-width: 991px) {
+			.two-factor-setup-qr {
+				margin-top: 1.5em;
+				padding-top: 1.5em;
+				border-top: 1px solid #ddd;
+			}
+		}
+	</style>
+@endsection
+
 @section('content')
 	<div class="row">
 		<div class="col-md-8 col-md-offset-2">
@@ -21,39 +112,66 @@
 
 			@if ($pendingConfirmation)
 				<p>
-					Scan the QR code below with your authenticator application, then enter the generated code to finish setup.
+					Scan the QR code with your authenticator application, then enter the generated code to finish setup.
 				</p>
 
-				<div class="text-center" style="margin: 1.5em 0;">
-					{!! Auth::user()->twoFactorQrCodeSvg() !!}
+				<div class="row two-factor-setup-row">
+					<div class="col-md-7 two-factor-setup-main">
+						<form method="POST" action="{{ route('two-factor.confirm') }}" class="form-horizontal">
+							@csrf
+
+							<div class="form-group">
+								<label for="code" class="control-label col-sm-4">Authentication Code</label>
+								<div class="col-sm-8">
+									<input class="form-control @error('code', 'confirmTwoFactorAuthentication') has-error @enderror" name="code"
+										type="text" inputmode="numeric" value="{{ old('code') }}" autocomplete="one-time-code" id="code"
+										required autofocus>
+									@error('code', 'confirmTwoFactorAuthentication')
+										<span class="help-block">{{ $message }}</span>
+									@enderror
+								</div>
+							</div>
+
+							<div class="form-group">
+								<div class="col-sm-8 col-sm-offset-4">
+									<input class="btn btn-primary" type="submit" value="Confirm and Enable">
+								</div>
+							</div>
+						</form>
+
+						@include('auth.two-factor.partials.why-mfa-required')
+						@include('auth.two-factor.partials.mfa-explainer')
+						@include('auth.two-factor.partials.authenticator-faqs')
+					</div>
+
+					<div class="col-md-5 text-center two-factor-setup-qr">
+						{!! Auth::user()->twoFactorQrCodeSvg() !!}
+						<p class="text-muted" style="margin-top: 0.75em; margin-bottom: 0;">Scan with your authenticator app</p>
+
+						<div style="margin-top: 1.5em;" x-data="{
+	    copied: false,
+	    copySecret() {
+	        navigator.clipboard.writeText(this.$refs.secretKey.textContent.trim()).then(() => {
+	            this.copied = true;
+	            setTimeout(() => { this.copied = false; }, 2000);
+	        });
+	    },
+	}">
+							<p class="text-muted" style="margin-bottom: 0.5em;">
+								Cannot scan the QR code? Enter this setup code manually in your authenticator application.
+							</p>
+							<div class="well well-sm two-factor-setup-secret-well">
+								<code x-ref="secretKey" class="two-factor-setup-secret">{{ Auth::user()->twoFactorSecretKey() }}</code>
+							</div>
+							<div>
+								<button type="button" class="btn btn-link" style="padding-left: 0;" @click.prevent="copySecret()">
+									<i class="fa fa-copy"></i> Copy to clipboard
+								</button>
+								<span x-show="copied" x-cloak class="text-success" style="display: none; margin-left: 0.5em;">Copied!</span>
+							</div>
+						</div>
+					</div>
 				</div>
-
-				<p class="text-muted">
-					If you cannot scan the QR code, configure your application manually using your account email address and
-					the secret from your authenticator setup screen.
-				</p>
-
-				<form method="POST" action="{{ route('two-factor.confirm') }}" class="form-horizontal">
-					@csrf
-
-					<div class="form-group">
-						<label for="code" class="control-label col-sm-5">Authentication Code</label>
-						<div class="col-sm-4">
-							<input class="form-control @error('code', 'confirmTwoFactorAuthentication') has-error @enderror" name="code"
-								type="text" inputmode="numeric" value="{{ old('code') }}" autocomplete="one-time-code" id="code"
-								required autofocus>
-							@error('code', 'confirmTwoFactorAuthentication')
-								<span class="help-block">{{ $message }}</span>
-							@enderror
-						</div>
-					</div>
-
-					<div class="form-group">
-						<div class="col-sm-4 col-sm-offset-5">
-							<input class="btn btn-primary" type="submit" value="Confirm and Enable">
-						</div>
-					</div>
-				</form>
 			@else
 				<p>Click below to generate a QR code for your authenticator application.</p>
 

--- a/tests/Feature/Account/Auth/TwoFactorAuthTest.php
+++ b/tests/Feature/Account/Auth/TwoFactorAuthTest.php
@@ -168,6 +168,20 @@ class TwoFactorAuthTest extends TestCase
     }
 
     #[Test]
+    public function setup_page_displays_manual_secret_when_pending_confirmation(): void
+    {
+        app(EnableTwoFactorAuthentication::class)($this->account, true);
+
+        $secret = Fortify::currentEncrypter()->decrypt($this->account->fresh()->two_factor_secret);
+
+        $this->actingAs($this->account)
+            ->get(route('two-factor.setup'))
+            ->assertOk()
+            ->assertSee($secret, false)
+            ->assertSee('Copy to clipboard', false);
+    }
+
+    #[Test]
     public function invalid_setup_confirmation_code_returns_to_setup_with_error(): void
     {
         app(EnableTwoFactorAuthentication::class)($this->account, true);


### PR DESCRIPTION
## Summary

Improves the two-factor authentication **setup** experience for members who must (or choose to) enable 2FA. Builds on mandatory 2FA for configurable roles (#4810).

## What changed

### Setup page layout (`auth/two-factor/setup`)

- **Two-column layout (desktop):** Confirmation form on the left; QR code, manual setup code, and copy action on the right, separated by a light divider.
- **Manual setup code:** Displays the TOTP secret below the QR (centered, content-width) with an Alpine-powered **Copy to clipboard** link (`btn-link` style).
- **Mobile:** Form and help sections stack above the QR block; column order keeps the auth code input stable while FAQs expand below the form.

### Collapsible help sections

Three independent, **collapsed-by-default** panels (Alpine `x-collapse`), below the confirmation form:

1. **Why is this required?** / **Why use two-factor authentication?** — Copy adapts to `mandatory_two_factor`.
2. **What is two-factor authentication?** — Plain-language MFA ovew.
3. **Common authenticator apps** — Short guides for Google Authenticator, Microsoft Authenticator, Authy, and 1Password.

FAQs live in Blade partials with a simple PHP array for easy extension.

### Backend

- `HasTwoFactor::twoFactorSecretKey()` — Decrypts the Fortify secret for display during pending setup (same source as the QR code).

### Mobile fixed navigation

- New `mobile-fixed-nav-height.js` measures `#nav` at runtime (includes dev environment banner when present) and sets `--mobile-fixed-nav-height` for spacer and `scroll-padding-top`.
- Avoids hard-coded nav height assumptions in SCSS; no dev-specific hooks in `layout.blade.php`.
- Safe-area padding on `#nav` for notched devices.

## Notes

- Secret is only shown during **pending confirmation** (after “Begin Setup”, before code is confirmed)—same security model as displaying the QR.
- Depends on mandatory 2FA infrastructure from #4810; this PR is UX-only on top of that.


https://github.com/user-attachments/assets/a2fda0c6-94c8-4fb8-b935-31f2e8c000be


