### PR TITLE
fix: stop casting discord id's to ints

### DIFF
--- a/app/Libraries/Discord.php
+++ b/app/Libraries/Discord.php
@@ -405,7 +405,7 @@ class Discord
         ];
     }
 
-    private function findRole(string $roleName): int
+    private function findRole(string $roleName)
     {
         $endpoint = "{$this->base_url}/guilds/{$this->guild_id}/roles";
         $context = [

--- a/app/Libraries/Discord.php
+++ b/app/Libraries/Discord.php
@@ -423,7 +423,7 @@ class Discord
             ->pluck('id')
             ->first();
 
-        return (int) $role_id;
+        return $role_id;
     }
 
     /**

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -85,7 +85,7 @@ trait HasDiscordAccount
                 }
 
                 // Set their roles to only the suspended role (replaces all current roles
-                $discord->setRoles($this, [(int) $suspendedRoleId]);
+                $discord->setRoles($this, [$suspendedRoleId]);
 
                 return;
             }
@@ -117,7 +117,7 @@ trait HasDiscordAccount
      */
     private function computeTargetRoles(Collection $currentRoles, $suspendedRoleId): Collection
     {
-        $targetRoles = $currentRoles->reject(fn ($role) => (int) $role === (int) $suspendedRoleId);
+        $targetRoles = $currentRoles->reject(fn ($role) => $role === $suspendedRoleId);
 
         $discordRoleRules = DiscordRoleRule::all()->map(function (DiscordRoleRule $roleRule) {
             return ['discord_id' => $roleRule->discord_id, 'satisfied' => $roleRule->accountSatisfies($this)];
@@ -131,13 +131,13 @@ trait HasDiscordAccount
             ->keys();
 
         // Remove managed roles that aren't satisfied
-        $targetRoles = $targetRoles->reject(fn ($role) => $managedRoleIds->contains((int) $role));
+        $targetRoles = $targetRoles->reject(fn ($role) => $managedRoleIds->contains($role));
 
         // Add satisfied managed roles, ensuring the suspended role can't be re-introduced
         return $targetRoles
             ->merge($satisfiedRoleIds)
             ->unique()
-            ->reject(fn ($role) => (int) $role === (int) $suspendedRoleId)
+            ->reject(fn ($role) => $role === $suspendedRoleId)
             ->values();
     }
 


### PR DESCRIPTION
# Summary of changes
- stop casting discord id's to ints

# Screenshots (if necessary)
