### PR TITLE
fix: Back to admin URL is wrong

### DIFF
--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -47,7 +47,7 @@ return [
     |
     */
 
-    'back_to_system_url' => config('app.url').'/admin',
+    'back_to_system_url' => '/admin',
 
     'back_to_system_label' => 'Back to Admin',
 


### PR DESCRIPTION
Fixes #4848
# Summary of changes

Remove the addition of app.url, which meant that the redirect was vatsim.uk/vatsim.uk/admin. The removal of this has made the redirect to be vatsim.uk/admin

# Screenshots (if necessary)
After:
<img width="100" height="64" alt="image" src="https://github.com/user-attachments/assets/f0fabc23-5437-4986-bf50-0479528f15f0" />

Before:
<img width="145" height="38" alt="image" src="https://github.com/user-attachments/assets/8c2af072-e812-493f-85ca-c1f9a912d9fd" />
