### PR TITLE
Hotfix for failing test on waiting list retention checks

### DIFF
--- a/app/Console/Commands/Training/CreateWaitingListRetentionChecks.php
+++ b/app/Console/Commands/Training/CreateWaitingListRetentionChecks.php
@@ -40,7 +40,7 @@ class CreateWaitingListRetentionChecks extends Command
                  * determined by when the account was added to the waiting list,
                  * create the first retention check.
                  */
-                if ($retentionChecks->isEmpty() && $waitingListAccount->created_at->diffInMonths(now()) >= $waitingList->retention_checks_months) {
+                if ($retentionChecks->isEmpty() && $waitingListAccount->created_at->lte(now()->subMonths($waitingList->retention_checks_months))) {
                     SendWaitingListRetentionCheck::dispatch($waitingListAccount);
 
                     continue;
@@ -59,7 +59,12 @@ class CreateWaitingListRetentionChecks extends Command
                  * determined by when the account was added to the waiting list,
                  * create a new retention check.
                  */
-                if (min($mostRecentRetentionCheck->created_at, $mostRecentRetentionCheck->email_sent_at)->diffInMonths(now()) >= $waitingList->retention_checks_months) {
+                $lastRetentionCheckAt = min(
+                    $mostRecentRetentionCheck->created_at,
+                    $mostRecentRetentionCheck->email_sent_at ?? $mostRecentRetentionCheck->created_at,
+                );
+
+                if ($lastRetentionCheckAt->lte(now()->subMonths($waitingList->retention_checks_months))) {
                     SendWaitingListRetentionCheck::dispatch($waitingListAccount);
                 }
             }


### PR DESCRIPTION
## Carbon 3 upgrade

| | |
|---|---|
| **Commit** | `4d5730e38` |
| **PR** | [#3976](https://github.com/vatsimuk/vukcore/pull/3976) — Laravel 12 |
| **Date** | 21 May 2025 |
| **Change** | `nesbot/carbon` **2.73.0 → 3.9.1** (via `composer.lock`) |

Filament v4 (`613750d70`, 6 Apr 2026) only bumped Carbon within v3 (3.11.0 → 3.11.3).

## Retention check test failure (unrelated)

**Cause:** Carbon 3’s `diffInMonths()` returns a float (e.g. `2.93` for `now()->subMonths(3)->subDays(1)`), so `>= 3` in `CreateWaitingListRetentionChecks` failed and no retention check was created.

**Fix:** Compare calendar dates instead: `created_at->lte(now()->subMonths($months))` (and the same pattern for recurring checks).

**Note:** The test can be date-dependent in CI; the bug has been possible since the Laravel 12 / Carbon 3 upgrade, not only on recent branches.