### PR TITLE
fix: make autosave on the conduct mentoring page more aggressive

### DIFF
--- a/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
+++ b/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
@@ -29,7 +29,9 @@ trait InteractsWithCtsRichEditorNotes
      */
     protected function conductSessionRichEditor(RichEditor $editor, ?callable $afterStateUpdated = null): RichEditor
     {
-        $editor = $editor->live(onBlur: true);
+        $editor = $editor
+            ->live()
+            ->extraFieldWrapperAttributes(['wire:ignore' => true]);
 
         if ($afterStateUpdated !== null) {
             return $editor->afterStateUpdated($afterStateUpdated);

--- a/app/Filament/Training/Concerns/InteractsWithTrainingConductAutosave.php
+++ b/app/Filament/Training/Concerns/InteractsWithTrainingConductAutosave.php
@@ -14,7 +14,7 @@ trait InteractsWithTrainingConductAutosave
 
     public int $autosaveIdleSeconds = 1;
 
-    public int $autosaveMinInterval = 5;
+    public int $autosaveMinInterval = 3;
 
     public ?int $lastAutosaveAt = null;
 

--- a/resources/views/filament/training/pages/conduct-mentoring-session.blade.php
+++ b/resources/views/filament/training/pages/conduct-mentoring-session.blade.php
@@ -1,5 +1,5 @@
 <x-filament-panels::page>
-	<div wire:poll.5s="autosave"></div>
+	<div wire:poll.2s="autosave"></div>
 	{{ $this->sessionDetailsInfolist }}
 
 	{{ $this->form }}


### PR DESCRIPTION
# Summary of changes
- Sets to live instead of onblur so you don't have to click out of the textbox for it to save
- decreases the polling time from every 5s to 2s

# Screenshots (if necessary)
