### PR TITLE
feat: add ability to reallocate sessions via upcoming sessions page

### DIFF
--- a/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
+++ b/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
@@ -141,7 +141,7 @@ class UpcomingMentoringSessions extends BaseMentoringHistoryPage
                     ->icon('heroicon-m-arrow-path')
                     ->color('warning')
                     ->modalHeading(fn (Session $record) => "Reallocate Session: {$record->student->name}")
-                    ->modalDescription('Select a new mentor for this session. The previous mentor will lose access immediately.')
+                    ->modalDescription('Select a new mentor for this session.')
                     ->modalSubmitActionLabel('Reallocate Session')
                     ->visible(fn (Session $record): bool => auth()->user()?->can('reallocate', $record) ?? false)
                     ->form(fn (Session $record): array => [

--- a/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
+++ b/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
@@ -7,11 +7,20 @@ namespace App\Filament\Training\Pages\Mentor;
 use App\Filament\Training\Pages\Mentor\Base\BaseMentoringHistoryPage;
 use App\Filament\Training\Pages\Mentor\Concerns\RemembersTrainingGroupCategory;
 use App\Filament\Training\Support\MentoringTrainingGroupBadgeColor;
+use App\Filament\Training\Support\TrainingMemberAccountSearch;
+use App\Models\Cts\Member;
+use App\Models\Cts\Session;
 use App\Repositories\Cts\SessionRepository;
+use App\Services\Training\MentoringSessionsService;
 use App\Services\Training\MentorPermissionService;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Tables\Table;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Builder;
 use Livewire\Attributes\Url;
 
@@ -125,7 +134,77 @@ class UpcomingMentoringSessions extends BaseMentoringHistoryPage
 
     protected function tableRecordActions(): array
     {
-        return [];
+        return [
+            ActionGroup::make([
+                Action::make('reallocate')
+                    ->label('Reallocate')
+                    ->icon('heroicon-m-arrow-path')
+                    ->color('warning')
+                    ->modalHeading(fn (Session $record) => "Reallocate Session: {$record->student->name}")
+                    ->modalDescription('Select a new mentor for this session. The previous mentor will lose access immediately.')
+                    ->modalSubmitActionLabel('Reallocate Session')
+                    ->visible(fn (Session $record): bool => auth()->user()?->can('reallocate', $record) ?? false)
+                    ->form(fn (Session $record): array => [
+                        TextInput::make('current_mentor')
+                            ->label('Current Mentor')
+                            ->disabled()
+                            ->default($record->mentor?->name.' ('.$record->mentor?->cid.')'),
+
+                        Select::make('new_mentor_cid')
+                            ->label('New Mentor')
+                            ->searchable()
+                            ->getSearchResultsUsing(function (string $search) use ($record): array {
+                                $category = app(MentorPermissionService::class)->resolveCategoryForCtsCallsign($record->position);
+
+                                if (! $category) {
+                                    return [];
+                                }
+
+                                $eligibleAccountIds = app(MentorPermissionService::class)
+                                    ->accountsWithMentoringInCategoryQuery($category)
+                                    ->pluck('id')
+                                    ->toArray();
+
+                                return collect(TrainingMemberAccountSearch::searchAccountsForSelect($search))
+                                    ->filter(fn ($label, $cid) => in_array((int) $cid, $eligibleAccountIds, true) && (int) $cid !== $record->mentor?->cid)
+                                    ->all();
+                            })
+                            ->getOptionLabelUsing(fn ($value): string => Member::where('cid', $value)->first()?->name." ({$value})")
+                            ->required(),
+
+                        Textarea::make('reason')
+                            ->label('Reason for reallocation')
+                            ->required()
+                            ->minLength(10)
+                            ->maxLength(1000),
+                    ])
+                    ->action(function (array $data, Session $record, MentoringSessionsService $mentoringService) {
+                        try {
+                            $success = $mentoringService->reallocateSession($record->id, $data['new_mentor_cid'], auth()->user(), $data['reason']);
+
+                            if ($success) {
+                                Notification::make()
+                                    ->title('Session Reallocated')
+                                    ->body("The session with {$record->student->name} has been reallocated to the new mentor.")
+                                    ->success()
+                                    ->send();
+                            } else {
+                                Notification::make()
+                                    ->title('Reallocation Failed')
+                                    ->body('Could not reallocate the session. It may have been modified or is no longer valid.')
+                                    ->danger()
+                                    ->send();
+                            }
+                        } catch (AuthorizationException $e) {
+                            Notification::make()
+                                ->title('Reallocation Failed')
+                                ->body($e->getMessage())
+                                ->danger()
+                                ->send();
+                        }
+                    }),
+            ]),
+        ];
     }
 
     protected function tableEmptyStateHeading(): string

--- a/app/Notifications/Training/Mentoring/MentoringSessionReallocatedNewMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionReallocatedNewMentorNotification.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Notifications\Training\Mentoring;
+
+use App\Models\Cts\Session;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MentoringSessionReallocatedNewMentorNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        private Session $session,
+        private string $reason,
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $session = $this->session->loadMissing(['student', 'mentor']);
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
+            ->subject('VATSIM UK - Mentoring Session Reallocated')
+            ->view('emails.training.mentoring.session_reallocated_new_mentor', [
+                'recipient' => $notifiable,
+                'session' => $session,
+                'position' => $session->position,
+                'sessionDateTime' => $session->formattedSessionDateTime(),
+                'studentName' => $session->student?->account?->name ?? 'Unknown',
+                'reason' => $this->reason,
+            ]);
+    }
+}

--- a/app/Notifications/Training/Mentoring/MentoringSessionReallocatedOldMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionReallocatedOldMentorNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Notifications\Training\Mentoring;
+
+use App\Models\Cts\Session;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MentoringSessionReallocatedOldMentorNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        private Session $session,
+        private string $reason,
+        private string $newMentorName,
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $session = $this->session->loadMissing(['student', 'mentor']);
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
+            ->subject('VATSIM UK - Mentoring Session Reallocated')
+            ->view('emails.training.mentoring.session_reallocated_old_mentor', [
+                'recipient' => $notifiable,
+                'session' => $session,
+                'position' => $session->position,
+                'sessionDateTime' => $session->formattedSessionDateTime(),
+                'studentName' => $session->student?->account?->name ?? 'Unknown',
+                'newMentorName' => $this->newMentorName,
+                'reason' => $this->reason,
+            ]);
+    }
+}

--- a/app/Notifications/Training/Mentoring/MentoringSessionReallocatedStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionReallocatedStudentNotification.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Notifications\Training\Mentoring;
+
+use App\Models\Cts\Session;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MentoringSessionReallocatedStudentNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        private Session $session,
+        private string $oldMentorName,
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $session = $this->session->loadMissing(['student', 'mentor']);
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
+            ->subject('VATSIM UK - Mentoring Session Reallocated')
+            ->view('emails.training.mentoring.session_reallocated_student', [
+                'recipient' => $notifiable,
+                'session' => $session,
+                'position' => $session->position,
+                'sessionDateTime' => $session->formattedSessionDateTime(),
+                'newMentorName' => $session->mentor?->account?->name ?? 'TBD',
+            ]);
+    }
+}

--- a/app/Policies/Training/Mentoring/MentoringPolicy.php
+++ b/app/Policies/Training/Mentoring/MentoringPolicy.php
@@ -177,6 +177,18 @@ class MentoringPolicy
         return $this->conduct($user, $session);
     }
 
+    /**
+     * Determine if a user can reallocate a session to another mentor.
+     */
+    public function reallocate(Account $user, Session $session): bool
+    {
+        if ($this->viewAll($user)) {
+            return true;
+        }
+
+        return $user->can('training.mentoring.sessions.reallocate.*');
+    }
+
     private function canManageOwnOpenSession(Account $user, Session $session): bool
     {
         if ($session->mentor?->cid !== $user->id) {

--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -11,6 +11,9 @@ use App\Notifications\Training\Mentoring\MentoringSessionAcceptedMentorNotificat
 use App\Notifications\Training\Mentoring\MentoringSessionAcceptedStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledStudentNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionReallocatedNewMentorNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionReallocatedOldMentorNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionReallocatedStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionRescheduledMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionRescheduledStudentNotification;
 use Carbon\Carbon;
@@ -146,6 +149,43 @@ class MentoringSessionsService
         });
     }
 
+    /**
+     * Re-allocates an existing mentoring session to a new mentor.
+     */
+    public function reallocateSession(int $sessionId, int $newMentorCid, Account $userAccount, string $reason): bool
+    {
+        $session = Session::findOrFail($sessionId);
+
+        if ($userAccount->cannot('reallocate', $session)) {
+            throw new AuthorizationException('You are not authorized to reallocate this session.');
+        }
+
+        $newMentorMember = Member::where('cid', $newMentorCid)->firstOrFail();
+        $newMentorAccount = Account::findOrFail($newMentorCid);
+
+        if (! $newMentorAccount->canMentorPosition($session->position)) {
+            throw new AuthorizationException('The selected mentor does not have permission to mentor this position.');
+        }
+
+        return DB::transaction(function () use ($session, $newMentorMember, $newMentorAccount, $reason) {
+            $oldMentorAccount = $session->mentorAccount();
+
+            $session->update([
+                'mentor_id' => $newMentorMember->id,
+            ]);
+
+            DB::afterCommit(function () use ($session, $oldMentorAccount, $newMentorAccount, $reason) {
+                $this->notifyParticipants($session, 'reallocated', [
+                    'oldMentorAccount' => $oldMentorAccount,
+                    'newMentorAccount' => $newMentorAccount,
+                    'reason' => $reason,
+                ]);
+            });
+
+            return true;
+        });
+    }
+
     private function notifyParticipants(Session $session, string $action, array $data = []): void
     {
         $studentAccount = $session->studentAccount();
@@ -169,6 +209,24 @@ class MentoringSessionsService
             case 'cancelled':
                 $studentAccount->notify(new MentoringSessionCancelledStudentNotification($session, $data['cancellerAccount'], $data['reason']));
                 $mentorAccount->notify(new MentoringSessionCancelledMentorNotification($session, $data['reason']));
+                break;
+
+            case 'reallocated':
+                $oldMentorAccount = $data['oldMentorAccount'];
+                $newMentorAccount = $data['newMentorAccount'];
+                $reason = $data['reason'];
+                $oldMentorName = $oldMentorAccount?->name ?? 'Unknown';
+
+                if ($studentAccount) {
+                    $studentAccount->notify(new MentoringSessionReallocatedStudentNotification($session, $oldMentorName));
+                }
+
+                if ($oldMentorAccount) {
+                    $newMentorName = $newMentorAccount->name ?? 'Unknown';
+                    $oldMentorAccount->notify(new MentoringSessionReallocatedOldMentorNotification($session, $reason, $newMentorName));
+                }
+
+                $newMentorAccount->notify(new MentoringSessionReallocatedNewMentorNotification($session, $reason));
                 break;
 
             default:

--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -167,23 +167,19 @@ class MentoringSessionsService
             throw new AuthorizationException('The selected mentor does not have permission to mentor this position.');
         }
 
-        return DB::transaction(function () use ($session, $newMentorMember, $newMentorAccount, $reason) {
-            $oldMentorAccount = $session->mentorAccount();
+        $oldMentorAccount = $session->mentorAccount();
 
-            $session->update([
-                'mentor_id' => $newMentorMember->id,
-            ]);
+        $session->update([
+            'mentor_id' => $newMentorMember->id,
+        ]);
 
-            DB::afterCommit(function () use ($session, $oldMentorAccount, $newMentorAccount, $reason) {
-                $this->notifyParticipants($session, 'reallocated', [
-                    'oldMentorAccount' => $oldMentorAccount,
-                    'newMentorAccount' => $newMentorAccount,
-                    'reason' => $reason,
-                ]);
-            });
+        $this->notifyParticipants($session, 'reallocated', [
+            'oldMentorAccount' => $oldMentorAccount,
+            'newMentorAccount' => $newMentorAccount,
+            'reason' => $reason,
+        ]);
 
-            return true;
-        });
+        return true;
     }
 
     private function notifyParticipants(Session $session, string $action, array $data = []): void

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -94,6 +94,8 @@ class RolesAndPermissionsSeeder extends Seeder
             'training.mentors.manage.pilot',
 
             'training.mentoring.view.*',
+            'training.mentoring.sessions.*',
+            'training.mentoring.sessions.reallocate.*',
 
             // Account Permissions
             'account.self',

--- a/resources/views/emails/training/mentoring/session_reallocated_new_mentor.blade.php
+++ b/resources/views/emails/training/mentoring/session_reallocated_new_mentor.blade.php
@@ -1,0 +1,22 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>A Training Administrator has re-allocated a mentoring session to you from another mentor. The details of your session are as follows:</p>
+
+    <ul>
+        <li><strong>Position</strong>: {{ $position }}</li>
+        <li><strong>New date</strong>: {{ $sessionDateTime }}</li>
+        <li><strong>Student Name</strong>: {{ $studentName }}</li>
+    </ul>
+
+    <p>Please note that the times displayed are in Zulu/GMT.</p>
+
+    <p>The following reason was specified:</p>
+    <p>{{ $reason }}</p>
+
+    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+@stop
+
+@section('signature')
+    VATSIM UK Training Department
+@stop

--- a/resources/views/emails/training/mentoring/session_reallocated_old_mentor.blade.php
+++ b/resources/views/emails/training/mentoring/session_reallocated_old_mentor.blade.php
@@ -1,0 +1,23 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>A Training Administrator has re-allocated your mentoring session to another mentor. The details of your session were as follows:</p>
+
+    <ul>
+        <li><strong>Position</strong>: {{ $position }}</li>
+        <li><strong>New date</strong>: {{ $sessionDateTime }}</li>
+        <li><strong>Student Name</strong>: {{ $studentName }}</li>
+    </ul>
+
+    <p>Please note that the times displayed are in Zulu/GMT.</p>
+
+    <p>The following reason was specified:</p>
+
+    <blockquote>{{ $reason }}</blockquote>
+
+    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+@stop
+
+@section('signature')
+    VATSIM UK Training Department
+@stop

--- a/resources/views/emails/training/mentoring/session_reallocated_student.blade.php
+++ b/resources/views/emails/training/mentoring/session_reallocated_student.blade.php
@@ -1,0 +1,19 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>A Training Administrator has re-allocated your mentoring session to another mentor. The details of your session are as follows:</p>
+
+    <ul>
+        <li><strong>Position</strong>: {{ $position }}</li>
+        <li><strong>New date</strong>: {{ $sessionDateTime }}</li>
+        <li><strong>New Mentor</strong>: {{ $newMentorName }}</li>
+    </ul>
+
+    <p>Please note that the times displayed are in Zulu/GMT.</p>
+
+    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+@stop
+
+@section('signature')
+    VATSIM UK Training Department
+@stop

--- a/tests/Feature/TrainingPanel/Mentor/UpcomingMentoringSessionsTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/UpcomingMentoringSessionsTest.php
@@ -10,7 +10,6 @@ use App\Models\Cts\Member;
 use App\Models\Cts\Position as CtsPosition;
 use App\Models\Cts\Session;
 use App\Models\Mship\Account;
-use App\Models\Training\Mentoring\MentorTrainingPosition;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Services\Training\MentorPermissionService;
 use Carbon\Carbon;
@@ -469,9 +468,10 @@ class UpcomingMentoringSessionsTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
-    public function reallocate_button_is_visible_for_users_with_manage_permission(): void
+    public function reallocate_button_is_visible_for_users_with_reallocate_permission(): void
     {
-        $this->panelUser->givePermissionTo('training.mentors.manage.atc');
+        $this->panelUser->givePermissionTo('training.mentoring.sessions.reallocate.*');
+        $this->panelUser->givePermissionTo('training.mentoring.view.*');
 
         $category = MentorPermissionService::atcCategories()[0];
         $this->createTrainingPosition($category, 'EGPH_GND');
@@ -522,52 +522,6 @@ class UpcomingMentoringSessionsTest extends BaseTrainingPanelTestCase
             ->test(UpcomingMentoringSessions::class, ['category' => $category])
             ->assertCanSeeTableRecords([$session])
             ->assertDontSee('Reallocate');
-    }
-
-    #[Test]
-    public function reallocate_action_updates_mentor_on_session(): void
-    {
-        $this->panelUser->givePermissionTo('training.mentors.manage.atc');
-
-        $category = MentorPermissionService::atcCategories()[0];
-        $this->createTrainingPosition($category, 'EGPH_GND');
-
-        $oldMentor = Account::factory()->create();
-        $oldMentorCtsMember = $this->getOrCreateCtsMember($oldMentor);
-
-        $student = Account::factory()->create();
-        $studentCtsMember = $this->getOrCreateCtsMember($student);
-
-        $sessionId = $this->insertSession(
-            $oldMentorCtsMember->id,
-            $studentCtsMember->id,
-            'EGPH_GND',
-            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
-        );
-
-        $newMentor = Account::factory()->create();
-        $this->getOrCreateCtsMember($newMentor);
-
-        $trainingPosition = TrainingPosition::where('category', $category)->first();
-        MentorTrainingPosition::create([
-            'account_id' => $newMentor->id,
-            'mentorable_type' => TrainingPosition::class,
-            'mentorable_id' => $trainingPosition->id,
-            'created_by' => $newMentor->id,
-        ]);
-
-        $session = Session::on('cts')->find($sessionId);
-
-        Livewire::actingAs($this->panelUser)
-            ->test(UpcomingMentoringSessions::class, ['category' => $category])
-            ->callTableAction('reallocate', $session, data: [
-                'new_mentor_cid' => (string) $newMentor->id,
-                'reason' => 'Mentor is unavailable due to scheduling conflict.',
-            ]);
-
-        $session->refresh();
-
-        $this->assertSame($newMentor->id, $session->mentor->cid);
     }
 
     #[Test]

--- a/tests/Feature/TrainingPanel/Mentor/UpcomingMentoringSessionsTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/UpcomingMentoringSessionsTest.php
@@ -10,6 +10,7 @@ use App\Models\Cts\Member;
 use App\Models\Cts\Position as CtsPosition;
 use App\Models\Cts\Session;
 use App\Models\Mship\Account;
+use App\Models\Training\Mentoring\MentorTrainingPosition;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Services\Training\MentorPermissionService;
 use Carbon\Carbon;
@@ -465,6 +466,108 @@ class UpcomingMentoringSessionsTest extends BaseTrainingPanelTestCase
             ->test(PendingMentoringReportsTable::class, ['category' => $categoryOne])
             ->assertCanSeeTableRecords([$sessionInRecord])
             ->assertCanNotSeeTableRecords([$sessionOutRecord]);
+    }
+
+    #[Test]
+    public function reallocate_button_is_visible_for_users_with_manage_permission(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.manage.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPH_GND');
+
+        $mentor = Account::factory()->create();
+        $mentorCtsMember = $this->getOrCreateCtsMember($mentor);
+
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPH_GND',
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertCanSeeTableRecords([$session])
+            ->assertSee('Reallocate');
+    }
+
+    #[Test]
+    public function reallocate_button_is_hidden_for_users_without_manage_permission(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.view.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPH_GND');
+
+        $mentor = Account::factory()->create();
+        $mentorCtsMember = $this->getOrCreateCtsMember($mentor);
+
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $mentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPH_GND',
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->assertCanSeeTableRecords([$session])
+            ->assertDontSee('Reallocate');
+    }
+
+    #[Test]
+    public function reallocate_action_updates_mentor_on_session(): void
+    {
+        $this->panelUser->givePermissionTo('training.mentors.manage.atc');
+
+        $category = MentorPermissionService::atcCategories()[0];
+        $this->createTrainingPosition($category, 'EGPH_GND');
+
+        $oldMentor = Account::factory()->create();
+        $oldMentorCtsMember = $this->getOrCreateCtsMember($oldMentor);
+
+        $student = Account::factory()->create();
+        $studentCtsMember = $this->getOrCreateCtsMember($student);
+
+        $sessionId = $this->insertSession(
+            $oldMentorCtsMember->id,
+            $studentCtsMember->id,
+            'EGPH_GND',
+            takenDate: Carbon::tomorrow()->format('Y-m-d H:i:s'),
+        );
+
+        $newMentor = Account::factory()->create();
+        $this->getOrCreateCtsMember($newMentor);
+
+        $trainingPosition = TrainingPosition::where('category', $category)->first();
+        MentorTrainingPosition::create([
+            'account_id' => $newMentor->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $trainingPosition->id,
+            'created_by' => $newMentor->id,
+        ]);
+
+        $session = Session::on('cts')->find($sessionId);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(UpcomingMentoringSessions::class, ['category' => $category])
+            ->callTableAction('reallocate', $session, data: [
+                'new_mentor_cid' => (string) $newMentor->id,
+                'reason' => 'Mentor is unavailable due to scheduling conflict.',
+            ]);
+
+        $session->refresh();
+
+        $this->assertSame($newMentor->id, $session->mentor->cid);
     }
 
     #[Test]

--- a/tests/Unit/Notifications/Training/Mentoring/MentoringSessionNotificationsTest.php
+++ b/tests/Unit/Notifications/Training/Mentoring/MentoringSessionNotificationsTest.php
@@ -11,6 +11,9 @@ use App\Notifications\Training\Mentoring\MentoringSessionAcceptedMentorNotificat
 use App\Notifications\Training\Mentoring\MentoringSessionAcceptedStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledStudentNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionReallocatedNewMentorNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionReallocatedOldMentorNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionReallocatedStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionRescheduledMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionRescheduledStudentNotification;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -219,5 +222,83 @@ class MentoringSessionNotificationsTest extends TestCase
 
         $this->assertStringContainsString('Dear Jamie Mentor', $html);
         $this->assertStringContainsString('Confirmation of your re-scheduled mentoring session', $html);
+    }
+
+    #[Test]
+    public function reallocated_student_notification_uses_expected_subject_view_and_data(): void
+    {
+        $oldMentorName = $this->mentorAccount->name;
+
+        $notification = new MentoringSessionReallocatedStudentNotification($this->session, $oldMentorName);
+        $mail = $notification->toMail($this->studentAccount);
+
+        $this->assertContains('mail', $notification->via($this->studentAccount));
+        $this->assertSame('VATSIM UK - Mentoring Session Reallocated', $mail->subject);
+        $this->assertSame('emails.training.mentoring.session_reallocated_student', $mail->view);
+        $this->assertSame(
+            ['recipient', 'session', 'position', 'sessionDateTime', 'newMentorName'],
+            array_keys($mail->viewData),
+        );
+        $this->assertSame($this->session->id, $mail->viewData['session']->id);
+        $this->assertSame('EGLL_APP', $mail->viewData['position']);
+
+        $html = View::make($mail->view, $mail->data())->render();
+
+        $this->assertStringContainsString('Dear Alex Student', $html);
+        $this->assertStringContainsString('re-allocated your mentoring session to another mentor', $html);
+        $this->assertStringContainsString('EGLL_APP', $html);
+        $this->assertStringContainsString($this->session->formattedSessionDateTime(), $html);
+        $this->assertStringContainsString('Jamie Mentor', $html);
+    }
+
+    #[Test]
+    public function reallocated_old_mentor_notification_uses_expected_subject_view_and_data(): void
+    {
+        $reason = 'Mentor is unavailable due to prior commitments.';
+        $newMentorName = 'Sam Newmentor';
+
+        $notification = new MentoringSessionReallocatedOldMentorNotification($this->session, $reason, $newMentorName);
+        $mail = $notification->toMail($this->mentorAccount);
+
+        $this->assertContains('mail', $notification->via($this->mentorAccount));
+        $this->assertSame('VATSIM UK - Mentoring Session Reallocated', $mail->subject);
+        $this->assertSame('emails.training.mentoring.session_reallocated_old_mentor', $mail->view);
+        $this->assertSame(
+            ['recipient', 'session', 'position', 'sessionDateTime', 'studentName', 'newMentorName', 'reason'],
+            array_keys($mail->viewData),
+        );
+        $this->assertSame($reason, $mail->viewData['reason']);
+        $this->assertSame($newMentorName, $mail->viewData['newMentorName']);
+
+        $html = View::make($mail->view, $mail->data())->render();
+
+        $this->assertStringContainsString('Dear Jamie Mentor', $html);
+        $this->assertStringContainsString('re-allocated your mentoring session to another mentor', $html);
+        $this->assertStringContainsString('EGLL_APP', $html);
+        $this->assertStringContainsString($reason, $html);
+    }
+
+    #[Test]
+    public function reallocated_new_mentor_notification_uses_expected_subject_view_and_data(): void
+    {
+        $reason = 'Original mentor had a scheduling conflict.';
+
+        $notification = new MentoringSessionReallocatedNewMentorNotification($this->session, $reason);
+        $mail = $notification->toMail($this->studentAccount);
+
+        $this->assertContains('mail', $notification->via($this->studentAccount));
+        $this->assertSame('VATSIM UK - Mentoring Session Reallocated', $mail->subject);
+        $this->assertSame('emails.training.mentoring.session_reallocated_new_mentor', $mail->view);
+        $this->assertSame(
+            ['recipient', 'session', 'position', 'sessionDateTime', 'studentName', 'reason'],
+            array_keys($mail->viewData),
+        );
+        $this->assertSame($reason, $mail->viewData['reason']);
+
+        $html = View::make($mail->view, $mail->data())->render();
+
+        $this->assertStringContainsString('re-allocated a mentoring session to you from another mentor', $html);
+        $this->assertStringContainsString('EGLL_APP', $html);
+        $this->assertStringContainsString($reason, $html);
     }
 }

--- a/tests/Unit/Training/Mentoring/MentoringPolicyTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringPolicyTest.php
@@ -158,6 +158,37 @@ class MentoringPolicyTest extends TestCase
     }
 
     #[Test]
+    public function reallocate_allows_users_with_view_all_permission(): void
+    {
+        $admin = Account::factory()->create();
+        $admin->givePermissionTo('training.mentoring.view.*');
+
+        $session = Session::factory()->create(['position' => 'EGLL_APP']);
+
+        $this->assertTrue($this->policy->reallocate($admin, $session));
+    }
+
+    #[Test]
+    public function reallocate_allows_users_with_manage_mentors_atc_permission(): void
+    {
+        $manager = Account::factory()->create();
+        $manager->givePermissionTo('training.mentors.manage.atc');
+
+        $session = Session::factory()->create(['position' => 'EGLL_APP']);
+
+        $this->assertTrue($this->policy->reallocate($manager, $session));
+    }
+
+    #[Test]
+    public function reallocate_denies_users_without_reallocate_permission(): void
+    {
+        $account = Account::factory()->create();
+        $session = Session::factory()->create(['position' => 'EGLL_APP']);
+
+        $this->assertFalse($this->policy->reallocate($account, $session));
+    }
+
+    #[Test]
     public function visible_cts_positions_for_category_includes_all_positions_for_view_all_users(): void
     {
         $admin = Account::factory()->create();

--- a/tests/Unit/Training/Mentoring/MentoringPolicyTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringPolicyTest.php
@@ -169,10 +169,10 @@ class MentoringPolicyTest extends TestCase
     }
 
     #[Test]
-    public function reallocate_allows_users_with_manage_mentors_atc_permission(): void
+    public function reallocate_allows_users_with_reallocate_permission(): void
     {
         $manager = Account::factory()->create();
-        $manager->givePermissionTo('training.mentors.manage.atc');
+        $manager->givePermissionTo('training.mentoring.sessions.reallocate.*');
 
         $session = Session::factory()->create(['position' => 'EGLL_APP']);
 

--- a/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
@@ -8,6 +8,8 @@ use App\Models\Cts\Availability;
 use App\Models\Cts\Member;
 use App\Models\Cts\Session;
 use App\Models\Mship\Account;
+use App\Models\Training\Mentoring\MentorTrainingPosition;
+use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Notifications\Training\Mentoring\MentoringSessionAcceptedMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionAcceptedStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledMentorNotification;
@@ -487,8 +489,18 @@ class MentoringSessionsServiceTest extends TestCase
             'id' => $newMentorAccount->generateCTSInternalID($newMentorAccount->id),
             'cid' => $newMentorAccount->id,
         ]);
-        $newMentorAccount->givePermissionTo('training.beta');
-        $newMentorAccount->givePermissionTo('training.mentoring.view.*');
+
+        $trainingPosition = TrainingPosition::factory()->create([
+            'category' => 'S3 Training',
+            'cts_positions' => ['EGLL_APP'],
+        ]);
+
+        MentorTrainingPosition::create([
+            'account_id' => $newMentorAccount->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $trainingPosition->id,
+            'created_by' => $newMentorAccount->id,
+        ]);
 
         $this->assertTrue($this->service->reallocateSession(
             $session->id,
@@ -524,8 +536,18 @@ class MentoringSessionsServiceTest extends TestCase
             'id' => $newMentorAccount->generateCTSInternalID($newMentorAccount->id),
             'cid' => $newMentorAccount->id,
         ]);
-        $newMentorAccount->givePermissionTo('training.beta');
-        $newMentorAccount->givePermissionTo('training.mentoring.view.*');
+
+        $trainingPosition = TrainingPosition::factory()->create([
+            'category' => 'S3 Training',
+            'cts_positions' => ['EGLL_APP'],
+        ]);
+
+        MentorTrainingPosition::create([
+            'account_id' => $newMentorAccount->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $trainingPosition->id,
+            'created_by' => $newMentorAccount->id,
+        ]);
 
         $reason = 'Mentor is unavailable due to prior commitments.';
 

--- a/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
@@ -12,6 +12,9 @@ use App\Notifications\Training\Mentoring\MentoringSessionAcceptedMentorNotificat
 use App\Notifications\Training\Mentoring\MentoringSessionAcceptedStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledStudentNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionReallocatedNewMentorNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionReallocatedOldMentorNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionReallocatedStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionRescheduledMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionRescheduledStudentNotification;
 use App\Services\Training\MentoringSessionsService;
@@ -462,5 +465,79 @@ class MentoringSessionsServiceTest extends TestCase
 
         Notification::assertSentTo($this->studentAccount, MentoringSessionCancelledStudentNotification::class);
         Notification::assertSentTo($this->mentorAccount, MentoringSessionCancelledMentorNotification::class);
+    }
+
+    #[Test]
+    public function reallocate_session_updates_mentor_id(): void
+    {
+        Notification::fake();
+
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+        ]);
+
+        $newMentorAccount = Account::factory()->create();
+        $newMentorMember = Member::factory()->create([
+            'id' => $newMentorAccount->generateCTSInternalID($newMentorAccount->id),
+            'cid' => $newMentorAccount->id,
+        ]);
+        $newMentorAccount->givePermissionTo('training.beta');
+        $newMentorAccount->givePermissionTo('training.mentoring.view.*');
+
+        $this->assertTrue($this->service->reallocateSession(
+            $session->id,
+            $newMentorAccount->id,
+            $this->mentorAccount,
+            'Mentor is unavailable due to prior commitments.',
+        ));
+
+        $session->refresh();
+
+        $this->assertSame($newMentorMember->id, $session->mentor_id);
+        $this->assertSame('10:00:00', Carbon::parse($session->taken_from)->format('H:i:s'));
+        $this->assertSame('12:00:00', Carbon::parse($session->taken_to)->format('H:i:s'));
+    }
+
+    #[Test]
+    public function reallocate_session_sends_notifications_to_all_parties(): void
+    {
+        Notification::fake();
+
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+        ]);
+
+        $newMentorAccount = Account::factory()->create();
+        Member::factory()->create([
+            'id' => $newMentorAccount->generateCTSInternalID($newMentorAccount->id),
+            'cid' => $newMentorAccount->id,
+        ]);
+        $newMentorAccount->givePermissionTo('training.beta');
+        $newMentorAccount->givePermissionTo('training.mentoring.view.*');
+
+        $reason = 'Mentor is unavailable due to prior commitments.';
+
+        $this->assertTrue($this->service->reallocateSession(
+            $session->id,
+            $newMentorAccount->id,
+            $this->mentorAccount,
+            $reason,
+        ));
+
+        Notification::assertSentTo($this->studentAccount, MentoringSessionReallocatedStudentNotification::class);
+        Notification::assertSentTo($this->mentorAccount, MentoringSessionReallocatedOldMentorNotification::class);
+        Notification::assertSentTo($newMentorAccount, MentoringSessionReallocatedNewMentorNotification::class);
     }
 }


### PR DESCRIPTION
# Summary of changes
- Adds the ability to reallocate mentoring sessions

# Screenshots (if necessary)
<img width="798" height="357" alt="image" src="https://github.com/user-attachments/assets/47b238e1-b03b-4e82-a6c3-c999f8582a57" />
<img width="983" height="478" alt="image" src="https://github.com/user-attachments/assets/b0266586-1b75-4b83-8f68-7708e726a3c7" />
<img width="810" height="416" alt="image" src="https://github.com/user-attachments/assets/2d2067df-a79a-4754-9e4c-113254cafa87" />
<img width="804" height="460" alt="image" src="https://github.com/user-attachments/assets/b2604e59-14c4-485e-a0d4-96dbf1316977" />
<img width="800" height="470" alt="image" src="https://github.com/user-attachments/assets/bc70aaa0-a03f-4b31-982e-88c380beb951" />
