### PR TITLE
Colour code position badge in upcoming sessions when 'all' category selected

### DIFF
--- a/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
+++ b/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
@@ -69,6 +69,14 @@ abstract class BaseMentoringHistoryPage extends Page implements HasTable
         return true;
     }
 
+    /**
+     * @return string|array<int, string>|\Closure(mixed, mixed): string|array<int, string>
+     */
+    protected function getPositionColumnBadgeColor(): string|array|\Closure
+    {
+        return 'gray';
+    }
+
     public function table(Table $table): Table
     {
         return $table
@@ -115,7 +123,7 @@ abstract class BaseMentoringHistoryPage extends Page implements HasTable
             TextColumn::make('position')
                 ->label('Position')
                 ->badge()
-                ->color('gray'),
+                ->color($this->getPositionColumnBadgeColor()),
 
             TextColumn::make('taken_date')
                 ->label('Date & Time')

--- a/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
+++ b/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
@@ -6,6 +6,7 @@ namespace App\Filament\Training\Pages\Mentor;
 
 use App\Filament\Training\Pages\Mentor\Base\BaseMentoringHistoryPage;
 use App\Filament\Training\Pages\Mentor\Concerns\RemembersTrainingGroupCategory;
+use App\Filament\Training\Support\MentoringTrainingGroupBadgeColor;
 use App\Repositories\Cts\SessionRepository;
 use App\Services\Training\MentorPermissionService;
 use Filament\Actions\Action;
@@ -140,6 +141,15 @@ class UpcomingMentoringSessions extends BaseMentoringHistoryPage
     protected function includeStatusFilter(): bool
     {
         return false;
+    }
+
+    protected function getPositionColumnBadgeColor(): string|array|\Closure
+    {
+        if ($this->category !== MentorPermissionService::ALL_CATEGORIES) {
+            return 'gray';
+        }
+
+        return fn ($record) => MentoringTrainingGroupBadgeColor::forCtsCallsign($record->position);
     }
 
     private function getVisibleCtsPositions(): array

--- a/app/Filament/Training/Support/MentoringTrainingGroupBadgeColor.php
+++ b/app/Filament/Training/Support/MentoringTrainingGroupBadgeColor.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Support;
+
+use App\Services\Training\MentorPermissionService;
+use Filament\Support\Colors\Color;
+
+final class MentoringTrainingGroupBadgeColor
+{
+    /**
+     * Distinct Filament badge colors per mentoring training group (category).
+     *
+     * @var array<string, string|array<int, string>>
+     */
+    private const CATEGORY_COLORS = [
+        'OBS to S1 Training' => Color::Sky,
+        'S2 Training' => Color::Blue,
+        'S3 Training' => Color::Emerald,
+        'C1 Training' => Color::Amber,
+        'Heathrow GMC' => Color::Rose,
+        'Heathrow AIR' => Color::Violet,
+        'Heathrow APC' => Color::Fuchsia,
+        'P1 Training' => Color::Cyan,
+        'P2 Training' => Color::Teal,
+        'P3 Training' => Color::Indigo,
+    ];
+
+    public static function forCategory(?string $category): string|array
+    {
+        if ($category === null || $category === '') {
+            return 'gray';
+        }
+
+        return self::CATEGORY_COLORS[$category] ?? 'gray';
+    }
+
+    public static function forCtsCallsign(string $callsign): string|array
+    {
+        $category = app(MentorPermissionService::class)->resolveCategoryForCtsCallsign($callsign);
+
+        return self::forCategory($category);
+    }
+}

--- a/app/Livewire/Training/PendingMentoringReportsTable.php
+++ b/app/Livewire/Training/PendingMentoringReportsTable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Training;
 
+use App\Filament\Training\Support\MentoringTrainingGroupBadgeColor;
 use App\Models\Cts\Session;
 use App\Repositories\Cts\SessionRepository;
 use App\Services\Training\MentorPermissionService;
@@ -55,7 +56,11 @@ class PendingMentoringReportsTable extends Component implements HasActions, HasF
                 TextColumn::make('position')
                     ->label('Position')
                     ->badge()
-                    ->color('gray'),
+                    ->color(
+                        $this->category === MentorPermissionService::ALL_CATEGORIES
+                            ? fn (Session $record) => MentoringTrainingGroupBadgeColor::forCtsCallsign($record->position)
+                            : 'gray'
+                    ),
 
                 TextColumn::make('taken_date')
                     ->label('Date & Time')

--- a/app/Services/Training/MentorPermissionService.php
+++ b/app/Services/Training/MentorPermissionService.php
@@ -23,6 +23,9 @@ class MentorPermissionService
 {
     public const ALL_CATEGORIES = 'all';
 
+    /** @var array<string, string>|null */
+    private ?array $ctsCallsignToCategoryMap = null;
+
     public const ATC_CATEGORY_ROLE_MAP = [
         'OBS to S1 Training' => 'ATC Mentor (OBS)',
         'S2 Training' => 'ATC Mentor (TWR)',
@@ -309,6 +312,42 @@ class MentorPermissionService
         }
 
         return Carbon::parse($lastMentoredDate);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getCtsCallsignToCategoryMap(): array
+    {
+        if ($this->ctsCallsignToCategoryMap !== null) {
+            return $this->ctsCallsignToCategoryMap;
+        }
+
+        $map = [];
+
+        TrainingPosition::query()
+            ->whereNotNull('category')
+            ->get()
+            ->each(function (TrainingPosition $position) use (&$map): void {
+                foreach ($position->cts_positions ?? [] as $callsign) {
+                    $map[$callsign] = $position->category;
+                }
+            });
+
+        foreach (self::PILOT_CATEGORY_QUALIFICATION_MAP as $category => $qualificationCode) {
+            $callsign = self::QUALIFICATION_CTS_POSITION_MAP[$qualificationCode] ?? null;
+
+            if ($callsign !== null) {
+                $map[$callsign] = $category;
+            }
+        }
+
+        return $this->ctsCallsignToCategoryMap = $map;
+    }
+
+    public function resolveCategoryForCtsCallsign(string $callsign): ?string
+    {
+        return $this->getCtsCallsignToCategoryMap()[$callsign] ?? null;
     }
 
     public function getAllCtsCallsignsForCategory(string $category): array

--- a/tests/Unit/Training/MentoringTrainingGroupBadgeColorTest.php
+++ b/tests/Unit/Training/MentoringTrainingGroupBadgeColorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Training;
+
+use App\Filament\Training\Support\MentoringTrainingGroupBadgeColor;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\MentorPermissionService;
+use Filament\Support\Colors\Color;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MentoringTrainingGroupBadgeColorTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_returns_distinct_colors_for_known_categories(): void
+    {
+        $this->assertSame(Color::Sky, MentoringTrainingGroupBadgeColor::forCategory('OBS to S1 Training'));
+        $this->assertSame(Color::Blue, MentoringTrainingGroupBadgeColor::forCategory('S2 Training'));
+        $this->assertSame(Color::Emerald, MentoringTrainingGroupBadgeColor::forCategory('S3 Training'));
+        $this->assertSame(Color::Cyan, MentoringTrainingGroupBadgeColor::forCategory('P1 Training'));
+    }
+
+    #[Test]
+    public function it_returns_gray_for_unknown_categories(): void
+    {
+        $this->assertSame('gray', MentoringTrainingGroupBadgeColor::forCategory('Unknown Category'));
+        $this->assertSame('gray', MentoringTrainingGroupBadgeColor::forCategory(null));
+    }
+
+    #[Test]
+    public function it_resolves_badge_color_from_cts_callsign(): void
+    {
+        $category = MentorPermissionService::atcCategories()[0];
+
+        TrainingPosition::factory()->create([
+            'category' => $category,
+            'cts_positions' => ['EGLL_GND'],
+        ]);
+
+        $this->assertSame(
+            MentoringTrainingGroupBadgeColor::forCategory($category),
+            MentoringTrainingGroupBadgeColor::forCtsCallsign('EGLL_GND')
+        );
+    }
+}


### PR DESCRIPTION
## Summary

When mentors view **Upcoming Sessions** with **Training Group: All** selected, position badges are now colour-coded by training group (category) so sessions from different groups are easier to distinguish at a glance.

The same behaviour applies to the **Pending Reports** table on that page when **All** is selected. Selecting a single training group keeps position badges grey, as before.

## Changes

- Added `MentoringTrainingGroupBadgeColor` to map each mentoring category to a distinct Filament badge colour.
- Added `MentorPermissionService::resolveCategoryForCtsCallsign()` and a cached `getCtsCallsignToCategoryMap()` to resolve CTS callsigns to training groups (ATC `TrainingPosition` records and pilot qualification mappings).
- Extended `BaseMentoringHistoryPage` with an overridable `getPositionColumnBadgeColor()` hook (default: grey).
- Updated `UpcomingMentoringSessions` to apply category colours only when `category === 'all'`.
- Updated `PendingMentoringReportsTable` with the same conditional colouring.

## Category colours

| Category | Badge colour |
|----------|--------------|
| OBS to S1 Training | Sky |
| S2 Training | Blue |
| S3 Training | Emerald |
| C1 Training | Amber |
| Heathrow GMC | Rose |
| Heathrow AIR | Violet |
| Heathrow APC | Fuchsia |
| P1 Training | Cyan |
| P2 Training | Teal |
| P3 Training | Indigo |

Unknown or unmapped callsigns fall back to grey.

