### PR TITLE
feat: automatically sync members who have recently had a ban expired

### DIFF
--- a/app/Console/Commands/Members/SyncExpiredBans.php
+++ b/app/Console/Commands/Members/SyncExpiredBans.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands\Members;
+
+use App\Console\Commands\Command;
+use App\Jobs\UpdateMember;
+use App\Models\Mship\Account\Ban;
+use Carbon\Carbon;
+
+class SyncExpiredBans extends Command
+{
+    protected $signature = 'mship:sync-expired-bans';
+
+    protected $description = 'Run an account sync for accounts whose bans have recently expired';
+
+    public function handle(): int
+    {
+        // Look at bans in the last 24 hours
+        $since = Carbon::now()->subHours(24);
+
+        $expiredBans = Ban::isNotRepealed()
+            ->where('period_finish', '>=', $since)
+            ->where('period_finish', '<=', Carbon::now())
+            ->with('account')
+            ->get();
+
+        $syncedCount = 0;
+
+        foreach ($expiredBans as $ban) {
+            $account = $ban->account;
+
+            if (! $account) {
+                continue;
+            }
+
+            UpdateMember::dispatch($account->id);
+            $syncedCount++;
+        }
+
+        $this->log("Dispatched {$syncedCount} account sync(s) for accounts with expired bans in the last 13h.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/Members/SyncExpiredBans.php
+++ b/app/Console/Commands/Members/SyncExpiredBans.php
@@ -37,7 +37,7 @@ class SyncExpiredBans extends Command
             $syncedCount++;
         }
 
-        $this->log("Dispatched {$syncedCount} account sync(s) for accounts with expired bans in the last 13h.");
+        $this->log("Dispatched {$syncedCount} account sync(s) for accounts with expired bans in the last 24 hours.");
 
         return Command::SUCCESS;
     }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -77,6 +77,10 @@ class Kernel extends ConsoleKernel
             ->twiceDaily(2, 14)
             ->graceTimeInMinutes(15);
 
+        $schedule->command('mship:sync-expired-bans')
+            ->twiceDaily(5, 17)
+            ->graceTimeInMinutes(15);
+
         $schedule->command('waiting-lists:create-retention-checks')
             ->dailyAt('07:00')
             ->graceTimeInMinutes(15);

--- a/tests/Unit/Console/Commands/Members/SyncExpiredBansCommandTest.php
+++ b/tests/Unit/Console/Commands/Members/SyncExpiredBansCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console\Commands\Members;
+
+use App\Enums\BanTypeEnum;
+use App\Jobs\UpdateMember;
+use App\Models\Mship\Account;
+use App\Models\Mship\Account\Ban;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Bus;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SyncExpiredBansCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Account $account;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Bus::fake();
+
+        $this->account = Account::factory()->create();
+        Ban::query()->delete();
+    }
+
+    private function createBan(array $attributes): Ban
+    {
+        return Ban::factory()->create(array_merge([
+            'account_id' => $this->account->id,
+            'banned_by' => null,
+            'type' => BanTypeEnum::Local,
+            'reason_id' => null,
+            'repealed_at' => null,
+        ], $attributes));
+    }
+
+    #[Test]
+    public function it_dispatches_sync_jobs_for_accounts_with_recently_expired_bans(): void
+    {
+        $this->createBan([
+            'period_start' => now()->subHours(6),
+            'period_finish' => now()->subHours(2),
+        ]);
+
+        Artisan::call('mship:sync-expired-bans');
+        Bus::assertDispatched(UpdateMember::class, fn ($job) => $job->accountID === $this->account->id);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_for_bans_outside_the_lookback_window(): void
+    {
+        $this->createBan([
+            'period_start' => now()->subDays(2),
+            'period_finish' => now()->subDays(1),
+        ]);
+
+        Artisan::call('mship:sync-expired-bans');
+        Bus::assertNotDispatched(UpdateMember::class);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_for_still_active_bans(): void
+    {
+        $this->createBan([
+            'period_start' => now()->subHours(2),
+            'period_finish' => now()->addHours(2),
+        ]);
+
+        Artisan::call('mship:sync-expired-bans');
+        Bus::assertNotDispatched(UpdateMember::class);
+    }
+}

--- a/tests/Unit/Console/Commands/Members/SyncExpiredBansCommandTest.php
+++ b/tests/Unit/Console/Commands/Members/SyncExpiredBansCommandTest.php
@@ -57,8 +57,8 @@ class SyncExpiredBansCommandTest extends TestCase
     public function it_does_not_dispatch_for_bans_outside_the_lookback_window(): void
     {
         $this->createBan([
-            'period_start' => now()->subDays(2),
-            'period_finish' => now()->subDays(1),
+            'period_start' => now()->subDays(3),
+            'period_finish' => now()->subDays(2),
         ]);
 
         Artisan::call('mship:sync-expired-bans');


### PR DESCRIPTION
# Summary of changes
We often get requests to reinstate someone's access to the discord after a ban has expired, as an account sync has not been run.

- `SyncExpiredBans` will run twice a day at 5:00 and 17:00, look for bans expired in the last 24 hours, and run an account sync on those members

# Screenshots (if necessary)
