### PR TITLE
fix: improvements to the design of the view mentoring report page

### DIFF
--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -233,12 +233,23 @@ class ViewMentoringReport extends Page implements HasInfolists
 
                 $sheetRows[] = Grid::make(14)
                     ->schema([
-                        TextEntry::make("field_name_{$uniqueKey}")
-                            ->state($sheet->field?->field ?? 'Unknown Field')
-                            ->hiddenLabel()
-                            ->size(TextSize::Large)
-                            ->weight(FontWeight::Bold)
-                            ->columnSpan(8),
+                        Grid::make(1)
+                            ->schema([
+                                TextEntry::make("field_name_{$uniqueKey}")
+                                    ->state($sheet->field?->field ?? 'Unknown Field')
+                                    ->hiddenLabel()
+                                    ->size(TextSize::Large)
+                                    ->weight(FontWeight::Bold),
+
+                                TextEntry::make("field_notes_{$uniqueKey}")
+                                    ->label('Notes')
+                                    ->state($this->ctsPlainNotesForHtmlDisplay($sheet->notes))
+                                    ->hiddenLabel()
+                                    ->html()
+                                    ->prose()
+                                    ->extraAttributes(['style' => 'word-break:break-word'])
+                                    ->hidden(blank($sheet->notes)),
+                            ])->columnSpan(8),
 
                         TextEntry::make("field_best_{$uniqueKey}")
                             ->label('Best')
@@ -271,16 +282,6 @@ class ViewMentoringReport extends Page implements HasInfolists
                             ->state($sheet->field_score)
                             ->badge()
                             ->columnSpan(2),
-
-                        TextEntry::make("field_notes_{$uniqueKey}")
-                            ->label('Notes')
-                            ->state($this->ctsPlainNotesForHtmlDisplay($sheet->notes))
-                            ->hiddenLabel()
-                            ->html()
-                            ->prose()
-                            ->extraAttributes(['style' => 'word-break:break-word'])
-                            ->columnSpan(8)
-                            ->hidden(blank($sheet->notes)),
                     ])
                     ->extraAttributes(['class' => MentoringReportLayout::CRITERION_ROW_CLASSES]);
             }

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -234,12 +234,14 @@ class ViewMentoringReport extends Page implements HasInfolists
                 $sheetRows[] = Grid::make(14)
                     ->schema([
                         Grid::make(1)
+                            ->extraAttributes(['class' => 'gap-0'])
                             ->schema([
                                 TextEntry::make("field_name_{$uniqueKey}")
                                     ->state($sheet->field?->field ?? 'Unknown Field')
                                     ->hiddenLabel()
                                     ->size(TextSize::Large)
-                                    ->weight(FontWeight::Bold),
+                                    ->weight(FontWeight::Bold)
+                                    ->extraAttributes(['style' => 'margin-bottom:0.5px']),
 
                                 TextEntry::make("field_notes_{$uniqueKey}")
                                     ->label('Notes')

--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -279,7 +279,7 @@ class ViewMentoringReport extends Page implements HasInfolists
                             ->html()
                             ->prose()
                             ->extraAttributes(['style' => 'word-break:break-word'])
-                            ->columnSpan(12)
+                            ->columnSpan(8)
                             ->hidden(blank($sheet->notes)),
                     ])
                     ->extraAttributes(['class' => MentoringReportLayout::CRITERION_ROW_CLASSES]);

--- a/app/Filament/Training/Support/MentoringReportLayout.php
+++ b/app/Filament/Training/Support/MentoringReportLayout.php
@@ -9,7 +9,7 @@ use Illuminate\Support\HtmlString;
 final class MentoringReportLayout
 {
     /** Vertical rhythm between criteria rows (no border separators). */
-    public const CRITERION_ROW_CLASSES = 'mb-10 last:mb-0';
+    public const CRITERION_ROW_CLASSES = 'mb-2 last:mb-0';
 
     public static function categorySectionTitle(string $categoryName): HtmlString
     {


### PR DESCRIPTION
# Summary of changes
- Contain the criteria note text to the left hand side of the screen
- Move the criteria note text up

# Screenshots (if necessary)
Before:
<img width="1196" height="636" alt="image" src="https://github.com/user-attachments/assets/11f4f1d0-f10a-4d36-a944-3ec94a89c5ca" />

After:
<img width="963" height="787" alt="image" src="https://github.com/user-attachments/assets/e613f9a2-59d8-4925-adfd-e17af5041bfb" />