### PR TITLE
feat: show syllabus action on view and conduct mentoring pages

### DIFF
--- a/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
+++ b/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
@@ -11,6 +11,7 @@ use App\Filament\Training\Support\MentoringReportLayout;
 use App\Models\Cts\ProgSheetField;
 use App\Models\Cts\ReportSheet;
 use App\Models\Cts\Session;
+use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Repositories\Cts\MentoringReportRepository;
 use App\Services\Training\MentoringReportService;
 use Filament\Actions\Action;
@@ -156,22 +157,36 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
 
     public function sessionDetailsInfolist(Schema $schema): Schema
     {
+        $syllabusUrl = $this->relevantSyllabusUrl();
+
         return $schema
             ->record($this->session)
             ->components([
-                Section::make('Session Details')->columnSpanFull()->schema([
-                    TextEntry::make('student')
-                        ->label('Student')
-                        ->getStateUsing(fn () => "{$this->session->student->name} ({$this->session->student->cid})"),
-                    TextEntry::make('mentor')
-                        ->label('Mentor')
-                        ->getStateUsing(fn () => "{$this->session->mentor->name} ({$this->session->mentor->cid})"),
-                    TextEntry::make('position')
-                        ->label('Position'),
-                    TextEntry::make('schedule')
-                        ->label('Date & Time')
-                        ->getStateUsing(fn () => "{$this->session->taken_date} | {$this->session->taken_from} - {$this->session->taken_to}"),
-                ])->columns(2),
+                Section::make('Session Details')
+                    ->columnSpanFull()
+                    ->headerActions([
+                        Action::make('viewSyllabus')
+                            ->label('View Syllabus')
+                            ->icon('heroicon-m-document-text')
+                            ->color('gray')
+                            ->size('sm')
+                            ->url($syllabusUrl)
+                            ->openUrlInNewTab()
+                            ->visible(fn () => filled($syllabusUrl)),
+                    ])
+                    ->schema([
+                        TextEntry::make('student')
+                            ->label('Student')
+                            ->getStateUsing(fn () => "{$this->session->student->name} ({$this->session->student->cid})"),
+                        TextEntry::make('mentor')
+                            ->label('Mentor')
+                            ->getStateUsing(fn () => "{$this->session->mentor->name} ({$this->session->mentor->cid})"),
+                        TextEntry::make('position')
+                            ->label('Position'),
+                        TextEntry::make('schedule')
+                            ->label('Date & Time')
+                            ->getStateUsing(fn () => "{$this->session->taken_date} | {$this->session->taken_from} - {$this->session->taken_to}"),
+                    ])->columns(2),
             ]);
     }
 
@@ -208,7 +223,7 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
                     ->schema([
                         $this->mentoringReportNotesEditor(TrainingRichEditor::make('body'))
                             ->columnSpanFull()
-                            ->live(debounce: 1000)
+                            ->live(onBlur: true)
                             ->extraInputAttributes(['style' => 'min-height: 200px;'])
                             ->afterStateHydrated(fn ($component) => $component->state(
                                 $this->ctsRichEditorHtmlForHydration($this->additionalComments)
@@ -265,7 +280,7 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
                 $this->mentoringReportNotesEditor(TrainingRichEditor::make("criteria.{$fieldId}.notes"))
                     ->default('<p></p>')
                     ->columnSpan(12)
-                    ->live(debounce: 500)
+                    ->live(onBlur: true)
                     ->extraInputAttributes(['style' => 'min-height: 150px;'])
                     ->afterStateUpdated(fn () => $this->markDirty()),
             ])
@@ -424,5 +439,17 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
             ->where('field_id', '!=', 0)
             ->pluck('notes', 'field_id')
             ->all();
+    }
+
+    /**
+     * Resolves the syllabus link.
+     */
+    private function relevantSyllabusUrl(): ?string
+    {
+        $trainingPosition = TrainingPosition::query()
+            ->whereJsonContains('cts_positions', $this->session->position)
+            ->first();
+
+        return $trainingPosition?->syllabus_url;
     }
 }

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -12,6 +12,7 @@ use App\Livewire\Training\CriteriaCategoryTable;
 use App\Livewire\Training\SessionCriteriaTable;
 use App\Models\Cts\Session;
 use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPosition\TrainingPosition;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Filament\Actions\Action;
@@ -82,9 +83,21 @@ class ViewMentoringReport extends Page implements HasInfolists
 
     public function infolist(Schema $schema): Schema
     {
+        $syllabusUrl = $this->relevantSyllabusUrl();
+
         return $schema->record($this->session)->components([
             Section::make('Session Summary')
                 ->columns(3)
+                ->headerActions([
+                    Action::make('viewSyllabus')
+                        ->label('View Syllabus')
+                        ->icon('heroicon-m-document-text')
+                        ->color('gray')
+                        ->size('sm')
+                        ->url($syllabusUrl)
+                        ->openUrlInNewTab()
+                        ->visible(fn () => filled($syllabusUrl)),
+                ])
                 ->schema([
                     TextEntry::make('student.account.name')
                         ->label('Student')
@@ -390,5 +403,17 @@ class ViewMentoringReport extends Page implements HasInfolists
             ])
             )
             ->all();
+    }
+
+    /**
+     * Resolves the syllabus link.
+     */
+    private function relevantSyllabusUrl(): ?string
+    {
+        $trainingPosition = TrainingPosition::query()
+            ->whereJsonContains('cts_positions', $this->session->position)
+            ->first();
+
+        return $trainingPosition?->syllabus_url;
     }
 }

--- a/app/Models/Training/TrainingPosition/TrainingPosition.php
+++ b/app/Models/Training/TrainingPosition/TrainingPosition.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Route;
 
 class TrainingPosition extends Model
 {
@@ -22,6 +23,14 @@ class TrainingPosition extends Model
     ];
 
     protected $guarded = [];
+
+    protected const SYLLABUS_ROUTES = [
+        'OBS to S1 Training' => 'site.policy.training.s1-syllabus',
+        'S1 Training' => 'site.policy.training.s1-syllabus',
+        'S2 Training' => 'site.policy.training.s2-syllabus',
+        'S3 Training' => 'site.policy.training.s3-syllabus',
+        'C1 Training' => 'site.policy.training.c1-syllabus',
+    ];
 
     public function position(): BelongsTo
     {
@@ -51,5 +60,16 @@ class TrainingPosition extends Model
     public function getShouldShowSoloEndorsementAttribute(): bool
     {
         return $this->feature_toggles['show_solo_endorsement'] ?? true;
+    }
+
+    public function getSyllabusUrlAttribute(): ?string
+    {
+        $routeName = self::SYLLABUS_ROUTES[$this->category] ?? null;
+
+        if (! $routeName) {
+            return null;
+        }
+
+        return Route::has($routeName) ? route($routeName) : null;
     }
 }


### PR DESCRIPTION
# Summary of changes
- Show a link to access the syllabus on view and conduct mentoring pages

# Screenshots (if necessary)
<img width="758" height="196" alt="image" src="https://github.com/user-attachments/assets/b1aa711f-2f9e-49f4-bd3a-2881adb3e6ee" />
