### PR TITLE
Discord booster fixes

### DIFF
--- a/app/Models/Discord/DiscordRoleRule.php
+++ b/app/Models/Discord/DiscordRoleRule.php
@@ -22,6 +22,7 @@ class DiscordRoleRule extends Model
 
     protected $casts = [
         'permission_id' => 'int',
+        'discord_id' => 'string',
     ];
 
     /**

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -80,18 +80,19 @@ trait HasDiscordAccount
             // Handle if the user is banned on core
             if ($this->isBanned) {
                 // If they are already in the suspended role, we are happy
-                if ($currentRoles->contains($suspendedRoleId)) {
+                if ($currentRoles->contains((string) $suspendedRoleId)) {
                     return;
                 }
 
-                $rolesToAdd = [$suspendedRoleId];
+                $rolesToAdd = [(string) $suspendedRoleId];
 
-                if ($currentRoles->contains(config('services.discord.booster_role_id'))) {
-                    $rolesToAdd[] = config('services.discord.booster_role_id');
+                $boosterRoleId = config('services.discord.booster_role_id');
+                if ($boosterRoleId && $currentRoles->contains((string) $boosterRoleId)) {
+                    $rolesToAdd[] = (string) $boosterRoleId;
                 }
 
                 // Set their roles to only the suspended role (replaces all current roles)
-                $discord->setRoles($this, [...$rolesToAdd]);
+                $discord->setRoles($this, $rolesToAdd);
 
                 return;
             }
@@ -121,9 +122,9 @@ trait HasDiscordAccount
      * - Unmanaged roles are preserved as-is.
      * - The suspended role is always excluded from the result.
      */
-    private function computeTargetRoles(Collection $currentRoles, $suspendedRoleId): Collection
+    private function computeTargetRoles(Collection $currentRoles, string $suspendedRoleId): Collection
     {
-        $targetRoles = $currentRoles->reject(fn ($role) => $role === $suspendedRoleId);
+        $targetRoles = $currentRoles->reject(fn ($role) => (string) $role === $suspendedRoleId);
 
         $discordRoleRules = DiscordRoleRule::all()->map(function (DiscordRoleRule $roleRule) {
             return ['discord_id' => $roleRule->discord_id, 'satisfied' => $roleRule->accountSatisfies($this)];
@@ -134,16 +135,17 @@ trait HasDiscordAccount
         $satisfiedRoleIds = $discordRoleRules
             ->groupBy('discord_id')
             ->filter(fn (Collection $group) => $group->contains(fn ($rule) => $rule['satisfied']))
-            ->keys();
+            ->keys()
+            ->map(fn ($id) => (string) $id);
 
         // Remove managed roles that aren't satisfied
-        $targetRoles = $targetRoles->reject(fn ($role) => $managedRoleIds->contains($role));
+        $targetRoles = $targetRoles->reject(fn ($role) => $managedRoleIds->contains((string) $role));
 
         // Add satisfied managed roles, ensuring the suspended role can't be re-introduced
         return $targetRoles
             ->merge($satisfiedRoleIds)
             ->unique()
-            ->reject(fn ($role) => $role === $suspendedRoleId)
+            ->reject(fn ($role) => (string) $role === $suspendedRoleId)
             ->values();
     }
 
@@ -152,6 +154,7 @@ trait HasDiscordAccount
      */
     private function rolesNeedUpdate(Collection $currentRoles, Collection $targetRoles): bool
     {
-        return $currentRoles->sort()->values()->toArray() !== $targetRoles->sort()->values()->toArray();
+        return $currentRoles->map(fn ($role) => (string) $role)->sort()->values()->toArray()
+            !== $targetRoles->map(fn ($role) => (string) $role)->sort()->values()->toArray();
     }
 }

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -61,7 +61,7 @@ trait HasDiscordAccount
         /** @var Discord */
         $discord = app()->make(Discord::class);
 
-        $suspendedRoleId = config('services.discord.suspended_member_role_id');
+        $suspendedRoleId = config('services.discord.suspended_member_role_id') ?? '';
 
         try {
             $discord->setNickname($this, $this->discordName);

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -84,8 +84,14 @@ trait HasDiscordAccount
                     return;
                 }
 
-                // Set their roles to only the suspended role (replaces all current roles
-                $discord->setRoles($this, [$suspendedRoleId]);
+                $rolesToAdd = [$suspendedRoleId];
+
+                if ($currentRoles->contains(config('services.discord.booster_role_id'))) {
+                    $rolesToAdd[] = config('services.discord.booster_role_id');
+                }
+
+                // Set their roles to only the suspended role (replaces all current roles)
+                $discord->setRoles($this, [...$rolesToAdd]);
 
                 return;
             }

--- a/config/services.php
+++ b/config/services.php
@@ -50,7 +50,7 @@ return [
         'client_secret' => env('DISCORD_SECRET', null),
         'redirect_uri' => env('DISCORD_REDIRECT_URI', null),
         'base_discord_uri' => env('DISCORD_API_BASE', 'https://discord.com/api/v6'),
-        'suspended_member_role_id' => env('DISCORD_SUSPENDED_MEMBER_ROLE_ID', null),
+        'suspended_member_role_id' => env('DISCORD_SUSPENDED_MEMBER_ROLE_ID', '1511158845987229737'),
         'training_alerts_channel_id' => env('DISCORD_TRAINING_ALERTS_CHANNEL_ID', null),
         'booster_role_id' => env('DISCORD_BOOSTER_ROLE_ID', '740539876889591878'),
     ],

--- a/config/services.php
+++ b/config/services.php
@@ -52,6 +52,7 @@ return [
         'base_discord_uri' => env('DISCORD_API_BASE', 'https://discord.com/api/v6'),
         'suspended_member_role_id' => env('DISCORD_SUSPENDED_MEMBER_ROLE_ID', null),
         'training_alerts_channel_id' => env('DISCORD_TRAINING_ALERTS_CHANNEL_ID', null),
+        'booster_role_id' => env('DISCORD_BOOSTER_ROLE_ID', '740539876889591878'),
     ],
 
     'google' => [

--- a/config/training.php
+++ b/config/training.php
@@ -8,13 +8,13 @@ return [
     ],
 
     'discord' => [
-        'exam_announce_channel_id' => env('DISCORD_EXAM_ANNOUNCE_CHANNEL_ID', 1086017278988013609),
-        'exam_pilot_role_id' => env('DISCORD_EXAM_PILOT_ROLE_ID', 1086016803047747675),
-        'exam_controller_role_id' => env('DISCORD_EXAM_CONTROLLER_ROLE_ID', 1086016870282432663),
-        'exam_success_channel_id' => env('DISCORD_EXAM_SUCCESS_CHANNEL_ID', 1135654373981180034),
-        'mentoring_announce_channel_id' => env('DISCORD_MENTORING_ANNOUNCE_CHANNEL_ID', 1086017310101344406),
-        'mentoring_pilot_role_id' => env('DISCORD_MENTORING_PILOT_ROLE_ID', 1086016916394606622),
-        'mentoring_controller_role_id' => env('DISCORD_MENTORING_CONTROLLER_ROLE_ID', 1086016985537716256),
+        'exam_announce_channel_id' => env('DISCORD_EXAM_ANNOUNCE_CHANNEL_ID', '1086017278988013609'),
+        'exam_pilot_role_id' => env('DISCORD_EXAM_PILOT_ROLE_ID', '1086016803047747675'),
+        'exam_controller_role_id' => env('DISCORD_EXAM_CONTROLLER_ROLE_ID', '1086016870282432663'),
+        'exam_success_channel_id' => env('DISCORD_EXAM_SUCCESS_CHANNEL_ID', '1135654373981180034'),
+        'mentoring_announce_channel_id' => env('DISCORD_MENTORING_ANNOUNCE_CHANNEL_ID', '1086017310101344406'),
+        'mentoring_pilot_role_id' => env('DISCORD_MENTORING_PILOT_ROLE_ID', '1086016916394606622'),
+        'mentoring_controller_role_id' => env('DISCORD_MENTORING_CONTROLLER_ROLE_ID', '1086016985537716256'),
         'vatuk_emoji_name_and_id' => env('DISCORD_VATUK_EMOJI_NAME_AND_ID', 'vuktrail:740917513436790834'),
     ],
 

--- a/tests/Unit/Mship/HasDiscordAccountTest.php
+++ b/tests/Unit/Mship/HasDiscordAccountTest.php
@@ -147,4 +147,73 @@ class HasDiscordAccountTest extends TestCase
         $this->assertEquals('MyVeryLongFirstNam A - 123456789', $user->discordName);
         $this->assertLessThanOrEqual(32, strlen($user->discordName));
     }
+
+    public function test_banned_user_with_booster_role_preserves_booster_role()
+    {
+        Config::set('services.discord.token', '123');
+        Config::set('services.discord.suspended_member_role_id', 'suspended');
+        Config::set('services.discord.booster_role_id', 'booster');
+
+        $this->user->discord_id = 12345;
+
+        // Give the user an active ban
+        $banReason = \App\Models\Mship\Ban\Reason::factory()->create(['period_amount' => 1, 'period_unit' => 'D']);
+        $this->user->addBan($banReason, 'Test ban reason', 'Test internal note', $this->privacc);
+
+        $this->assertTrue($this->user->isBanned);
+
+        $this->mock(Discord::class, function (MockInterface $mock) {
+            $mock->shouldReceive('setNickname')->once();
+            $mock->shouldReceive('getUserRoles')->andReturn(collect(['some_role', 'booster']))->once();
+            $mock->shouldReceive('setRoles')->with($this->user, ['suspended', 'booster'])->once();
+        });
+
+        $this->user->syncToDiscord();
+    }
+
+    public function test_banned_user_without_booster_role_gets_only_suspended_role()
+    {
+        Config::set('services.discord.token', '123');
+        Config::set('services.discord.suspended_member_role_id', 'suspended');
+        Config::set('services.discord.booster_role_id', 'booster');
+
+        $this->user->discord_id = 12345;
+
+        // Give the user an active ban
+        $banReason = \App\Models\Mship\Ban\Reason::factory()->create(['period_amount' => 1, 'period_unit' => 'D']);
+        $this->user->addBan($banReason, 'Test ban reason', 'Test internal note', $this->privacc);
+
+        $this->assertTrue($this->user->isBanned);
+
+        $this->mock(Discord::class, function (MockInterface $mock) {
+            $mock->shouldReceive('setNickname')->once();
+            $mock->shouldReceive('getUserRoles')->andReturn(collect(['some_role', 'other_role']))->once();
+            $mock->shouldReceive('setRoles')->with($this->user, ['suspended'])->once();
+        });
+
+        $this->user->syncToDiscord();
+    }
+
+    public function test_banned_user_already_in_suspended_role_does_not_update_roles()
+    {
+        Config::set('services.discord.token', '123');
+        Config::set('services.discord.suspended_member_role_id', 'suspended');
+        Config::set('services.discord.booster_role_id', 'booster');
+
+        $this->user->discord_id = 12345;
+
+        // Give the user an active ban
+        $banReason = \App\Models\Mship\Ban\Reason::factory()->create(['period_amount' => 1, 'period_unit' => 'D']);
+        $this->user->addBan($banReason, 'Test ban reason', 'Test internal note', $this->privacc);
+
+        $this->assertTrue($this->user->isBanned);
+
+        $this->mock(Discord::class, function (MockInterface $mock) {
+            $mock->shouldReceive('setNickname')->once();
+            $mock->shouldReceive('getUserRoles')->andReturn(collect(['suspended', 'booster']))->once();
+            $mock->shouldNotReceive('setRoles');
+        });
+
+        $this->user->syncToDiscord();
+    }
 }

--- a/tests/Unit/Mship/HasDiscordAccountTest.php
+++ b/tests/Unit/Mship/HasDiscordAccountTest.php
@@ -25,7 +25,7 @@ class HasDiscordAccountTest extends TestCase
         $this->mock(Discord::class, function (MockInterface $mock) {
             $mock->shouldReceive('setNickname')->once();
             $mock->shouldReceive('getUserRoles')->andReturn(collect(['2']))->once();
-            $mock->shouldReceive('setRoles')->with($this->user, [1])->once();
+            $mock->shouldReceive('setRoles')->with($this->user, ['1'])->once();
         });
 
         $permissionHas = factory(Permission::class)->create(['name' => 'discord.test.role-1']);


### PR DESCRIPTION
 - Do not manage booster role
 - Clean up remaining int IDs