### PR TITLE
feat: allow mentor to post announcement to #request-mentoring-atc-traffic

### DIFF
--- a/app/Livewire/Training/AcceptedMentoringSessionsTable.php
+++ b/app/Livewire/Training/AcceptedMentoringSessionsTable.php
@@ -4,11 +4,15 @@ namespace App\Livewire\Training;
 
 use App\Filament\Training\Pages\Mentor\ConductMentoringSession;
 use App\Models\Cts\Session;
+use App\Services\Training\MentoringAnnouncementService;
 use App\Services\Training\MentoringReportService;
+use App\Services\Training\MentorPermissionService;
 use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
@@ -73,6 +77,7 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
                     ->url(fn (Session $record): string => ConductMentoringSession::getUrl(['sessionId' => $record->id]))
                     ->visible(fn (Session $record): bool => auth()->user()?->can('conduct', $record) ?? false),
                 $this->markNoShowTableAction(),
+                $this->postMentoringSessionAnnouncementAction(),
             ])
             ->emptyStateHeading('No upcoming mentoring sessions found');
     }
@@ -122,6 +127,54 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
                     Notification::make()
                         ->title('Session marked as no-show')
                         ->success()
+                        ->send();
+                }
+            });
+    }
+
+    protected function postMentoringSessionAnnouncementAction(): Action
+    {
+        return Action::make('postMentoringAnnouncement')
+            ->label('Post Mentoring Announcement')
+            ->icon('heroicon-o-megaphone')
+            ->color('info')
+            ->visible(function (Session $record): bool {
+                $category = app(MentorPermissionService::class)->resolveCategoryForCtsCallsign($record->position);
+
+                if ($category === 'OBS to S1 Training') {
+                    return false;
+                }
+
+                return app(MentoringAnnouncementService::class)->canPostAnnouncement($record, auth()->user()->member->id);
+            })
+            ->form([
+                Checkbox::make('ping_pilot')
+                    ->label('Ping: Pilot Role')
+                    ->default(true),
+
+                Checkbox::make('ping_controller')
+                    ->label('Ping: Controller Role')
+                    ->default(false),
+
+                Textarea::make('notes')
+                    ->label('Additional notes')
+                    ->placeholder('Optional: additional notes')
+                    ->rows(4)
+                    ->maxLength(1000),
+            ])
+            ->requiresConfirmation()
+            ->action(function (Session $record, array $data): void {
+                try {
+                    app(MentoringAnnouncementService::class)->postAnnouncement($record, $data);
+
+                    Notification::make()
+                        ->title('Discord notification sent')
+                        ->success()
+                        ->send();
+                } catch (\Throwable) {
+                    Notification::make()
+                        ->title('Failed to post to Discord')
+                        ->danger()
                         ->send();
                 }
             });

--- a/app/Services/Training/MentoringAnnouncementService.php
+++ b/app/Services/Training/MentoringAnnouncementService.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services\Training;
+
+use App\Libraries\Discord;
+use App\Models\Cts\Session;
+use Carbon\CarbonImmutable;
+
+class MentoringAnnouncementService
+{
+    public function __construct(
+        private readonly Discord $discord,
+        private readonly MentorPermissionService $mentorPermissionService,
+    ) {}
+
+    public function canPostAnnouncement(Session $session, int $memberId): bool
+    {
+        if (filled($session->filed)) {
+            return false;
+        }
+
+        if (filled($session->cancelled_datetime)) {
+            return false;
+        }
+
+        if (CarbonImmutable::parse("{$session->taken_date} {$session->taken_from}")->isPast()) {
+            return false;
+        }
+
+        return $session->mentor_id === $memberId;
+    }
+
+    public function postAnnouncement(Session $session, array $data): void
+    {
+        $channelId = config('training.discord.mentoring_announce_channel_id');
+
+        $this->discord->sendMessageToChannel($channelId, [
+            'content' => $this->buildMessage($session, $data),
+        ]);
+    }
+
+    public function buildMessage(Session $session, array $data): string
+    {
+        $category = $this->mentorPermissionService->resolveCategoryForCtsCallsign($session->position);
+
+        if ($category !== null && in_array($category, MentorPermissionService::pilotCategories(), true)) {
+            return $this->buildPilotMessage($session, $data);
+        }
+
+        return $this->buildAtcMessage($session, $data);
+    }
+
+    public function buildAtcMessage(Session $session, array $data): string
+    {
+        [$unix, $mentions, $notesBlock] = $this->buildSharedParts($session, $data);
+
+        return ($mentions !== '' ? $mentions."\n" : '')
+            ."**Upcoming ATC Mentoring Session**\n"
+            ."There will be a mentoring session on **{$session->position}** on **<t:{$unix}:F>** (<t:{$unix}:R>)"
+            .$notesBlock;
+    }
+
+    public function buildPilotMessage(Session $session, array $data): string
+    {
+        [$unix, $mentions, $notesBlock] = $this->buildSharedParts($session, $data);
+
+        return ($mentions !== '' ? $mentions."\n" : '')
+            ."**Upcoming Pilot Mentoring Session**\n"
+            ."There will be a **{$session->position}** mentoring session on **<t:{$unix}:F>** (<t:{$unix}:R>)"
+            .$notesBlock;
+    }
+
+    private function buildSharedParts(Session $session, array $data): array
+    {
+        $unix = CarbonImmutable::parse("{$session->taken_date} {$session->taken_from}")
+            ->utc()
+            ->getTimestamp();
+
+        $mentions = $this->buildMentions($data);
+
+        $notes = trim($data['notes'] ?? '');
+        $notesBlock = $notes !== '' ? "\n\n**Notes:**\n{$notes}" : '';
+
+        return [$unix, $mentions, $notesBlock];
+    }
+
+    private function buildMentions(array $data): string
+    {
+        $pilotRoleId = config('training.discord.mentoring_pilot_role_id');
+        $controllerRoleId = config('training.discord.mentoring_controller_role_id');
+
+        $pingPilot = ! empty($data['ping_pilot']);
+        $pingController = ! empty($data['ping_controller']);
+
+        return collect([$pingPilot && filled($pilotRoleId) ? "<@&{$pilotRoleId}>" : null, $pingController && filled($controllerRoleId) ? "<@&{$controllerRoleId}>" : null])->filter()->implode(' ');
+    }
+}

--- a/config/training.php
+++ b/config/training.php
@@ -12,6 +12,9 @@ return [
         'exam_pilot_role_id' => env('DISCORD_EXAM_PILOT_ROLE_ID', 1086016803047747675),
         'exam_controller_role_id' => env('DISCORD_EXAM_CONTROLLER_ROLE_ID', 1086016870282432663),
         'exam_success_channel_id' => env('DISCORD_EXAM_SUCCESS_CHANNEL_ID', 1135654373981180034),
+        'mentoring_announce_channel_id' => env('DISCORD_MENTORING_ANNOUNCE_CHANNEL_ID', 1086017310101344406),
+        'mentoring_pilot_role_id' => env('DISCORD_MENTORING_PILOT_ROLE_ID', 1086016916394606622),
+        'mentoring_controller_role_id' => env('DISCORD_MENTORING_CONTROLLER_ROLE_ID', 1086016985537716256),
         'vatuk_emoji_name_and_id' => env('DISCORD_VATUK_EMOJI_NAME_AND_ID', 'vuktrail:740917513436790834'),
     ],
 

--- a/tests/Unit/Training/Mentoring/MentoringAnnouncementServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringAnnouncementServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Unit\Services\Training\Mentoring;
+
+use App\Libraries\Discord;
+use App\Models\Cts\Session;
+use App\Services\Training\MentoringAnnouncementService;
+use App\Services\Training\MentorPermissionService;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MentoringAnnouncementServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function makeService(?MentorPermissionService $permissionService = null): MentoringAnnouncementService
+    {
+        return new MentoringAnnouncementService(new Discord, $permissionService ?? $this->createMock(MentorPermissionService::class));
+    }
+
+    private function makeSession(array $attributes = []): Session
+    {
+        return Session::factory()->make(array_merge([
+            'mentor_id' => 100,
+            'position' => 'EGLL_TWR',
+            'taken_date' => now()->addDay()->format('Y-m-d'),
+            'taken_from' => '12:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ], $attributes));
+    }
+
+    private function makeAtcPermissionService(string $category = 'S2 Training'): MentorPermissionService
+    {
+        $mock = $this->createMock(MentorPermissionService::class);
+        $mock->method('resolveCategoryForCtsCallsign')->willReturn($category);
+
+        return $mock;
+    }
+
+    #[Test]
+    public function it_disallows_posting_announcements_for_filed_sessions(): void
+    {
+        $session = $this->makeSession(['filed' => now()]);
+        $this->assertFalse($this->makeService()->canPostAnnouncement($session, 100));
+    }
+
+    #[Test]
+    public function it_disallows_posting_announcements_for_cancelled_sessions(): void
+    {
+        $session = $this->makeSession(['cancelled_datetime' => now()]);
+        $this->assertFalse($this->makeService()->canPostAnnouncement($session, 100));
+    }
+
+    #[Test]
+    public function it_disallows_posting_announcements_for_past_sessions(): void
+    {
+        $session = $this->makeSession([
+            'taken_date' => now()->subDay()->format('Y-m-d'),
+            'taken_from' => '12:00:00',
+        ]);
+
+        $this->assertFalse($this->makeService()->canPostAnnouncement($session, 100));
+    }
+
+    #[Test]
+    public function it_disallows_posting_announcements_for_non_mentors(): void
+    {
+        $session = $this->makeSession(['mentor_id' => 100]);
+        $this->assertFalse($this->makeService()->canPostAnnouncement($session, 999));
+    }
+
+    #[Test]
+    public function it_allows_posting_announcements_for_the_assigned_mentor(): void
+    {
+        $session = $this->makeSession(['mentor_id' => 100]);
+        $this->assertTrue($this->makeService()->canPostAnnouncement($session, 100));
+    }
+
+    #[Test]
+    public function it_builds_atc_message_with_no_mentions_and_no_notes(): void
+    {
+        config()->set('training.discord.mentoring_pilot_role_id', '111');
+        config()->set('training.discord.mentoring_controller_role_id', '222');
+
+        $service = $this->makeService($this->makeAtcPermissionService());
+        $session = $this->makeSession(['position' => 'EGPH_TWR', 'taken_date' => '2026-01-11', 'taken_from' => '12:00:00']);
+
+        $message = $service->buildMessage($session, ['ping_pilot' => false, 'ping_controller' => false, 'notes' => '']);
+
+        $this->assertStringContainsString('ATC Mentoring Session', $message);
+        $this->assertStringContainsString('EGPH_TWR', $message);
+        $this->assertStringNotContainsString('<@&111>', $message);
+        $this->assertStringNotContainsString('<@&222>', $message);
+        $this->assertStringNotContainsString('**Notes:**', $message);
+    }
+
+    #[Test]
+    public function it_builds_atc_message_with_mentions_and_notes(): void
+    {
+        config()->set('training.discord.mentoring_pilot_role_id', '111');
+        config()->set('training.discord.mentoring_controller_role_id', '222');
+
+        $service = $this->makeService($this->makeAtcPermissionService());
+        $session = $this->makeSession(['position' => 'EGPH_TWR', 'taken_date' => '2026-01-11', 'taken_from' => '12:00:00']);
+
+        $message = $service->buildMessage($session, ['ping_pilot' => true, 'ping_controller' => true, 'notes' => '  Some notes here  ']);
+
+        $this->assertStringContainsString('<@&111>', $message);
+        $this->assertStringContainsString('<@&222>', $message);
+        $this->assertStringContainsString("**Notes:**\nSome notes here", $message);
+    }
+
+    #[Test]
+    public function it_builds_pilot_message_for_pilot_category_sessions(): void
+    {
+        $mock = $this->createMock(MentorPermissionService::class);
+        $mock->method('resolveCategoryForCtsCallsign')->willReturn('P1 Training');
+
+        $session = $this->makeSession(['position' => 'P1_PPL(A)', 'taken_date' => '2026-01-11', 'taken_from' => '12:00:00']);
+
+        $message = $this->makeService($mock)->buildMessage($session, ['ping_pilot' => false, 'ping_controller' => false, 'notes' => '']);
+
+        $this->assertStringContainsString('Pilot Mentoring Session', $message);
+        $this->assertStringNotContainsString('ATC Mentoring Session', $message);
+    }
+
+    #[Test]
+    public function it_includes_discord_timestamps_in_the_message(): void
+    {
+        $service = $this->makeService($this->makeAtcPermissionService());
+        $session = $this->makeSession(['taken_date' => '2026-01-11', 'taken_from' => '12:00:00']);
+
+        $unix = CarbonImmutable::parse('2026-01-11 12:00:00')->utc()->getTimestamp();
+
+        $message = $service->buildMessage($session, ['ping_pilot' => false, 'ping_controller' => false, 'notes' => '']);
+
+        $this->assertStringContainsString("<t:{$unix}:F>", $message);
+        $this->assertStringContainsString("<t:{$unix}:R>", $message);
+    }
+
+    #[Test]
+    public function it_only_pings_pilot_role_when_only_pilot_selected(): void
+    {
+        config()->set('training.discord.mentoring_pilot_role_id', '111');
+        config()->set('training.discord.mentoring_controller_role_id', '222');
+
+        $message = $this->makeService($this->makeAtcPermissionService())->buildMessage(
+            $this->makeSession(),
+            ['ping_pilot' => true, 'ping_controller' => false, 'notes' => ''],
+        );
+
+        $this->assertStringContainsString('<@&111>', $message);
+        $this->assertStringNotContainsString('<@&222>', $message);
+    }
+
+    #[Test]
+    public function it_only_pings_controller_role_when_only_controller_selected(): void
+    {
+        config()->set('training.discord.mentoring_pilot_role_id', '111');
+        config()->set('training.discord.mentoring_controller_role_id', '222');
+
+        $message = $this->makeService($this->makeAtcPermissionService())->buildMessage(
+            $this->makeSession(),
+            ['ping_pilot' => false, 'ping_controller' => true, 'notes' => ''],
+        );
+
+        $this->assertStringNotContainsString('<@&111>', $message);
+        $this->assertStringContainsString('<@&222>', $message);
+    }
+}


### PR DESCRIPTION
# Summary of changes
- allow mentor to post announcement to #request-mentoring-atc-traffic

# Screenshots (if necessary)
<img width="352" height="81" alt="image" src="https://github.com/user-attachments/assets/012b9d83-166b-4b8b-a31b-f01fde99e2f5" />
<img width="348" height="161" alt="image" src="https://github.com/user-attachments/assets/961575a8-8347-4ad9-90b9-55d005c04f9f" />
