### PR TITLE
fix: allow users with admin permission to sort availability page

### DIFF
--- a/app/Livewire/Training/AvailabilityGantt.php
+++ b/app/Livewire/Training/AvailabilityGantt.php
@@ -39,7 +39,7 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
 
     public ?string $positionFilter = null;
 
-    private const STUDENTS_PER_PAGE = 6;
+    public int $studentsPerPage = 6;
 
     public int $studentsPage = 1;
 
@@ -83,7 +83,7 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
 
     public function getPagedStudentsProperty()
     {
-        return $this->students->forPage($this->studentsPage, self::STUDENTS_PER_PAGE);
+        return $this->students->forPage($this->studentsPage, $this->studentsPerPage);
     }
 
     public function previousStudentsPage(): void
@@ -95,7 +95,7 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
 
     public function nextStudentsPage(): void
     {
-        if ($this->studentsPage * self::STUDENTS_PER_PAGE < $this->students->count()) {
+        if ($this->studentsPage * $this->studentsPerPage < $this->students->count()) {
             $this->studentsPage++;
         }
     }

--- a/app/Livewire/Training/AvailabilityGantt.php
+++ b/app/Livewire/Training/AvailabilityGantt.php
@@ -49,13 +49,9 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
         $this->date = max(request()->query('date', Carbon::today()->format('Y-m-d')), Carbon::today()->format('Y-m-d'));
         $this->category = request()->query('category', null);
 
-        $this->rememberCategory();
-
         if ($this->category && ! (auth()->user()?->can('viewCategory', [new MentoringScope, $this->category]) ?? false)) {
             $this->category = null;
         }
-
-        $this->saveCategoryToSession();
     }
 
     public function previousDay()

--- a/app/Livewire/Training/AvailabilityGantt.php
+++ b/app/Livewire/Training/AvailabilityGantt.php
@@ -8,6 +8,7 @@ use App\Models\Cts\Member;
 use App\Models\Cts\Session;
 use App\Models\Training\Mentoring\MentoringScope;
 use App\Services\Training\MentoringSessionsService;
+use App\Services\Training\MentorPermissionService;
 use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
@@ -121,6 +122,16 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
     {
         $user = auth()->user();
 
+        if ($user?->can('viewAll', Session::class) ?? false) {
+            $service = app(MentorPermissionService::class);
+
+            if ($this->category) {
+                return $service->getAllCtsCallsignsForCategory($this->category);
+            }
+
+            return $service->getAllCtsCallsignsForCategories($user->getAvailableMentoringCategories());
+        }
+
         return $this->category ? $user->getAssignedCallsignsForCategory($this->category) : $user->getAllAssignedCallsigns();
     }
 
@@ -129,22 +140,12 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
         $targetDate = Carbon::parse($this->date);
         $allowedCallsigns = $this->getAllowedCallsigns();
 
-        $hasViewAllPermission = auth()->user()?->can('viewAll', Session::class) ?? false;
-
-        if (empty($allowedCallsigns) && ! $hasViewAllPermission) {
-            return collect();
-        }
-
         return Member::query()
-            ->whereHas('sessions', function ($query) use ($allowedCallsigns, $hasViewAllPermission) {
+            ->whereHas('sessions', function ($query) use ($allowedCallsigns) {
                 $query->whereNull('mentor_id')
                     ->whereNull('filed')
-                    ->whereNull('cancelled_datetime');
-
-                // If doesn't have view all permission, filter strictly by their allowed mentoring callsigns
-                if (! $hasViewAllPermission) {
-                    $query->whereIn('position', $allowedCallsigns);
-                }
+                    ->whereNull('cancelled_datetime')
+                    ->whereIn('position', $allowedCallsigns);
             })
             ->whereHas('availabilities', function ($query) use ($targetDate) {
                 $query->whereDate('date', $targetDate);

--- a/app/Services/Training/MentorPermissionService.php
+++ b/app/Services/Training/MentorPermissionService.php
@@ -50,7 +50,7 @@ class MentorPermissionService
 
     public const QUALIFICATION_CTS_POSITION_MAP = [
         'PPL' => 'P1_PPL(A)',
-        'IR' => 'P2_SEIRA)',
+        'IR' => 'P2_SEIR(A)',
         'CMEL' => 'P3_CMEL(A)',
     ];
 

--- a/resources/views/livewire/training/availability-gantt.blade.php
+++ b/resources/views/livewire/training/availability-gantt.blade.php
@@ -40,11 +40,23 @@
 
 		{{-- Page Arrows --}}
 		@if ($students->count() > $this->studentsPerPage)
-			<div class="flex items-center justify-end gap-2 pt-2 border-gray-200 dark:border-white/10">
-				<x-filament::button color="gray" wire:click="previousStudentsPage" icon="heroicon-m-chevron-left" class="!px-2"
-					:disabled="$studentsPage <= 1" />
-				<x-filament::button color="gray" wire:click="nextStudentsPage" icon="heroicon-m-chevron-right" class="!px-2"
-					:disabled="$studentsPage * $this->studentsPerPage >= $students->count()" />
+			@php
+				$totalStudents = $students->count();
+				$totalPages = (int) ceil($totalStudents / $this->studentsPerPage);
+			@endphp
+			<div class="flex items-center justify-between gap-3 pt-2 border-gray-200 dark:border-white/10">
+				<div class="text-sm text-gray-500 dark:text-gray-400">
+					{{ $totalStudents }} student{{ $totalStudents === 1 ? '' : 's' }} with availability
+				</div>
+				<div class="flex items-center gap-3">
+					<x-filament::button color="gray" wire:click="previousStudentsPage" icon="heroicon-m-chevron-left" class="!px-2"
+						:disabled="$studentsPage <= 1" />
+					<div class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+						Page {{ $studentsPage }} / {{ $totalPages }}
+					</div>
+					<x-filament::button color="gray" wire:click="nextStudentsPage" icon="heroicon-m-chevron-right" class="!px-2"
+						:disabled="$studentsPage * $this->studentsPerPage >= $students->count()" />
+				</div>
 			</div>
 		@endif
 	@endif


### PR DESCRIPTION
# Summary of changes
- Allows users with admin permission to sort availability page
- Adds page numbers at the bottom
- Remove type on P2 callsign

# Screenshots (if necessary)
<img width="785" height="92" alt="image" src="https://github.com/user-attachments/assets/4e6892ff-08e3-487c-a0f2-38831323b89e" />
