### PR TITLE
Auto detect mentoring session adjacent atc

### DIFF
--- a/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
+++ b/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
@@ -11,6 +11,7 @@ use App\Filament\Training\Support\MentoringReportLayout;
 use App\Models\Cts\ProgSheetField;
 use App\Models\Cts\ReportSheet;
 use App\Models\Cts\Session;
+use App\Models\NetworkData\Atc as NetworkdataAtc;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Repositories\Cts\MentoringReportRepository;
 use App\Services\Training\MentoringReportService;
@@ -25,6 +26,7 @@ use Filament\Infolists\Contracts\HasInfolists;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Callout;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
@@ -186,8 +188,24 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
                         TextEntry::make('schedule')
                             ->label('Date & Time')
                             ->getStateUsing(fn () => "{$this->session->taken_date} | {$this->session->taken_from} - {$this->session->taken_to}"),
+                        Callout::make('adjacent_atc')
+                            ->visible(fn () => $this->adjacentAtcPositions->isNotEmpty())
+                            ->icon('heroicon-m-signal')
+                            ->color('primary')
+                            ->columnSpanFull()
+                            ->heading('Adjacent ATC Online')
+                            ->description(
+                                $this->adjacentAtcPositions
+                                    ->map(fn (NetworkdataAtc $atc) => $atc->callsign)
+                                    ->implode(', ')
+                            ),
                     ])->columns(2),
             ]);
+    }
+
+    public function getAdjacentAtcPositionsProperty(): \Illuminate\Support\Collection
+    {
+        return NetworkdataAtc::adjacentPositionsForMentoringSession($this->session);
     }
 
     public function form(Schema $schema): Schema

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -11,6 +11,7 @@ use App\Filament\Training\Support\MentoringReportScores;
 use App\Livewire\Training\CriteriaCategoryTable;
 use App\Livewire\Training\SessionCriteriaTable;
 use App\Models\Cts\Session;
+use App\Models\NetworkData\Atc as NetworkdataAtc;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use Carbon\Carbon;
@@ -126,6 +127,17 @@ class ViewMentoringReport extends Page implements HasInfolists
                     TextEntry::make('position')
                         ->label('Position & Time')
                         ->helperText(fn (Session $record) => Carbon::parse($record->taken_date)->format('d/m/Y').' | '.Carbon::parse($record->taken_from)->format('H:i').' - '.Carbon::parse($record->taken_to)->format('H:i')),
+
+                    Callout::make('adjacent_atc')
+                        ->visible(fn (Session $record) => NetworkdataAtc::adjacentPositionsForMentoringSession($record)->isNotEmpty())
+                        ->icon('heroicon-m-signal')
+                        ->color('primary')
+                        ->columnSpanFull()
+                        ->heading('Adjacent ATC Online')
+                        ->description(fn (Session $record) => NetworkdataAtc::adjacentPositionsForMentoringSession($record)
+                            ->map(fn (NetworkdataAtc $atc) => $atc->callsign)
+                            ->implode(', ')
+                        ),
 
                     Callout::make('Session Cancelled')
                         ->heading(function (Session $record): string {

--- a/app/Models/NetworkData/Atc.php
+++ b/app/Models/NetworkData/Atc.php
@@ -339,4 +339,31 @@ class Atc extends Model
             return $this->connected_at->lt($mentoringEnd) && $this->disconnected_at->gt($mentoringStart);
         });
     }
+
+    /**
+     * Find adjacent ATC positions on the same aerodrome that were active during a mentoring session.
+     *
+     * This detects controllers on other positions at the same aerodrome during the session.
+     * We exclude the position being mentored on.
+     *
+     * @return \Illuminate\Support\Collection<int, static>
+     */
+    public static function adjacentPositionsForMentoringSession(CtsSession $mentoringSession): \Illuminate\Support\Collection
+    {
+        $areaCode = explode('_', $mentoringSession->position)[0];
+
+        $sessionStart = \Carbon\Carbon::parse($mentoringSession->taken_date.' '.$mentoringSession->taken_from);
+        $sessionEnd = \Carbon\Carbon::parse($mentoringSession->taken_date.' '.$mentoringSession->taken_to);
+
+        return static::where('callsign', 'like', $areaCode.'_%')
+            ->where('callsign', '!=', $mentoringSession->position)
+            ->where('connected_at', '<', $sessionEnd)
+            ->where(function ($query) use ($sessionStart) {
+                $query->whereNull('disconnected_at')
+                    ->orWhere('disconnected_at', '>', $sessionStart);
+            })
+            ->get()
+            ->unique('callsign')
+            ->values();
+    }
 }

--- a/tests/Unit/NetworkData/AtcSessionModelTest.php
+++ b/tests/Unit/NetworkData/AtcSessionModelTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Unit\NetworkData;
 
+use App\Models\Cts\Session as MentoringSession;
 use App\Models\Mship\Qualification;
+use App\Models\NetworkData\Atc;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Test;
@@ -27,11 +29,11 @@ class AtcSessionModelTest extends TestCase
     public function it_can_create_an_atc_session()
     {
         $qualification = Qualification::inRandomOrder()->first();
-        $atcSession = factory(\App\Models\NetworkData\Atc::class)->make();
+        $atcSession = factory(Atc::class)->make();
         $atcSession->qualification_id = $qualification->id;
         $this->user->networkDataAtc()->save($atcSession);
 
-        $this->assertInstanceOf(\App\Models\NetworkData\Atc::class, $atcSession,
+        $this->assertInstanceOf(Atc::class, $atcSession,
             'NetworkData::AtcSession not created.');
         $this->assertEquals(true, $atcSession->exists, "NetworkData::AtcSession doesn't exist.");
 
@@ -42,7 +44,7 @@ class AtcSessionModelTest extends TestCase
     public function it_can_create_an_atc_session_and_mark_as_disconnected()
     {
         $qualification = Qualification::inRandomOrder()->first();
-        $atcSession = factory(\App\Models\NetworkData\Atc::class)->make();
+        $atcSession = factory(Atc::class)->make();
         $atcSession->qualification_id = $qualification->id;
         $this->user->networkDataAtc()->save($atcSession);
 
@@ -61,7 +63,7 @@ class AtcSessionModelTest extends TestCase
     public function it_updates_minutes_online_when_a_session_is_marked_as_disconnected()
     {
         $qualification = Qualification::inRandomOrder()->first();
-        $atcSession = factory(\App\Models\NetworkData\Atc::class)->make();
+        $atcSession = factory(Atc::class)->make();
         $atcSession->qualification_id = $qualification->id;
         $account = \App\Models\Mship\Account::factory()->create();
         $account->networkDataAtc()->save($atcSession);
@@ -79,7 +81,7 @@ class AtcSessionModelTest extends TestCase
     public function it_triggers_an_event_when_an_atc_session_is_deleted()
     {
         $qualification = Qualification::inRandomOrder()->first();
-        $atcSession = factory(\App\Models\NetworkData\Atc::class)->make();
+        $atcSession = factory(Atc::class)->make();
         $atcSession->qualification_id = $qualification->id;
         $account = \App\Models\Mship\Account::factory()->create();
         $account->networkDataAtc()->save($atcSession);
@@ -92,12 +94,12 @@ class AtcSessionModelTest extends TestCase
     #[Test]
     public function it_detects_overlap_when_atc_session_overlaps_mentoring()
     {
-        $atc = factory(\App\Models\NetworkData\Atc::class)->make();
+        $atc = factory(Atc::class)->make();
         $atc->connected_at = \Carbon\Carbon::parse('2026-03-29 18:30:00');
         $atc->disconnected_at = \Carbon\Carbon::parse('2026-03-29 19:30:00');
         $this->user->networkDataAtc()->save($atc);
 
-        $mentoring = \App\Models\Cts\Session::factory()->create([
+        $mentoring = MentoringSession::factory()->create([
             'taken_date' => '2026-03-29',
             'taken_from' => '18:00:00',
             'taken_to' => '20:00:00',
@@ -112,12 +114,12 @@ class AtcSessionModelTest extends TestCase
     #[Test]
     public function it_returns_false_when_atc_session_does_not_overlap_mentoring()
     {
-        $atc = factory(\App\Models\NetworkData\Atc::class)->make();
+        $atc = factory(Atc::class)->make();
         $atc->connected_at = \Carbon\Carbon::parse('2026-03-29 15:00:00');
         $atc->disconnected_at = \Carbon\Carbon::parse('2026-03-29 17:00:00');
         $this->user->networkDataAtc()->save($atc);
 
-        $differentDate = \App\Models\Cts\Session::factory()->create([
+        $differentDate = MentoringSession::factory()->create([
             'taken_date' => '2026-05-10',
             'taken_from' => '18:00:00',
             'taken_to' => '20:00:00',
@@ -132,7 +134,7 @@ class AtcSessionModelTest extends TestCase
     #[Test]
     public function it_returns_false_when_atc_session_has_no_disconnected_at()
     {
-        $atc = factory(\App\Models\NetworkData\Atc::class)->make();
+        $atc = factory(Atc::class)->make();
         $atc->connected_at = \Carbon\Carbon::parse('2026-03-29 18:30:00');
         $atc->disconnected_at = null;
         $this->user->networkDataAtc()->save($atc);
@@ -143,12 +145,12 @@ class AtcSessionModelTest extends TestCase
     #[Test]
     public function it_matches_correct_mentoring_when_multiple_exist()
     {
-        $atc = factory(\App\Models\NetworkData\Atc::class)->make();
+        $atc = factory(Atc::class)->make();
         $atc->connected_at = \Carbon\Carbon::parse('2026-04-26 20:00:00');
         $atc->disconnected_at = \Carbon\Carbon::parse('2026-04-26 21:00:00');
         $this->user->networkDataAtc()->save($atc);
 
-        $earlier = \App\Models\Cts\Session::factory()->create([
+        $earlier = MentoringSession::factory()->create([
             'taken_date' => '2026-03-29',
             'taken_from' => '18:00:00',
             'taken_to' => '20:00:00',
@@ -156,7 +158,7 @@ class AtcSessionModelTest extends TestCase
             'noShow' => 0,
         ]);
 
-        $matching = \App\Models\Cts\Session::factory()->create([
+        $matching = MentoringSession::factory()->create([
             'taken_date' => '2026-04-26',
             'taken_from' => '19:30:00',
             'taken_to' => '21:30:00',
@@ -165,5 +167,132 @@ class AtcSessionModelTest extends TestCase
         ]);
 
         $this->assertTrue($atc->hasOverlappingCompletedMentoringSession(collect([$earlier, $matching])));
+    }
+
+    // ─── adjacentPositionsForMentoringSession tests ───────────────────────────────
+
+    #[Test]
+    public function it_returns_adjacent_atc_positions_on_same_aerodrome()
+    {
+        $mentoringSession = MentoringSession::factory()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-03-29',
+            'taken_from' => '18:00:00',
+            'taken_to' => '20:00:00',
+        ]);
+
+        // Create ATC sessions on the same aerodrome (EGKK) during the session time
+        factory(Atc::class)->states('offline')->create([
+            'callsign' => 'EGKK_APP',
+            'connected_at' => '2026-03-29 18:30:00',
+            'disconnected_at' => '2026-03-29 19:30:00',
+        ]);
+
+        factory(Atc::class)->states('offline')->create([
+            'callsign' => 'EGKK_GND',
+            'connected_at' => '2026-03-29 18:00:00',
+            'disconnected_at' => '2026-03-29 20:00:00',
+        ]);
+
+        $result = Atc::adjacentPositionsForMentoringSession($mentoringSession);
+
+        $this->assertCount(2, $result);
+        $this->assertTrue($result->pluck('callsign')->contains('EGKK_APP'));
+        $this->assertTrue($result->pluck('callsign')->contains('EGKK_GND'));
+    }
+
+    #[Test]
+    public function it_returns_adjacent_atc_with_exclusions_and_deduplication()
+    {
+        $mentoringSession = MentoringSession::factory()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-03-29',
+            'taken_from' => '18:00:00',
+            'taken_to' => '20:00:00',
+        ]);
+
+        // Same position as the mentoring session — should be excluded
+        factory(Atc::class)->states('offline')->create([
+            'callsign' => 'EGKK_TWR',
+            'connected_at' => '2026-03-29 18:00:00',
+            'disconnected_at' => '2026-03-29 20:00:00',
+        ]);
+
+        // Two ATC sessions with same callsign — should be deduplicated
+        factory(Atc::class)->states('offline')->create([
+            'callsign' => 'EGKK_APP',
+            'connected_at' => '2026-03-29 18:00:00',
+            'disconnected_at' => '2026-03-29 19:00:00',
+        ]);
+        factory(Atc::class)->states('offline')->create([
+            'callsign' => 'EGKK_APP',
+            'connected_at' => '2026-03-29 19:00:00',
+            'disconnected_at' => '2026-03-29 20:00:00',
+        ]);
+
+        // Different aerodrome — should be excluded
+        factory(Atc::class)->states('offline')->create([
+            'callsign' => 'EGLL_APP',
+            'connected_at' => '2026-03-29 18:30:00',
+            'disconnected_at' => '2026-03-29 19:30:00',
+        ]);
+
+        // ATC still online (no disconnected_at) — should be included
+        factory(Atc::class)->create([
+            'callsign' => 'EGKK_GND',
+            'connected_at' => '2026-03-29 17:30:00',
+            'disconnected_at' => null,
+        ]);
+
+        $result = Atc::adjacentPositionsForMentoringSession($mentoringSession);
+
+        $this->assertCount(2, $result);
+        $this->assertTrue($result->pluck('callsign')->contains('EGKK_APP'));
+        $this->assertTrue($result->pluck('callsign')->contains('EGKK_GND'));
+    }
+
+    #[Test]
+    public function it_excludes_atc_outside_the_session_time_range()
+    {
+        $mentoringSession = MentoringSession::factory()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-03-29',
+            'taken_from' => '18:00:00',
+            'taken_to' => '20:00:00',
+        ]);
+
+        // ATC session that ended before the mentoring session started
+        factory(Atc::class)->states('offline')->create([
+            'callsign' => 'EGKK_APP',
+            'connected_at' => '2026-03-29 16:00:00',
+            'disconnected_at' => '2026-03-29 17:00:00',
+        ]);
+
+        // ATC session that started after the mentoring session ended
+        factory(Atc::class)->states('offline')->create([
+            'callsign' => 'EGKK_GND',
+            'connected_at' => '2026-03-29 21:00:00',
+            'disconnected_at' => '2026-03-29 22:00:00',
+        ]);
+
+        $result = Atc::adjacentPositionsForMentoringSession($mentoringSession);
+
+        $this->assertCount(0, $result);
+    }
+
+    #[Test]
+    public function it_returns_empty_collection_when_no_matching_atc_exists()
+    {
+        $mentoringSession = MentoringSession::factory()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-03-29',
+            'taken_from' => '18:00:00',
+            'taken_to' => '20:00:00',
+        ]);
+
+        $result = Atc::adjacentPositionsForMentoringSession($mentoringSession);
+
+        $this->assertCount(0, $result);
+        $this->assertTrue($result->isEmpty());
     }
 }


### PR DESCRIPTION
Both on the conduct and on the standard report view page.
Included a lot of tests as I did not trust the logic, especially when using datetime

<img width="1249" height="719" alt="image" src="https://github.com/user-attachments/assets/3b1d9638-e253-4bb4-bc3a-31e4a22e7ae9" />
