### PR TITLE
Improve UX of backup codes view for 2FA

### DIFF
--- a/app/Http/Controllers/Auth/TwoFactorBackupCodesController.php
+++ b/app/Http/Controllers/Auth/TwoFactorBackupCodesController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\BaseController;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class TwoFactorBackupCodesController extends BaseController
+{
+    public function show(Request $request): View|RedirectResponse
+    {
+        $user = Auth::user();
+
+        if (! $user->hasEnabledTwoFactorAuthentication()) {
+            return redirect()->route('two-factor.setup');
+        }
+
+        $this->setTitle('Save Your Recovery Codes');
+
+        return $this->viewMake('auth.two-factor.backup-codes')
+            ->with('recoveryCodes', $user->recoveryCodes());
+    }
+}

--- a/app/Http/Responses/Auth/TwoFactorConfirmedResponse.php
+++ b/app/Http/Responses/Auth/TwoFactorConfirmedResponse.php
@@ -14,7 +14,7 @@ class TwoFactorConfirmedResponse implements TwoFactorConfirmedResponseContract
         }
 
         return redirect()
-            ->intended(route('mship.manage.dashboard'))
+            ->route('two-factor.backup-codes')
             ->withSuccess('Two-factor authentication has been enabled for your account.');
     }
 }

--- a/resources/views/auth/two-factor/backup-codes.blade.php
+++ b/resources/views/auth/two-factor/backup-codes.blade.php
@@ -38,10 +38,6 @@
 		.two-factor-recovery-codes-copied {
 			margin-left: 0.75em;
 		}
-
-		[x-cloak] {
-			display: none !important;
-		}
 	</style>
 	@include('auth.two-factor.partials.setup-faqs-styles')
 @endsection
@@ -50,37 +46,26 @@
 	<div class="row">
 		<div class="col-md-8 col-md-offset-2">
 			@include('components.html.panel_open', [
-				'title' => 'Two-Factor Authentication',
-				'icon' => ['type' => 'fa', 'key' => 'fa-shield'],
+				'title' => 'Save Your Recovery Codes',
+				'icon' => ['type' => 'fa', 'key' => 'fa-key'],
 			])
-			<p>Two-factor authentication is enabled for your account.</p>
 
-			<h4>Recovery Codes</h4>
-			<p class="text-muted">Store these recovery codes in a secure location. Each code may only be used once.</p>
+			<p>
+				Two-factor authentication is now enabled. Save these recovery codes before continuing — each code can
+				only be used once if you lose access to your authenticator application.
+			</p>
 
 			@include('auth.two-factor.partials.why-backup-codes-matter')
 
 			@include('auth.two-factor.partials.recovery-codes-display', ['recoveryCodes' => $recoveryCodes])
 
-			<form method="POST" action="{{ route('two-factor.regenerate-recovery-codes') }}" class="form-horizontal"
-				style="margin-bottom: 1.5em;">
-				@csrf
-				<input class="btn btn-default" type="submit" value="Regenerate Recovery Codes"
-					onclick="return confirm('This will invalidate your existing recovery codes. Continue?');">
-			</form>
-
-			@if (!Auth::user()->mandatory_two_factor)
-				<form method="POST" action="{{ route('two-factor.disable') }}"
-					onsubmit="return confirm('Disable two-factor authentication for this account?');">
-					@csrf
-					@method('DELETE')
-					<input class="btn btn-danger" type="submit" value="Disable Two-Factor Authentication">
-				</form>
-			@endif
-
-			<p style="margin-top: 1.5em;">
-				<a href="{{ route('mship.manage.dashboard') }}">Return to dashboard</a>
+			<p class="text-muted">
+				Keep these codes somewhere secure, such as a password manager. Do not store them in the same place as
+				your authenticator application.
 			</p>
+
+			<a href="{{ route('mship.manage.dashboard') }}" class="btn btn-primary">Continue to dashboard</a>
+
 			@include('components.html.panel_close')
 		</div>
 	</div>

--- a/resources/views/auth/two-factor/partials/recovery-codes-display.blade.php
+++ b/resources/views/auth/two-factor/partials/recovery-codes-display.blade.php
@@ -1,0 +1,32 @@
+<div class="two-factor-recovery-codes-display" x-data="{
+    copied: false,
+    copyCodes() {
+        navigator.clipboard.writeText(this.$refs.codes.textContent.trim()).then(() => {
+            this.copied = true;
+            setTimeout(() => { this.copied = false; }, 2000);
+        });
+    },
+    downloadCodes() {
+        const text = this.$refs.codes.textContent.trim();
+        const blob = new Blob([text + '\n'], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'vatsim-uk-recovery-codes.txt';
+        link.click();
+        URL.revokeObjectURL(url);
+    },
+}">
+	<div class="well well-sm two-factor-recovery-codes-well">
+		<pre class="two-factor-recovery-codes"><code x-ref="codes">{{ implode("\n", $recoveryCodes) }}</code></pre>
+	</div>
+	<div class="two-factor-recovery-codes-actions">
+		<a href="#" class="two-factor-recovery-codes-action" @click.prevent="copyCodes()">
+			<i class="fa fa-copy" aria-hidden="true"></i> Copy to clipboard
+		</a>
+		<a href="#" class="two-factor-recovery-codes-action" @click.prevent="downloadCodes()">
+			<i class="fa fa-download" aria-hidden="true"></i> Download as text file
+		</a>
+		<span x-show="copied" x-cloak class="text-success two-factor-recovery-codes-copied">Copied!</span>
+	</div>
+</div>

--- a/resources/views/auth/two-factor/partials/setup-faqs-styles.blade.php
+++ b/resources/views/auth/two-factor/partials/setup-faqs-styles.blade.php
@@ -1,0 +1,51 @@
+<style type="text/css">
+	.two-factor-setup-faqs {
+		margin-top: 1em;
+		margin-bottom: 0;
+	}
+
+	.two-factor-setup-faqs--above-recovery-codes {
+		margin-bottom: 1.5em;
+	}
+
+	.two-factor-setup-faqs--above-recovery-codes+.two-factor-recovery-codes-display {
+		margin-top: 1em;
+	}
+
+	.two-factor-setup-faqs-toggle {
+		display: block;
+		width: 100%;
+		margin: 0;
+		padding: 0;
+		text-align: left;
+		background: none;
+		border: none;
+		color: inherit;
+		cursor: pointer;
+	}
+
+	.two-factor-setup-faqs-toggle:hover,
+	.two-factor-setup-faqs-toggle:focus {
+		color: inherit;
+		text-decoration: none;
+		outline: none;
+	}
+
+	.two-factor-setup-faqs-chevron {
+		display: inline-block;
+		margin-right: 0.35em;
+		transition: transform 0.2s ease;
+	}
+
+	.two-factor-setup-faqs-chevron--expanded {
+		transform: rotate(90deg);
+	}
+
+	.two-factor-setup-faq:last-child p:last-child {
+		margin-bottom: 0;
+	}
+
+	[x-cloak] {
+		display: none !important;
+	}
+</style>

--- a/resources/views/auth/two-factor/partials/why-backup-codes-matter.blade.php
+++ b/resources/views/auth/two-factor/partials/why-backup-codes-matter.blade.php
@@ -1,0 +1,24 @@
+<div class="two-factor-setup-faqs two-factor-setup-faqs--above-recovery-codes" x-data="{ expanded: false }">
+	<button type="button" class="two-factor-setup-faqs-toggle" @click="expanded = ! expanded" :aria-expanded="expanded">
+		<i class="fa fa-chevron-right two-factor-setup-faqs-chevron"
+			:class="{ 'two-factor-setup-faqs-chevron--expanded': expanded }" aria-hidden="true"></i>
+		<strong>Why are recovery codes important?</strong>
+		<span class="text-muted" x-text="expanded ? '(Hide help)' : '(Show help)'">(Show help)</span>
+	</button>
+
+	<div x-show="expanded" x-collapse x-cloak style="display: none;">
+		<div class="two-factor-setup-faq">
+			<p class="text-muted">
+				Your authenticator application generates the codes you normally use to sign in. If you lose your phone, replace
+				your device, or uninstall the app without backing it up, you may no longer be able to sign in.
+			</p>
+			<p class="text-muted">
+				Recovery codes are a one-time fallback for exactly that situation. Each code works once, so save the full set
+				now in a secure place — such as a password manager or encrypted note — separate from your authenticator app.
+			</p>
+			<p class="text-muted" style="margin-bottom: 0;">
+				Without recovery codes, regaining access to your account can take longer and may require staff assistance.
+			</p>
+		</div>
+	</div>
+</div>

--- a/routes/fortify-two-factor.php
+++ b/routes/fortify-two-factor.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Auth\TwoFactorBackupCodesController;
 use App\Http\Controllers\Auth\TwoFactorSetupController;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
@@ -27,6 +28,9 @@ Route::prefix('auth/two-factor')->middleware(config('fortify.middleware', ['web'
 
     Route::middleware($authMiddleware)->group(function () use ($authMiddleware) {
         Route::get('setup', [TwoFactorSetupController::class, 'show'])->name('two-factor.setup');
+
+        Route::get('backup-codes', [TwoFactorBackupCodesController::class, 'show'])
+            ->name('two-factor.backup-codes');
 
         Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
             ->name('two-factor.confirm-password');

--- a/tests/Feature/Account/Auth/TwoFactorAuthTest.php
+++ b/tests/Feature/Account/Auth/TwoFactorAuthTest.php
@@ -226,6 +226,40 @@ class TwoFactorAuthTest extends TestCase
     }
 
     #[Test]
+    public function confirming_two_factor_redirects_to_backup_codes_page(): void
+    {
+        app(EnableTwoFactorAuthentication::class)($this->account, true);
+
+        $secret = Fortify::currentEncrypter()->decrypt($this->account->fresh()->two_factor_secret);
+        $code = app(Google2FA::class)->getCurrentOtp($secret);
+        $recoveryCode = $this->account->fresh()->recoveryCodes()[0];
+
+        $this->actingAs($this->account)
+            ->withSession(['auth.password_confirmed_at' => now()->unix()])
+            ->post(route('two-factor.confirm'), ['code' => $code])
+            ->assertRedirect(route('two-factor.backup-codes'))
+            ->assertSessionHas('success');
+
+        $this->actingAs($this->account)
+            ->get(route('two-factor.backup-codes'))
+            ->assertOk()
+            ->assertSee('Save Your Recovery Codes', false)
+            ->assertSee('Why are recovery codes important?', false)
+            ->assertSee($recoveryCode, false)
+            ->assertSee('Copy to clipboard', false)
+            ->assertSee('Download as text file', false)
+            ->assertSee('Continue to dashboard', false);
+    }
+
+    #[Test]
+    public function backup_codes_page_requires_enabled_two_factor(): void
+    {
+        $this->actingAs($this->account)
+            ->get(route('two-factor.backup-codes'))
+            ->assertRedirect(route('two-factor.setup'));
+    }
+
+    #[Test]
     public function setup_page_shows_manage_view_when_two_factor_is_enabled(): void
     {
         $this->enableTwoFactorFor($this->account);
@@ -233,7 +267,10 @@ class TwoFactorAuthTest extends TestCase
         $this->actingAs($this->account)
             ->get(route('two-factor.setup'))
             ->assertOk()
-            ->assertSee('Recovery Codes', false);
+            ->assertSee('Recovery Codes', false)
+            ->assertSee('Why are recovery codes important?', false)
+            ->assertSee('Copy to clipboard', false)
+            ->assertSee('Download as text file', false);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Improves the two-factor authentication backup/recovery codes experience after members complete MFA setup.

- Post-setup redirect: Confirming an authenticator code now redirects to a dedicated backup codes page (`/auth/two-factor/backup-codes`) instead of the dashboard, so members are prompted to save recovery codes immediately.
- Backup codes page: New page showing all recovery codes in a copyable monospace block, with link-style actions (with icons) to copy to clipboard or download as `vatsim-uk-recovery-codes.txt`, plus a continue-to-dashboard CTA.
- 2FA manage view: Reuses the same recovery codes display (copy/download) and adds a collapsible "Why are recovery codes important?" explainer with spacing above the code block.
- Shared partials: `recovery-codes-display`, `why-backup-codes-matter`, and `setup-faqs-styles` keep backup-codes and manage views consistent.

## Changes

- `TwoFactorConfirmedResponse` — redirects to `two-factor.backup-codes`
- `TwoFactorBackupCodesController` — es backup codes page (requires confirmed 2FA)
- `routes/fortify-two-factor.php` — registers `GET auth/two-factor/backup-codes`
- Views — `backup-codes.blade.php`, updated `manage.blade.php`, new partials
- Tests — coverage for confirm redirect, backup codes page
