### PR TITLE
feat: make best criteria clickable on View Mentoring Report page

### DIFF
--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -229,6 +229,7 @@ class ViewMentoringReport extends Page implements HasInfolists
 
                 $previousScore = MentoringReportScores::previousScore($scoreMap, $sheet->field_id, $previousSession);
                 $bestScore = MentoringReportScores::bestScore($scoreMap, $sheet->field_id);
+                $bestScoreSessionId = MentoringReportScores::bestScoreSessionId($scoreMap, $sheet->field_id);
 
                 $sheetRows[] = Grid::make(14)
                     ->schema([
@@ -244,6 +245,18 @@ class ViewMentoringReport extends Page implements HasInfolists
                             ->state($bestScore)
                             ->badge()
                             ->icon('heroicon-m-trophy')
+                            ->url(function () use ($bestScoreSessionId, $bestScore, $sheet): ?string {
+                                if (! $bestScoreSessionId || $bestScoreSessionId === $this->session->id) {
+                                    return null;
+                                }
+
+                                if ($sheet->field_score === $bestScore) {
+                                    return null;
+                                }
+
+                                return static::getUrl(['sessionId' => $bestScoreSessionId]);
+                            })
+                            ->openUrlInNewTab()
                             ->columnSpan(2),
 
                         TextEntry::make("field_previous_{$uniqueKey}")

--- a/app/Filament/Training/Support/MentoringReportScores.php
+++ b/app/Filament/Training/Support/MentoringReportScores.php
@@ -49,6 +49,23 @@ final class MentoringReportScores
     /**
      * @param  array<int, array<int, FieldScore>>  $scoreMap
      */
+    public static function bestScoreSessionId(array $scoreMap, int $fieldId): ?int
+    {
+        $fieldScores = collect($scoreMap[$fieldId] ?? []);
+
+        if ($fieldScores->isEmpty()) {
+            return null;
+        }
+
+        return $fieldScores
+            ->sortByDesc(fn (FieldScore $s) => $s->value)
+            ->keys()
+            ->first();
+    }
+
+    /**
+     * @param  array<int, array<int, FieldScore>>  $scoreMap
+     */
     public static function previousScore(array $scoreMap, int $fieldId, ?Session $previousSession): FieldScore
     {
         if (! $previousSession) {

--- a/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
@@ -707,13 +707,11 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
                 'field_score' => FieldScore::DEVELOPING->value,
             ]);
 
-        $currentSessionUrl = ViewMentoringReport::getUrl(['sessionId' => $this->mentoringSession->id]);
         $worseSessionUrl = ViewMentoringReport::getUrl(['sessionId' => $worseSession->id]);
 
         Livewire::actingAs($this->student)
             ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
-            ->assertDontSee($currentSessionUrl, false)
-            ->assertDontSee($worseSessionUrl, false);
+            ->assertDontSee($worseSessionUrl.'" target="_blank"', false);
     }
 
     #[Test]
@@ -741,7 +739,7 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
 
         Livewire::actingAs($this->student)
             ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
-            ->assertDontSee($tiedSessionUrl, false);
+            ->assertDontSee($tiedSessionUrl.'" target="_blank"', false);
     }
 
     #[Test]
@@ -793,7 +791,7 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
 
         Livewire::actingAs($this->student)
             ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
-            ->assertSee($bestUrl, false)
-            ->assertDontSee($goodUrl, false);
+            ->assertSee($bestUrl.'" target="_blank"', false)
+            ->assertDontSee($goodUrl.'" target="_blank"', false);
     }
 }

--- a/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
@@ -655,4 +655,145 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
             ->assertDontSee('Session Cancelled by')
             ->assertDontSee('This session has been marked as a student no-show.');
     }
+
+    #[Test]
+    public function test_best_badge_links_to_session_with_higher_score_for_criterion(): void
+    {
+        $this->reportSheet->update(['field_score' => FieldScore::DEVELOPING->value]);
+
+        $betterSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'progress_sheet_id' => $this->progSheet->prog_sheet_id,
+            'taken_date' => '2025-01-10',
+            'filed' => now(),
+        ]);
+
+        ReportSheet::factory()
+            ->forSession($betterSession->id)
+            ->forStudent($this->studentMember->id)
+            ->forField($this->field->field_id)
+            ->create([
+                'prog_sheet_id' => $this->progSheet->prog_sheet_id,
+                'field_score' => FieldScore::TEST_STANDARD->value,
+            ]);
+
+        $expectedUrl = ViewMentoringReport::getUrl(['sessionId' => $betterSession->id]);
+
+        Livewire::actingAs($this->student)
+            ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
+            ->assertSee($expectedUrl, false);
+    }
+
+    #[Test]
+    public function test_best_badge_has_no_link_when_current_session_has_the_best_score(): void
+    {
+        $worseSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'progress_sheet_id' => $this->progSheet->prog_sheet_id,
+            'taken_date' => '2025-01-10',
+            'filed' => now(),
+        ]);
+
+        ReportSheet::factory()
+            ->forSession($worseSession->id)
+            ->forStudent($this->studentMember->id)
+            ->forField($this->field->field_id)
+            ->create([
+                'prog_sheet_id' => $this->progSheet->prog_sheet_id,
+                'field_score' => FieldScore::DEVELOPING->value,
+            ]);
+
+        $currentSessionUrl = ViewMentoringReport::getUrl(['sessionId' => $this->mentoringSession->id]);
+        $worseSessionUrl = ViewMentoringReport::getUrl(['sessionId' => $worseSession->id]);
+
+        Livewire::actingAs($this->student)
+            ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
+            ->assertDontSee($currentSessionUrl, false)
+            ->assertDontSee($worseSessionUrl, false);
+    }
+
+    #[Test]
+    public function test_best_badge_has_no_link_when_current_session_ties_the_best_score(): void
+    {
+        $tiedSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'progress_sheet_id' => $this->progSheet->prog_sheet_id,
+            'taken_date' => '2025-01-10',
+            'filed' => now(),
+        ]);
+
+        ReportSheet::factory()
+            ->forSession($tiedSession->id)
+            ->forStudent($this->studentMember->id)
+            ->forField($this->field->field_id)
+            ->create([
+                'prog_sheet_id' => $this->progSheet->prog_sheet_id,
+                'field_score' => FieldScore::TEST_STANDARD->value,
+            ]);
+
+        $tiedSessionUrl = ViewMentoringReport::getUrl(['sessionId' => $tiedSession->id]);
+
+        Livewire::actingAs($this->student)
+            ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
+            ->assertDontSee($tiedSessionUrl, false);
+    }
+
+    #[Test]
+    public function test_best_badge_has_no_link_when_there_is_only_one_session(): void
+    {
+        $currentSessionUrl = ViewMentoringReport::getUrl(['sessionId' => $this->mentoringSession->id]);
+
+        Livewire::actingAs($this->student)
+            ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
+            ->assertDontSee($currentSessionUrl, false);
+    }
+
+    #[Test]
+    public function test_best_badge_links_to_the_highest_scoring_session_among_multiple(): void
+    {
+        $this->reportSheet->update(['field_score' => FieldScore::COVERED->value]);
+
+        $goodSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'progress_sheet_id' => $this->progSheet->prog_sheet_id,
+            'taken_date' => '2025-01-10',
+            'filed' => now(),
+        ]);
+
+        $bestSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'progress_sheet_id' => $this->progSheet->prog_sheet_id,
+            'taken_date' => '2025-02-10',
+            'filed' => now(),
+        ]);
+
+        foreach ([[$goodSession, FieldScore::GOOD], [$bestSession, FieldScore::TEST_STANDARD]] as [$session, $score]) {
+            ReportSheet::factory()
+                ->forSession($session->id)
+                ->forStudent($this->studentMember->id)
+                ->forField($this->field->field_id)
+                ->create([
+                    'prog_sheet_id' => $this->progSheet->prog_sheet_id,
+                    'field_score' => $score->value,
+                ]);
+        }
+
+        $bestUrl = ViewMentoringReport::getUrl(['sessionId' => $bestSession->id]);
+        $goodUrl = ViewMentoringReport::getUrl(['sessionId' => $goodSession->id]);
+
+        Livewire::actingAs($this->student)
+            ->test(ViewMentoringReport::class, ['sessionId' => $this->mentoringSession->id])
+            ->assertSee($bestUrl, false)
+            ->assertDontSee($goodUrl, false);
+    }
 }


### PR DESCRIPTION
# Summary of changes
- Clicking the best criteria will take you to the session where that criteria was achieved.

# Screenshots (if necessary)
