### PR TITLE
Improve mentoring report autosave and make consistent with exam report

### DIFF
--- a/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
+++ b/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Training\Concerns;
 
 use App\Filament\Forms\Components\TrainingRichEditor;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\RichContentRenderer;
 
 trait InteractsWithCtsRichEditorNotes
@@ -19,6 +20,22 @@ trait InteractsWithCtsRichEditorNotes
             ->disableToolbarButtons(['attachFiles', 'blockquote'])
             ->extraAttributes(['class' => 'mentoring-report-notes-editor'])
             ->extraFieldWrapperAttributes(['class' => 'mentoring-report-notes-field']);
+    }
+
+    /**
+     * Sync RichEditor state on blur only to avoid Livewire re-renders resetting TipTap cursor position mid-edit.
+     *
+     * @param  (callable(mixed): void)|null  $afterStateUpdated
+     */
+    protected function conductSessionRichEditor(RichEditor $editor, ?callable $afterStateUpdated = null): RichEditor
+    {
+        $editor = $editor->live(onBlur: true);
+
+        if ($afterStateUpdated !== null) {
+            return $editor->afterStateUpdated($afterStateUpdated);
+        }
+
+        return $editor->afterStateUpdated(fn () => $this->markDirty());
     }
 
     /**

--- a/app/Filament/Training/Concerns/InteractsWithTrainingConductAutosave.php
+++ b/app/Filament/Training/Concerns/InteractsWithTrainingConductAutosave.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Concerns;
+
+trait InteractsWithTrainingConductAutosave
+{
+    public bool $hasUnsavedChanges = false;
+
+    public bool $isSaving = false;
+
+    public ?int $lastChangedAt = null;
+
+    public int $autosaveIdleSeconds = 1;
+
+    public int $autosaveMinInterval = 5;
+
+    public ?int $lastAutosaveAt = null;
+
+    public function autosave(): void
+    {
+        if ($this->isSaving || ! $this->hasUnsavedChanges) {
+            return;
+        }
+
+        $now = now()->timestamp;
+
+        if ($this->lastChangedAt && ($now - $this->lastChangedAt) < $this->autosaveIdleSeconds) {
+            return;
+        }
+
+        if ($this->lastAutosaveAt && ($now - $this->lastAutosaveAt) < $this->autosaveMinInterval) {
+            return;
+        }
+
+        $this->lastAutosaveAt = $now;
+        $this->save(withNotification: false);
+    }
+
+    public function markDirty(bool $skipRender = false): void
+    {
+        $this->hasUnsavedChanges = true;
+        $this->lastChangedAt = now()->timestamp;
+
+        if ($skipRender) {
+            $this->skipRender();
+        }
+    }
+}

--- a/app/Filament/Training/Pages/Exam/ConductExam.php
+++ b/app/Filament/Training/Pages/Exam/ConductExam.php
@@ -4,6 +4,7 @@ namespace App\Filament\Training\Pages\Exam;
 
 use App\Enums\ExamResultEnum;
 use App\Filament\Training\Concerns\InteractsWithCtsRichEditorNotes;
+use App\Filament\Training\Concerns\InteractsWithTrainingConductAutosave;
 use App\Models\Cts\ExamBooking;
 use App\Models\Cts\ExamCriteria;
 use App\Models\Cts\ExamCriteriaAssessment;
@@ -36,6 +37,7 @@ class ConductExam extends Page implements HasForms, HasInfolists
 {
     use InteractsWithCtsRichEditorNotes;
     use InteractsWithForms, InteractsWithInfolists;
+    use InteractsWithTrainingConductAutosave;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
 
@@ -52,18 +54,6 @@ class ConductExam extends Page implements HasForms, HasInfolists
     public int $examId;
 
     public ExamBooking $examBooking;
-
-    public bool $hasUnsavedChanges = false;
-
-    public bool $isSaving = false;
-
-    public ?int $lastChangedAt = null;
-
-    public int $autosaveIdleSeconds = 1;
-
-    public int $autosaveMinInterval = 5;
-
-    public ?int $lastAutosaveAt = null;
 
     // save additional comments in session to persist across form submissions
     // this is because we don't save additional comments in the CTS database until the exam is completed
@@ -179,16 +169,16 @@ class ConductExam extends Page implements HasForms, HasInfolists
                     ->label($criteria->criteria)
                     ->columnSpanFull()
                     ->schema([
-                        RichEditor::make("form.{$criteria->id}.comments")
-                            ->label('Comments')
-                            ->default('<p></p>')
-                            ->columnSpan(9)
-                            ->disableToolbarButtons(['attachFiles', 'blockquote'])
-                            ->live(debounce: 500)
-                            ->extraInputAttributes([
-                                'style' => 'min-height: 200px;',
-                            ])
-                            ->afterStateUpdated(fn () => $this->markDirty()),
+                        $this->conductSessionRichEditor(
+                            RichEditor::make("form.{$criteria->id}.comments")
+                                ->label('Comments')
+                                ->default('<p></p>')
+                                ->columnSpan(9)
+                                ->disableToolbarButtons(['attachFiles', 'blockquote'])
+                                ->extraInputAttributes([
+                                    'style' => 'min-height: 200px;',
+                                ]),
+                        ),
                         Select::make("form.{$criteria->id}.grade")
                             ->label('Grade')
                             ->options(ExamCriteriaAssessment::gradeDropdownOptions())
@@ -196,7 +186,7 @@ class ConductExam extends Page implements HasForms, HasInfolists
                             ->columnSpan(3)
                             ->required()
                             ->live()
-                            ->afterStateUpdated(fn () => $this->save(withNotification: false)),
+                            ->afterStateUpdated(fn () => $this->markDirty(skipRender: true)),
                     ])->columns(12);
             }
         );
@@ -214,20 +204,22 @@ class ConductExam extends Page implements HasForms, HasInfolists
             ->label('Exam Result')
             ->columnSpanFull()
             ->schema([
-                RichEditor::make('additional_comments')
-                    ->label('Additional Comments')
-                    ->disableToolbarButtons(['attachFiles', 'blockquote'])
-                    ->columnSpan(9)
-                    ->live(debounce: 1000)
-                    // save additional comments in session to persist in session in case navigation occurs
-                    ->extraInputAttributes([
-                        'style' => 'min-height: 200px;',
-                    ])
+                $this->conductSessionRichEditor(
+                    RichEditor::make('additional_comments')
+                        ->label('Additional Comments')
+                        ->disableToolbarButtons(['attachFiles', 'blockquote'])
+                        ->columnSpan(9)
+                        ->extraInputAttributes([
+                            'style' => 'min-height: 200px;',
+                        ]),
+                    function ($state): void {
+                        $this->additionalComments = $state;
+                        $this->markDirty();
+                    },
+                )
                     ->afterStateHydrated(fn ($component) => $component->state(
                         $this->ctsRichEditorHtmlForHydration($this->additionalComments)
-                    ))
-                    // save additional comments in session to persist in session in case navigation occurs
-                    ->afterStateUpdated(fn ($state, $livewire) => ($this->additionalComments = $state)),
+                    )),
 
                 Select::make('exam_result')
                     ->label('Result')
@@ -366,34 +358,9 @@ class ConductExam extends Page implements HasForms, HasInfolists
                 ->title('Exam report saved')
                 ->success()
                 ->send();
+        } else {
+            $this->skipRender();
         }
-    }
-
-    public function autosave(): void
-    {
-        if ($this->isSaving || ! $this->hasUnsavedChanges) {
-            return;
-        }
-
-        $now = now()->timestamp;
-
-        if ($this->lastChangedAt && ($now - $this->lastChangedAt) < $this->autosaveIdleSeconds) {
-            return;
-        }
-
-        if ($this->lastAutosaveAt && ($now - $this->lastAutosaveAt) < $this->autosaveMinInterval) {
-            return;
-        }
-
-        $this->lastAutosaveAt = $now;
-
-        $this->save(withNotification: false);
-    }
-
-    public function markDirty(): void
-    {
-        $this->hasUnsavedChanges = true;
-        $this->lastChangedAt = now()->timestamp;
     }
 
     public function removeTrainingPlace()

--- a/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
+++ b/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
@@ -7,6 +7,7 @@ namespace App\Filament\Training\Pages\Mentor;
 use App\Enums\FieldScore;
 use App\Filament\Forms\Components\TrainingRichEditor;
 use App\Filament\Training\Concerns\InteractsWithCtsRichEditorNotes;
+use App\Filament\Training\Concerns\InteractsWithTrainingConductAutosave;
 use App\Filament\Training\Support\MentoringReportLayout;
 use App\Models\Cts\ProgSheetField;
 use App\Models\Cts\ReportSheet;
@@ -45,6 +46,7 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
     use InteractsWithCtsRichEditorNotes;
     use InteractsWithForms;
     use InteractsWithInfolists;
+    use InteractsWithTrainingConductAutosave;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
 
@@ -65,18 +67,6 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
 
     /** @var array<int, FieldScore> */
     public array $bestScores = [];
-
-    public bool $hasUnsavedChanges = false;
-
-    public bool $isSaving = false;
-
-    public ?int $lastChangedAt = null;
-
-    public int $autosaveIdleSeconds = 1;
-
-    public int $autosaveMinInterval = 5;
-
-    public ?int $lastAutosaveAt = null;
 
     #[LivewireSession('mentoringAdditionalComments.{sessionId}')]
     public ?string $additionalComments = '';
@@ -239,17 +229,18 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
                 Section::make('Additional Comments')
                     ->columnSpanFull()
                     ->schema([
-                        $this->mentoringReportNotesEditor(TrainingRichEditor::make('body'))
-                            ->columnSpanFull()
-                            ->live(onBlur: true)
-                            ->extraInputAttributes(['style' => 'min-height: 200px;'])
-                            ->afterStateHydrated(fn ($component) => $component->state(
-                                $this->ctsRichEditorHtmlForHydration($this->additionalComments)
-                            ))
-                            ->afterStateUpdated(function ($state): void {
+                        $this->conductSessionRichEditor(
+                            $this->mentoringReportNotesEditor(TrainingRichEditor::make('body'))
+                                ->columnSpanFull()
+                                ->extraInputAttributes(['style' => 'min-height: 200px;']),
+                            function ($state): void {
                                 $this->additionalComments = $state;
                                 $this->markDirty();
-                            }),
+                            },
+                        )
+                            ->afterStateHydrated(fn ($component) => $component->state(
+                                $this->ctsRichEditorHtmlForHydration($this->additionalComments)
+                            )),
                         Actions::make([
                             Action::make('submit_report')
                                 ->label('Submit Report')
@@ -294,13 +285,13 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
                     ->required()
                     ->columnSpan(2)
                     ->live()
-                    ->afterStateUpdated(fn () => $this->save(withNotification: false)),
-                $this->mentoringReportNotesEditor(TrainingRichEditor::make("criteria.{$fieldId}.notes"))
-                    ->default('<p></p>')
-                    ->columnSpan(12)
-                    ->live(onBlur: true)
-                    ->extraInputAttributes(['style' => 'min-height: 150px;'])
-                    ->afterStateUpdated(fn () => $this->markDirty()),
+                    ->afterStateUpdated(fn () => $this->markDirty(skipRender: true)),
+                $this->conductSessionRichEditor(
+                    $this->mentoringReportNotesEditor(TrainingRichEditor::make("criteria.{$fieldId}.notes"))
+                        ->default('<p></p>')
+                        ->columnSpan(12)
+                        ->extraInputAttributes(['style' => 'min-height: 150px;']),
+                ),
             ])
             ->extraAttributes(['class' => MentoringReportLayout::CRITERION_ROW_CLASSES]);
     }
@@ -333,6 +324,8 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
                     ->title('Mentoring report saved')
                     ->success()
                     ->send();
+            } else {
+                $this->skipRender();
             }
         } finally {
             $this->isSaving = false;
@@ -394,32 +387,6 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
         }
 
         $this->redirect(Mentoring::getUrl());
-    }
-
-    public function autosave(): void
-    {
-        if ($this->isSaving || ! $this->hasUnsavedChanges) {
-            return;
-        }
-
-        $now = now()->timestamp;
-
-        if ($this->lastChangedAt && ($now - $this->lastChangedAt) < $this->autosaveIdleSeconds) {
-            return;
-        }
-
-        if ($this->lastAutosaveAt && ($now - $this->lastAutosaveAt) < $this->autosaveMinInterval) {
-            return;
-        }
-
-        $this->lastAutosaveAt = $now;
-        $this->save(withNotification: false);
-    }
-
-    public function markDirty(): void
-    {
-        $this->hasUnsavedChanges = true;
-        $this->lastChangedAt = now()->timestamp;
     }
 
     private function noShowModalDescription(): string


### PR DESCRIPTION
## Summary

Fixes an intermittent cursor-jump bug in mentoring and exam conduct forms where the caret would jump to the end of a RichEditor notes field while editing multi-line content.

The root cause was Livewire re-rendering TipTap editors during typing — debounced `live()` syncs, immediate saves on score/grade changes, and 5-second autosave polling all triggered server round-trips that reset editor state without preserving cursor position.

## Problem

Mentors reported that while writing notes in the conduct mentoring session form, the cursor would unexpectedly jump to the end of the text field — sometimes repeatedly. This was most noticeable when:

- Writing multiple notes separated by **Enter** (new paragraphs)
- Using **Shift+Enter** to add a line under an existing note
- Clicking back to edit an earlier paragraph

This is a known TipTap + Livewire interaction: when editor content is programmatically reset from server state, the cursor position is lost and defaults to the end of the documenOn `ConductMentoringSession`, three mechanisms were compounding the issue:

1. **Debounced `live()` on RichEditor fields** — notes synced to the server every 500ms–1s while typing
2. **Immediate save on score change** — changing any criterion score triggered a full form save and page re-render
3. **Background autosave polling** — `wire:poll.5s` caused periodic Livewire requests that re-rendered all editors

The same patterns existed on `ConductExam`.

## Solution

Reduce Livewire round-trips while the user is actively editing rich text:

- **RichEditor fields** — replace `live(debounce: …)` with `live(onBlur: true)` via a shared `conductSessionRichEditor()` helper, so notes only sync when the user leaves the field
- **Score/grade selects** — replace immediate `save()` with `markDirty(skipRender: true)` so dropdown changes persist server-side state without re-rendering the page
- **Silent saves** — call `skipRender()` on autosave and other background saves so the 5s poll does not reset TipTapred autosave logic** — extract `InteractsWithTrainingConductAutosave` trait used by both conduct pages for consistent behaviour

## Changes

- **`InteractsWithTrainingConductAutosave`** (new) — shared autosave, `markDirty()`, and optional `skipRender` support
- **`InteractsWithCtsRichEditorNotes`** — add `conductSessionRichEditor()` helper for blur-based RichEditor sync
- **`ConductMentoringSession`** — apply fixes to criterion notes, additional comments, and score selects
- **`ConductExam`** — mirror the same patterns for criteria comments, additional comments, and grade selects

## Behaviour changes

| Before | After |
|--------|-------|
| Notes synced every 500ms–1s while typing | Notes synced on blur only |
| Score/grade change → immediate save + full re-render | Score/grade change → mark dirty, no re-render |
| Autosave → full page re-render | Autosave → persist silently, skip render |

Manual save (with notification) still re-renders normally so the Save button updates to "Saved". re alone, the Save button may not update until the next blur or interaction — an intentional trade-off to keep the cursor stable while editing notes elsewhere on the form.

