### PR TITLE
fix: use new View Mentoring Report page instead of CTS on view training place tables

### DIFF
--- a/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
+++ b/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Training\Pages\TrainingPlace;
 
+use App\Filament\Training\Pages\Mentor\ViewMentoringReport;
 use App\Filament\Training\Pages\TrainingPlace\Widgets\TrainingPlaceStatsWidget;
 use App\Filament\Training\Resources\TrainingPlaces\Pages\ListTrainingPlaces;
 use App\Models\Atc\Position;
@@ -14,7 +15,6 @@ use App\Repositories\Cts\SessionRepository;
 use App\Services\Training\ExamForwardingService;
 use Exception;
 use Filament\Actions\Action;
-use Filament\Actions\ViewAction;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -310,7 +310,11 @@ class ViewTrainingPlace extends Page implements HasInfolists, HasTable
                     }),
             ])
             ->recordActions([
-                ViewAction::make()->url(fn ($record) => "https://cts.vatsim.uk/mentors/report.php?id={$record->id}&view=report"),
+                Action::make('view')
+                    ->label('View Report')
+                    ->url(fn ($record) => ViewMentoringReport::getUrl(['sessionId' => $record->id]))
+                    ->visible(fn ($record) => $record->filed !== null)
+                    ->openUrlInNewTab(),
             ])
             ->emptyStateHeading('No mentoring sessions found');
     }

--- a/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\TrainingPanel\TrainingPlace;
 
+use App\Filament\Training\Pages\Mentor\ViewMentoringReport;
 use App\Filament\Training\Pages\TrainingPlace\ViewTrainingPlace;
 use App\Models\Atc\Position;
 use App\Models\Cts\ExamBooking;
@@ -255,9 +256,10 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
             'taken' => 1,
             'taken_date' => now()->subDays(5),
             'student_id' => $trainingPlace->account->member->id,
+            'filed' => now(),
         ]);
 
-        $expectedUrl = "https://cts.vatsim.uk/mentors/report.php?id={$session->getKey()}&view=report";
+        $expectedUrl = ViewMentoringReport::getUrl(['sessionId' => $session->getKey()]);
 
         Livewire::test(ViewTrainingPlace::class, ['trainingPlaceId' => $trainingPlace->id])
             ->assertStatus(200)


### PR DESCRIPTION
# Summary of changes
- use new View Mentoring Report page instead of CTS on view training place tables

# Screenshots (if necessary)
<img width="1121" height="748" alt="image" src="https://github.com/user-attachments/assets/e53f4e61-45a4-44b8-ae79-15e66edfbfbd" />
