### PR TITLE
feat: add improved override exam result action

### DIFF
--- a/app/Filament/Training/Pages/Exam/ViewExamReport.php
+++ b/app/Filament/Training/Pages/Exam/ViewExamReport.php
@@ -3,11 +3,13 @@
 namespace App\Filament\Training\Pages\Exam;
 
 use App\Enums\ExamResultEnum;
+use App\Filament\Forms\Components\TrainingRichEditor;
+use App\Filament\Training\Concerns\InteractsWithCtsRichEditorNotes;
 use App\Infolists\Components\PracticalExamCriteriaResult;
 use App\Models\Cts\ExamCriteria;
 use App\Models\Cts\ExamCriteriaAssessment;
 use App\Models\Cts\PracticalResult;
-use App\Services\Training\ExamResubmissionService;
+use App\Services\Training\OverrideExamReportService;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -25,6 +27,7 @@ use Filament\Support\Enums\Width;
 
 class ViewExamReport extends Page implements HasInfolists
 {
+    use InteractsWithCtsRichEditorNotes;
     use InteractsWithInfolists;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
@@ -94,75 +97,112 @@ class ViewExamReport extends Page implements HasInfolists
                     Action::make('override_result')
                         ->icon('heroicon-m-pencil-square')
                         ->color('warning')
+                        ->modalHeading('Override Exam Result')
+                        ->modalDescription('Update the outcome, criteria grades, and comments..')
                         ->modalWidth(Width::SevenExtraLarge)
-                        ->modalSubmitActionLabel('Override')
+                        ->modalSubmitActionLabel('Override Exam Result')
                         ->visible(fn () => auth()->user()->can('training.exams.override-result'))
                         ->schema([
-                            Section::make('Exam Result')->columns(2)->columnSpanFull()->schema([
+                            Section::make('Outcome')->columns(12)->columnSpanFull()->schema([
                                 Select::make('previous_exam_result')
                                     ->label('Previous Result')
                                     ->default($this->practicalResult->result)
-                                    ->options(fn () => $this->practicalResult->examBooking->isPilotExam()
-                                        ? ExamResultEnum::pilotOptions()
-                                        : ExamResultEnum::atcOptions()
-                                    )
+                                    ->options(fn () => $this->practicalResult->examBooking->isPilotExam() ? ExamResultEnum::pilotOptions() : ExamResultEnum::atcOptions())
                                     ->required()
                                     ->disabled()
-                                    ->columns(1)
+                                    ->columnSpan(6)
                                     ->dehydrated(true),
 
                                 Select::make('exam_result')
                                     ->label('New Result')
                                     ->default($this->practicalResult->result)
                                     ->live()
-                                    ->columns(1)
-                                    ->options(fn () => $this->practicalResult->examBooking->isPilotExam()
-                                        ? ExamResultEnum::pilotOptions()
-                                        : ExamResultEnum::atcOptions()
-                                    )
-                                    ->required(),
-                                Textarea::make('reason')
-                                    ->label('Reason for exam result change')
-                                    ->placeholder('Explain why this exam result was adjusted')
+                                    ->options(fn () => $this->practicalResult->examBooking->isPilotExam() ? ExamResultEnum::pilotOptions() : ExamResultEnum::atcOptions())
                                     ->required()
+                                    ->columnSpan(6),
+
+                                TrainingRichEditor::make('additional_comments')
+                                    ->label('Additional Comments')
+                                    ->live(onBlur: true)
+                                    ->afterStateHydrated(fn ($component) => $component->state(
+                                        $this->ctsRichEditorHtmlForHydration($this->practicalResult->notes)
+                                    ))
+                                    ->extraInputAttributes([
+                                        'style' => 'min-height: 180px;',
+                                    ])
+                                    ->columnSpanFull(),
+
+                                Textarea::make('reason')
+                                    ->label('Reason for override')
+                                    ->placeholder('Explain why the exam result, criteria, or comments were adjusted')
+                                    ->required()
+                                    ->rows(3)
                                     ->columnSpanFull(),
                             ]),
 
-                            Section::make('Exam Criteria')
+                            Section::make('Criteria Updates')
                                 ->columnSpanFull()
-                                ->visible(fn ($get) => ! $this->practicalResult->examBooking->isPilotExam()
+                                ->description('Change each criterias grade and comments individually.')
+                                ->visible(fn (Get $get) => ! $this->practicalResult->examBooking->isPilotExam()
                                     && $get('exam_result') !== $this->practicalResult->result
                                 )
                                 ->schema(function () {
                                     $criteria = ExamCriteria::byType($this->practicalResult->examBooking->exam)->get();
-                                    $existingAssessments = $this->practicalResult->criteria->pluck('result', 'criteria_id');
+                                    $existingAssessments = $this->practicalResult->criteria->keyBy('criteria_id');
 
                                     return $criteria->map(function (ExamCriteria $criteria) use ($existingAssessments) {
+                                        $assessment = $existingAssessments->get($criteria->id);
+                                        $existingGrade = $assessment?->result ?? ExamCriteriaAssessment::NOT_ASSESSED;
+                                        $existingNotesForCompare = $this->ctsRichContentNotesForCts($assessment?->notes) ?? '';
+
                                         return Fieldset::make("criteria_updates.{$criteria->id}")
                                             ->label($criteria->criteria)
                                             ->columnSpanFull()
+                                            ->columns(12)
                                             ->schema([
                                                 Select::make("criteria_updates.previous_{$criteria->id}.grade")
                                                     ->label('Previous Grade')
                                                     ->options(ExamCriteriaAssessment::gradeDropdownOptions())
-                                                    ->default($existingAssessments->get($criteria->id))
+                                                    ->default($existingGrade)
                                                     ->disabled()
-                                                    ->dehydrated(false),
+                                                    ->dehydrated(false)
+                                                    ->columnSpan(4),
 
                                                 Select::make("criteria_updates.{$criteria->id}.grade")
                                                     ->label('New Grade')
                                                     ->options(ExamCriteriaAssessment::gradeDropdownOptions())
-                                                    ->default($existingAssessments->get($criteria->id))
+                                                    ->default($existingGrade)
                                                     ->live()
-                                                    ->required(),
+                                                    ->required()
+                                                    ->columnSpan(4),
+
+                                                TrainingRichEditor::make("criteria_updates.{$criteria->id}.notes")
+                                                    ->label('Report comments for this criteria')
+                                                    ->live(onBlur: true)
+                                                    ->afterStateHydrated(fn ($component) => $component->state(
+                                                        $this->ctsRichEditorHtmlForHydration($assessment?->notes)
+                                                    ))
+                                                    ->extraInputAttributes([
+                                                        'style' => 'min-height: 140px;',
+                                                    ])
+                                                    ->columnSpanFull(),
 
                                                 Textarea::make("criteria_updates.{$criteria->id}.change_comments")
                                                     ->label('Reason for criteria change')
                                                     ->placeholder('Explain why this specific criteria grade was adjusted')
-                                                    ->required(fn (Get $get) => $get("criteria_updates.{$criteria->id}.grade") !== ($existingAssessments->get($criteria->id))
-                                                    )
-                                                    ->visible(fn (Get $get) => $get("criteria_updates.{$criteria->id}.grade") !== ($existingAssessments->get($criteria->id))
-                                                    )
+                                                    ->required(function (Get $get) use ($existingGrade, $existingNotesForCompare, $criteria): bool {
+                                                        $gradeChanged = $get("criteria_updates.{$criteria->id}.grade") !== $existingGrade;
+                                                        $notesNow = $this->ctsRichContentNotesForCts($get("criteria_updates.{$criteria->id}.notes") ?? null) ?? '';
+
+                                                        return $gradeChanged || $notesNow !== $existingNotesForCompare;
+                                                    })
+                                                    ->visible(function (Get $get) use ($existingGrade, $existingNotesForCompare, $criteria): bool {
+                                                        $gradeChanged = $get("criteria_updates.{$criteria->id}.grade") !== $existingGrade;
+                                                        $notesNow = $this->ctsRichContentNotesForCts($get("criteria_updates.{$criteria->id}.notes") ?? null) ?? '';
+
+                                                        return $gradeChanged || $notesNow !== $existingNotesForCompare;
+                                                    })
+                                                    ->rows(3)
                                                     ->columnSpanFull(),
                                             ]);
                                     })->toArray();
@@ -197,51 +237,23 @@ class ViewExamReport extends Page implements HasInfolists
         ]);
     }
 
-    public function overrideResult($data)
+    public function overrideResult(array $data): void
     {
-        $newResult = ExamResultEnum::from($data['exam_result']);
-        $criteriaUpdates = $data['criteria_updates'] ?? [];
+        $hasChanges = app(OverrideExamReportService::class)->handle($this->practicalResult, $data, auth()->user());
 
-        $this->practicalResult->update(['result' => $newResult->value]);
+        if (! $hasChanges) {
+            Notification::make()
+                ->title('No changes to save')
+                ->body('Update the result, comments, or criteria before saving the override.')
+                ->warning()
+                ->send();
 
-        $account = $this->practicalResult->examBooking->student->account;
-
-        $account->addNote(noteType: 'training',
-            noteContent: "Exam result for {$this->practicalResult->examBooking->exam} overridden to {$newResult->human()}. Reason: {$data['reason']}",
-            writer: auth()->user(),
-        );
-
-        foreach ($criteriaUpdates as $criteriaId => $update) {
-            $assessment = ExamCriteriaAssessment::where('examid', $this->practicalResult->examid)
-                ->where('criteria_id', $criteriaId)
-                ->first();
-
-            $oldGrade = $assessment->result;
-            $newGrade = $update['grade'] ?? $oldGrade;
-
-            if ($oldGrade !== $newGrade) {
-                $assessment->result = $newGrade;
-                $assessment->save();
-
-                $criteriaName = ExamCriteria::find($criteriaId)?->criteria ?? "Criteria #{$criteriaId}";
-
-                $account->addNote(
-                    noteType: 'training',
-                    noteContent: "'{$criteriaName}' updated from {$oldGrade} to {$newGrade}. Reason: ".($update['change_comments'] ?? 'No comment.'),
-                    writer: auth()->user(),
-                );
-            }
+            return;
         }
 
-        app(ExamResubmissionService::class)->handle(
-            examBooking: $this->practicalResult->examBooking,
-            result: $newResult->value,
-            userId: auth()->id(),
-        );
-
         Notification::make()
-            ->title('Exam result amended')
-            ->body("Exam result updated to {$newResult->human()}")
+            ->title('Exam override saved')
+            ->body('The exam report and candidate notes have been updated.')
             ->success()
             ->send();
     }

--- a/app/Services/Training/OverrideExamReportService.php
+++ b/app/Services/Training/OverrideExamReportService.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Services\Training;
+
+use App\Enums\ExamResultEnum;
+use App\Filament\Training\Concerns\InteractsWithCtsRichEditorNotes;
+use App\Models\Cts\ExamCriteria;
+use App\Models\Cts\ExamCriteriaAssessment;
+use App\Models\Cts\PracticalResult;
+use App\Models\Mship\Account;
+use App\Repositories\Cts\ExamAssessmentRepository;
+
+class OverrideExamReportService
+{
+    use InteractsWithCtsRichEditorNotes;
+
+    public function __construct(
+        private readonly ExamAssessmentRepository $examAssessmentRepository,
+        private readonly ExamResubmissionService $examResubmissionService,
+    ) {}
+
+    public function handle(PracticalResult $practicalResult, array $data, Account $actor): bool
+    {
+        $newResult = ExamResultEnum::from($data['exam_result']);
+        $reason = trim((string) ($data['reason'] ?? ''));
+        $account = $practicalResult->examBooking->student->account;
+
+        $updates = [];
+        $resultChanged = $this->applyResultOverride($practicalResult, $newResult, $reason, $account, $actor, $updates);
+        $additionalCommentsChanged = $this->applyAdditionalCommentsOverride($practicalResult, $data['additional_comments'] ?? null, $reason, $account, $actor, $updates);
+        $criteriaChanged = $this->applyCriteriaOverrides($practicalResult, $data['criteria_updates'] ?? [], $reason, $account, $actor);
+
+        if ($updates !== []) {
+            $practicalResult->update($updates);
+        }
+
+        if ($resultChanged) {
+            $this->examResubmissionService->handle(
+                examBooking: $practicalResult->examBooking,
+                result: $newResult->value,
+                userId: $actor->id,
+            );
+        }
+
+        $hasChanges = $resultChanged || $additionalCommentsChanged || $criteriaChanged;
+
+        return $hasChanges;
+    }
+
+    private function applyResultOverride(PracticalResult $practicalResult, ExamResultEnum $newResult, string $reason, Account $account, Account $actor, array &$updates): bool
+    {
+        if ($practicalResult->result === $newResult->value) {
+            return false;
+        }
+
+        $oldResultHuman = ExamResultEnum::tryFrom($practicalResult->result)?->human() ?? $practicalResult->resultHuman();
+        $updates['result'] = $newResult->value;
+
+        $this->addTrainingNote(
+            account: $account,
+            actor: $actor,
+            content: "Exam result for {$practicalResult->examBooking->exam} exam overridden from {$oldResultHuman} to {$newResult->human()}. Reason: {$reason}",
+        );
+
+        return true;
+    }
+
+    private function applyAdditionalCommentsOverride(PracticalResult $practicalResult, mixed $newComments, string $reason, Account $account, Account $actor, array &$updates): bool
+    {
+        $oldNotes = $this->normalizedNotes($practicalResult->notes);
+        $newNotes = $this->normalizedNotes($newComments);
+
+        if ($oldNotes === $newNotes) {
+            return false;
+        }
+
+        $updates['notes'] = $newNotes;
+
+        $this->addTrainingNote(
+            account: $account,
+            actor: $actor,
+            content: "Additional comments updated for {$practicalResult->examBooking->exam} exam. Reason: {$reason}",
+        );
+
+        return true;
+    }
+
+    private function applyCriteriaOverrides(PracticalResult $practicalResult, array $criteriaUpdates, string $reason, Account $account, Account $actor): bool
+    {
+        if ($criteriaUpdates === []) {
+            return false;
+        }
+
+        $existingAssessments = ExamCriteriaAssessment::where('examid', $practicalResult->examid)
+            ->get()
+            ->keyBy('criteria_id');
+
+        $criteriaIds = array_map('intval', array_keys($criteriaUpdates));
+        $criteriaNames = ExamCriteria::whereIn('id', $criteriaIds)->pluck('criteria', 'id');
+        $gradeLabels = ExamCriteriaAssessment::gradeDropdownOptions();
+        $hasCriteriaChanges = false;
+
+        foreach ($criteriaUpdates as $criteriaId => $update) {
+            $criteriaId = (int) $criteriaId;
+            $assessment = $existingAssessments->get($criteriaId);
+            $oldGrade = $assessment?->result ?? ExamCriteriaAssessment::NOT_ASSESSED;
+            $newGrade = $update['grade'] ?? $oldGrade;
+            $oldNotes = $this->normalizedNotes($assessment?->notes);
+            $newNotes = $this->normalizedNotes($update['notes'] ?? null);
+            $hasGradeChange = $oldGrade !== $newGrade;
+            $hasNotesChange = $oldNotes !== $newNotes;
+
+            if (! $hasGradeChange && ! $hasNotesChange) {
+                continue;
+            }
+
+            $this->examAssessmentRepository->upsertExamCriteriaAssessment(
+                examId: $practicalResult->examid,
+                criteriaId: $criteriaId,
+                grade: $newGrade,
+                comments: $newNotes !== '' ? $newNotes : null,
+            );
+
+            $criteriaName = $criteriaNames->get($criteriaId) ?? "Criteria #{$criteriaId}";
+            $changeReason = trim((string) ($update['change_comments'] ?? ''));
+            $changeReasonText = $changeReason !== '' ? $changeReason : 'No reason provided.';
+
+            if ($hasGradeChange) {
+                $oldGradeLabel = $gradeLabels[$oldGrade] ?? $oldGrade;
+                $newGradeLabel = $gradeLabels[$newGrade] ?? $newGrade;
+
+                $this->addTrainingNote(
+                    account: $account,
+                    actor: $actor,
+                    content: "'{$criteriaName}' updated from {$oldGradeLabel} to {$newGradeLabel}. Reason: {$changeReasonText}",
+                );
+            } elseif ($hasNotesChange) {
+                $this->addTrainingNote(
+                    account: $account,
+                    actor: $actor,
+                    content: "'{$criteriaName}' comments updated. Reason: {$changeReasonText}",
+                );
+            }
+
+            $hasCriteriaChanges = true;
+        }
+
+        return $hasCriteriaChanges;
+    }
+
+    private function addTrainingNote(Account $account, Account $actor, string $content): void
+    {
+        $account->addNote(
+            noteType: 'training',
+            noteContent: $content,
+            writer: $actor,
+        );
+    }
+
+    private function normalizedNotes(mixed $notes): string
+    {
+        return $this->ctsRichContentNotesForCts($notes) ?? '';
+    }
+}

--- a/tests/Unit/Training/Exams/OverrideExamReportServiceTest.php
+++ b/tests/Unit/Training/Exams/OverrideExamReportServiceTest.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Tests\Unit\Training\Exams;
+
+use App\Enums\ExamResultEnum;
+use App\Models\Atc\Position;
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\ExamCriteria;
+use App\Models\Cts\ExamCriteriaAssessment;
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalResult;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\ExamResubmissionService;
+use App\Services\Training\OverrideExamReportService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class OverrideExamReportServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Account $studentAccount;
+
+    private Member $studentMember;
+
+    private ExamBooking $examBooking;
+
+    private PracticalResult $practicalResult;
+
+    private Account $actor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->studentAccount = Account::factory()->withQualification()->create();
+        $this->studentMember = Member::factory()->create([
+            'id' => $this->studentAccount->id,
+            'cid' => $this->studentAccount->id,
+        ]);
+
+        $this->examBooking = ExamBooking::factory()->create([
+            'taken' => 1,
+            'finished' => ExamBooking::FINISHED_FLAG,
+            'exam' => 'TWR',
+            'student_id' => $this->studentMember->id,
+            'student_rating' => Qualification::code('S1')->first()->vatsim,
+            'position_1' => 'EGKK_TWR',
+        ]);
+
+        $this->practicalResult = PracticalResult::factory()->create([
+            'examid' => $this->examBooking->id,
+            'student_id' => $this->studentMember->id,
+            'result' => PracticalResult::PASSED,
+            'notes' => 'Original comments',
+            'exam' => 'TWR',
+        ]);
+
+        $this->actor = Account::factory()->create();
+    }
+
+    public function test_updates_result_and_logs_note(): void
+    {
+        $service = app(OverrideExamReportService::class);
+        $noteCount = $this->studentAccount->notes()->count();
+
+        $result = $service->handle($this->practicalResult, [
+            'exam_result' => ExamResultEnum::Fail->value,
+            'reason' => 'Updated result',
+            'additional_comments' => $this->practicalResult->notes,
+            'criteria_updates' => [],
+        ], $this->actor);
+
+        $this->practicalResult->refresh();
+
+        $this->assertSame(ExamResultEnum::Fail->value, $this->practicalResult->result);
+        $this->assertTrue($result);
+        $this->assertSame($noteCount + 1, $this->studentAccount->notes()->count());
+        $this->assertStringContainsString('overridden from', $this->studentAccount->notes()->latest()->first()->content);
+    }
+
+    public function test_updates_additional_comments_and_logs_note(): void
+    {
+        $service = app(OverrideExamReportService::class);
+        $noteCount = $this->studentAccount->notes()->count();
+
+        $result = $service->handle($this->practicalResult, [
+            'exam_result' => $this->practicalResult->result,
+            'reason' => 'Updated comments',
+            'additional_comments' => '<p>New comments</p>',
+            'criteria_updates' => [],
+        ], $this->actor);
+
+        $this->practicalResult->refresh();
+
+        $this->assertTrue($result);
+        $this->assertSame($noteCount + 1, $this->studentAccount->notes()->count());
+        $this->assertStringContainsString('New comments', $this->practicalResult->notes);
+    }
+
+    public function test_creates_missing_criteria_assessment_and_logs_grade_change(): void
+    {
+        $service = app(OverrideExamReportService::class);
+
+        $criteria = ExamCriteria::create([
+            'exam' => 'TWR',
+            'criteria' => 'Separation',
+            'deleted' => 0,
+        ]);
+
+        $noteCount = $this->studentAccount->notes()->count();
+
+        $result = $service->handle($this->practicalResult, [
+            'exam_result' => $this->practicalResult->result,
+            'reason' => 'Criteria review',
+            'additional_comments' => $this->practicalResult->notes,
+            'criteria_updates' => [
+                $criteria->id => [
+                    'grade' => ExamCriteriaAssessment::FULLY_COMPETENT,
+                    'notes' => '<p>Strong separation</p>',
+                    'change_comments' => 'Reviewed after moderation',
+                ],
+            ],
+        ], $this->actor);
+
+        $assessment = ExamCriteriaAssessment::where('examid', $this->practicalResult->examid)
+            ->where('criteria_id', $criteria->id)
+            ->first();
+
+        $this->assertTrue($result);
+        $this->assertNotNull($assessment);
+        $this->assertSame(ExamCriteriaAssessment::FULLY_COMPETENT, $assessment->result);
+        $this->assertStringContainsString('Strong separation', $assessment->notes);
+        $this->assertSame($noteCount + 1, $this->studentAccount->notes()->count());
+    }
+
+    public function test_updates_criteria_comments_only_and_logs_comment_change(): void
+    {
+        $service = app(OverrideExamReportService::class);
+
+        $criteria = ExamCriteria::create([
+            'exam' => 'TWR',
+            'criteria' => 'Comms',
+            'deleted' => 0,
+        ]);
+
+        ExamCriteriaAssessment::create([
+            'examid' => $this->practicalResult->examid,
+            'criteria_id' => $criteria->id,
+            'result' => ExamCriteriaAssessment::MOSTLY_COMPETENT,
+            'notes' => 'Original notes',
+        ]);
+
+        $noteCount = $this->studentAccount->notes()->count();
+
+        $result = $service->handle($this->practicalResult, [
+            'exam_result' => $this->practicalResult->result,
+            'reason' => 'Update comments',
+            'additional_comments' => $this->practicalResult->notes,
+            'criteria_updates' => [
+                $criteria->id => [
+                    'grade' => ExamCriteriaAssessment::MOSTLY_COMPETENT,
+                    'notes' => '<p>Updated comms notes</p>',
+                    'change_comments' => 'Clarified report',
+                ],
+            ],
+        ], $this->actor);
+
+        $assessment = ExamCriteriaAssessment::where('examid', $this->practicalResult->examid)
+            ->where('criteria_id', $criteria->id)
+            ->firstOrFail();
+
+        $this->assertTrue($result);
+        $this->assertStringContainsString('Updated comms notes', $assessment->notes);
+        $this->assertSame($noteCount + 1, $this->studentAccount->notes()->count());
+        $this->assertStringContainsString('comments updated', $this->studentAccount->notes()->latest()->first()->content);
+    }
+
+    public function test_no_changes_returns_false_and_does_not_log_notes(): void
+    {
+        $service = app(OverrideExamReportService::class);
+        $noteCount = $this->studentAccount->notes()->count();
+
+        $result = $service->handle($this->practicalResult, [
+            'exam_result' => $this->practicalResult->result,
+            'reason' => 'No change',
+            'additional_comments' => $this->practicalResult->notes,
+            'criteria_updates' => [],
+        ], $this->actor);
+
+        $this->assertFalse($result);
+        $this->assertSame($noteCount, $this->studentAccount->notes()->count());
+    }
+
+    public function test_calls_resubmission_service_on_incomplete_result(): void
+    {
+        $position = Position::factory()->create([
+            'callsign' => 'EGKK_TWR',
+        ]);
+        TrainingPosition::factory()->create(['position_id' => $position->id]);
+
+        $mock = $this->mock(ExamResubmissionService::class);
+        $mock->shouldReceive('handle')
+            ->once()
+            ->withArgs(function (ExamBooking $booking, string $result, int $userId): bool {
+                return $booking->is($this->examBooking)
+                    && $result === ExamResultEnum::Incomplete->value
+                    && $userId === $this->actor->id;
+            });
+
+        $service = app(OverrideExamReportService::class);
+
+        $service->handle($this->practicalResult, [
+            'exam_result' => ExamResultEnum::Incomplete->value,
+            'reason' => 'Needs resubmission',
+            'additional_comments' => $this->practicalResult->notes,
+            'criteria_updates' => [],
+        ], $this->actor);
+    }
+
+    public function test_criteria_updates_with_identical_values_returns_false(): void
+    {
+        $service = app(OverrideExamReportService::class);
+
+        $criteria = ExamCriteria::create([
+            'exam' => 'TWR',
+            'criteria' => 'Comms',
+            'deleted' => 0,
+        ]);
+
+        ExamCriteriaAssessment::create([
+            'examid' => $this->practicalResult->examid,
+            'criteria_id' => $criteria->id,
+            'result' => ExamCriteriaAssessment::MOSTLY_COMPETENT,
+            'notes' => 'Same notes',
+        ]);
+
+        $noteCount = $this->studentAccount->notes()->count();
+
+        $result = $service->handle($this->practicalResult, [
+            'exam_result' => $this->practicalResult->result,
+            'reason' => 'No functional change',
+            'additional_comments' => $this->practicalResult->notes,
+            'criteria_updates' => [
+                $criteria->id => [
+                    'grade' => ExamCriteriaAssessment::MOSTLY_COMPETENT,
+                    'notes' => 'Same notes',
+                    'change_comments' => 'No changes made',
+                ],
+            ],
+        ], $this->actor);
+
+        $this->assertFalse($result);
+        $this->assertSame($noteCount, $this->studentAccount->notes()->count());
+    }
+}


### PR DESCRIPTION
Fixes TECH-640
Fixes TECH-642
Fixes TECH-641

# Summary of changes
- Moves the override logic to a service and resolves the result error
- Ensures notes are created for each individual critiera
- Allows changing additional comments and the comments regarding each critera.

# Screenshots (if necessary)
<img width="1137" height="798" alt="image" src="https://github.com/user-attachments/assets/a7247325-15d7-4c96-b9c5-4a681a95f1fb" />
<img width="1109" height="733" alt="image" src="https://github.com/user-attachments/assets/d2af89e9-df89-4c74-92a4-26d7303c2e29" />
