### PR TITLE
feat: add email settings to core

### DIFF
--- a/app/Enums/EmailType.php
+++ b/app/Enums/EmailType.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Enums;
+
+enum EmailType: string
+{
+    // Student - Sessions
+    case SessionAcceptedByMentor = 'session_accepted_by_mentor';
+    case SessionCancelledByMentor = 'session_cancelled_by_mentor';
+    case SessionRescheduledByMentor = 'session_rescheduled_by_mentor';
+    case AvailabilityReminder = 'availability_reminder';
+
+    // Student - Exams
+    case ExamAccepted = 'exam_accepted';
+    case ExamCancelled = 'exam_cancelled';
+
+    // Mentor
+    case MentorSessionConfirmation = 'mentor_session_confirmation';
+    case MentorSessionCancelled = 'mentor_session_cancelled';
+    case MentorSessionRescheduled = 'mentor_session_rescheduled';
+
+    // Examiner
+    case ExaminerExamAccepted = 'examiner_exam_accepted';
+    case ExaminerExamCancelled = 'examiner_exam_cancelled';
+
+    public function label(): string
+    {
+        return match ($this) {
+            // Student - Sessions
+            self::SessionAcceptedByMentor => 'Mentor accepts session',
+            self::SessionCancelledByMentor => 'Mentor cancels session',
+            self::SessionRescheduledByMentor => 'Mentor reschedules session',
+            self::AvailabilityReminder => 'Availability reminder',
+
+            // Student - Exams
+            self::ExamAccepted => 'Exam accepted',
+            self::ExamCancelled => 'Exam cancelled',
+
+            // Mentor
+            self::MentorSessionConfirmation => 'Session confirmation',
+            self::MentorSessionCancelled => 'Student cancels session',
+            self::MentorSessionRescheduled => 'Session rescheduled',
+
+            // Examiner
+            self::ExaminerExamAccepted => 'Exam accepted confirmation',
+            self::ExaminerExamCancelled => 'Candidate cancels exam',
+        };
+    }
+
+    public function description(): string
+    {
+        return match ($this) {
+            // Student - Sessions
+            self::SessionAcceptedByMentor => 'Sent when a mentor accepts your session request',
+            self::SessionCancelledByMentor => 'Sent when a mentor cancels your session',
+            self::SessionRescheduledByMentor => 'Sent when a mentor reschedules your session',
+            self::AvailabilityReminder => 'Sent as a reminder when you have no availability set',
+
+            // Student - Exams
+            self::ExamAccepted => 'Sent when an examiner accepts your exam request',
+            self::ExamCancelled => 'Sent when your exam is cancelled',
+
+            // Mentor
+            self::MentorSessionConfirmation => 'Sent when a session you are mentoring is confirmed',
+            self::MentorSessionCancelled => 'Sent when a student cancels their session',
+            self::MentorSessionRescheduled => 'Sent when a session you are mentoring is rescheduled',
+
+            // Examiner
+            self::ExaminerExamAccepted => 'Sent when you accept an exam request',
+            self::ExaminerExamCancelled => 'Sent when a candidate cancels their exam',
+        };
+    }
+
+    public function category(): string
+    {
+        return match ($this) {
+            self::SessionAcceptedByMentor,
+            self::SessionCancelledByMentor,
+            self::SessionRescheduledByMentor,
+            self::AvailabilityReminder,
+            self::ExamAccepted,
+            self::ExamCancelled => 'Student',
+
+            self::MentorSessionConfirmation,
+            self::MentorSessionCancelled,
+            self::MentorSessionRescheduled => 'Mentor',
+
+            self::ExaminerExamAccepted,
+            self::ExaminerExamCancelled => 'Examiner',
+        };
+    }
+
+    public static function forCategory(string $category): array
+    {
+        return array_filter(
+            self::cases(),
+            fn (EmailType $type) => $type->category() === $category
+        );
+    }
+
+    public static function categories(): array
+    {
+        return array_unique(array_map(
+            fn (EmailType $type) => $type->category(),
+            self::cases()
+        ));
+    }
+}

--- a/app/Enums/EmailType.php
+++ b/app/Enums/EmailType.php
@@ -8,7 +8,6 @@ enum EmailType: string
     case SessionAcceptedByMentor = 'session_accepted_by_mentor';
     case SessionCancelledByMentor = 'session_cancelled_by_mentor';
     case SessionRescheduledByMentor = 'session_rescheduled_by_mentor';
-    case AvailabilityReminder = 'availability_reminder';
 
     // Student - Exams
     case ExamAccepted = 'exam_accepted';
@@ -30,7 +29,6 @@ enum EmailType: string
             self::SessionAcceptedByMentor => 'Mentor accepts session',
             self::SessionCancelledByMentor => 'Mentor cancels session',
             self::SessionRescheduledByMentor => 'Mentor reschedules session',
-            self::AvailabilityReminder => 'Availability reminder',
 
             // Student - Exams
             self::ExamAccepted => 'Exam accepted',
@@ -54,7 +52,6 @@ enum EmailType: string
             self::SessionAcceptedByMentor => 'Sent when a mentor accepts your session request',
             self::SessionCancelledByMentor => 'Sent when a mentor cancels your session',
             self::SessionRescheduledByMentor => 'Sent when a mentor reschedules your session',
-            self::AvailabilityReminder => 'Sent as a reminder when you have no availability set',
 
             // Student - Exams
             self::ExamAccepted => 'Sent when an examiner accepts your exam request',
@@ -77,7 +74,6 @@ enum EmailType: string
             self::SessionAcceptedByMentor,
             self::SessionCancelledByMentor,
             self::SessionRescheduledByMentor,
-            self::AvailabilityReminder,
             self::ExamAccepted,
             self::ExamCancelled => 'Student',
 

--- a/app/Enums/EmailType.php
+++ b/app/Enums/EmailType.php
@@ -58,7 +58,7 @@ enum EmailType: string
             self::ExamCancelled => 'Sent when your exam is cancelled',
 
             // Mentor
-            self::MentorSessionConfirmation => 'Sent when a session you are mentoring is confirmed',
+            self::MentorSessionConfirmation => 'Sent when you accept a mentoring session',
             self::MentorSessionCancelled => 'Sent when a student cancels their session',
             self::MentorSessionRescheduled => 'Sent when a session you are mentoring is rescheduled',
 

--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/EndorsementsRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/EndorsementsRelationManager.php
@@ -6,7 +6,7 @@ use App\Models\Atc\Position;
 use App\Models\Atc\PositionGroup;
 use App\Models\Mship\Account\Endorsement;
 use App\Models\Mship\Qualification;
-use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Hidden;
@@ -83,15 +83,7 @@ class EndorsementsRelationManager extends RelationManager
             ->recordActions([
                 EditAction::make()
                     ->visible(fn ($record) => $record->expires_at),
-                Action::make('revoke')
-                    ->label('Revoke')
-                    ->color('danger')
-                    ->requiresConfirmation()
-                    ->icon('heroicon-o-no-symbol')
-                    ->modalHeading('Revoke Endorsement')
-                    ->modalSubmitActionLabel('Revoke')
-                    ->visible(fn (Endorsement $record) => $record->expires_at?->isFuture() ?? true)
-                    ->action(fn (Endorsement $record) => $record->update(['expires_at' => now()->subDay()->toDateString()])),
+                DeleteAction::make(),
             ])
             ->filters([
                 SelectFilter::make('endorsable_type')

--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/EndorsementsRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/EndorsementsRelationManager.php
@@ -6,7 +6,7 @@ use App\Models\Atc\Position;
 use App\Models\Atc\PositionGroup;
 use App\Models\Mship\Account\Endorsement;
 use App\Models\Mship\Qualification;
-use Filament\Actions\DeleteAction;
+use Filament\Actions\Action;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Hidden;
@@ -83,7 +83,15 @@ class EndorsementsRelationManager extends RelationManager
             ->recordActions([
                 EditAction::make()
                     ->visible(fn ($record) => $record->expires_at),
-                DeleteAction::make(),
+                Action::make('revoke')
+                    ->label('Revoke')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-no-symbol')
+                    ->modalHeading('Revoke Endorsement')
+                    ->modalSubmitActionLabel('Revoke')
+                    ->visible(fn (Endorsement $record) => $record->expires_at?->isFuture() ?? true)
+                    ->action(fn (Endorsement $record) => $record->update(['expires_at' => now()->subDay()->toDateString()])),
             ])
             ->filters([
                 SelectFilter::make('endorsable_type')

--- a/app/Filament/Training/Pages/EmailSettings.php
+++ b/app/Filament/Training/Pages/EmailSettings.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Filament\Training\Pages;
+
+use App\Enums\EmailType;
+use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class EmailSettings extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-envelope';
+
+    protected string $view = 'filament.training.pages.email-settings';
+
+    protected static ?string $navigationLabel = 'Email Settings';
+
+    protected static ?string $title = 'Training Email Settings';
+
+    protected static ?string $slug = 'email-settings';
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    public ?array $data = [];
+
+    public static function canAccess(): bool
+    {
+        return auth()->check();
+    }
+
+    public function mount(): void
+    {
+        $account = auth()->user();
+        $settings = $account->emailSettings()->pluck('enabled', 'email_type')->toArray();
+
+        $formData = [];
+        foreach (EmailType::cases() as $type) {
+            $formData[$type->value] = $settings[$type->value] ?? true;
+        }
+
+        $this->form->fill($formData);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->schema($this->buildFormSchema())
+            ->statePath('data');
+    }
+
+    protected function buildFormSchema(): array
+    {
+        $sections = [];
+
+        foreach (EmailType::categories() as $category) {
+            $types = EmailType::forCategory($category);
+            $fields = [];
+
+            foreach ($types as $type) {
+                $fields[] = Checkbox::make($type->value)
+                    ->label($type->label())
+                    ->helperText($type->description())
+                    ->default(true);
+            }
+
+            $sections[] = Section::make($category)
+                ->description("Manage your {$category} email notifications")
+                ->schema([
+                    Grid::make(1)
+                        ->schema($fields),
+                ])
+                ->collapsible();
+        }
+
+        return $sections;
+    }
+
+    public function save(): void
+    {
+        $data = $this->form->getState();
+        $account = auth()->user();
+
+        $account->setEmailPreferences($data);
+
+        Notification::make()
+            ->title('Email settings saved')
+            ->success()
+            ->send();
+    }
+}

--- a/app/Listeners/Mship/CheckEmailPreferences.php
+++ b/app/Listeners/Mship/CheckEmailPreferences.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Listeners\Mship;
+
+use App\Notifications\Contracts\HasEmailType;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Support\Facades\Log;
+
+class CheckEmailPreferences
+{
+    public function handle(NotificationSending $event): bool
+    {
+        $notification = $event->notification;
+        $notifiable = $event->notifiable;
+
+        if (! ($notification instanceof HasEmailType)) {
+            return true;
+        }
+
+        if (! method_exists($notifiable, 'isEmailEnabled')) {
+            return true;
+        }
+
+        $emailType = $notification->getEmailType();
+
+        if (! $notifiable->isEmailEnabled($emailType)) {
+            $notifiableId = method_exists($notifiable, 'getKey') ? $notifiable->getKey() : '?';
+            Log::info("Email suppressed for account {$notifiableId}: {$emailType->value} ({$emailType->label()})");
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -12,6 +12,7 @@ use App\Models\Mship\Concerns\HasBans;
 use App\Models\Mship\Concerns\HasCTSAccount;
 use App\Models\Mship\Concerns\HasDiscordAccount;
 use App\Models\Mship\Concerns\HasEmails;
+use App\Models\Mship\Concerns\HasEmailSettings;
 use App\Models\Mship\Concerns\HasEndorsement;
 use App\Models\Mship\Concerns\HasHelpdeskAccount;
 use App\Models\Mship\Concerns\HasMentoringPermissions;
@@ -229,6 +230,7 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
         HasCTSAccount,
         HasDiscordAccount,
         HasEmails,
+        HasEmailSettings,
         HasEndorsement,
         HasFactory,
         HasHelpdeskAccount,

--- a/app/Models/Mship/Account/EmailSetting.php
+++ b/app/Models/Mship/Account/EmailSetting.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models\Mship\Account;
+
+use App\Enums\EmailType;
+use App\Models\Mship\Account;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EmailSetting extends Model
+{
+    protected $table = 'mship_email_settings';
+
+    protected $fillable = [
+        'account_id',
+        'email_type',
+        'enabled',
+    ];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+    ];
+
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'account_id');
+    }
+
+    public function scopeEnabled($query)
+    {
+        return $query->where('enabled', true);
+    }
+
+    public function scopeForType($query, EmailType $type)
+    {
+        return $query->where('email_type', $type->value);
+    }
+}

--- a/app/Models/Mship/Account/EmailSetting.php
+++ b/app/Models/Mship/Account/EmailSetting.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\Mship\Account;
 
-use App\Enums\EmailType;
 use App\Models\Model;
 use App\Models\Mship\Account;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -24,15 +23,5 @@ class EmailSetting extends Model
     public function account(): BelongsTo
     {
         return $this->belongsTo(Account::class, 'account_id');
-    }
-
-    public function scopeEnabled($query)
-    {
-        return $query->where('enabled', true);
-    }
-
-    public function scopeForType($query, EmailType $type)
-    {
-        return $query->where('email_type', $type->value);
     }
 }

--- a/app/Models/Mship/Account/EmailSetting.php
+++ b/app/Models/Mship/Account/EmailSetting.php
@@ -3,8 +3,8 @@
 namespace App\Models\Mship\Account;
 
 use App\Enums\EmailType;
+use App\Models\Model;
 use App\Models\Mship\Account;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class EmailSetting extends Model

--- a/app/Models/Mship/Concerns/HasEmailSettings.php
+++ b/app/Models/Mship/Concerns/HasEmailSettings.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models\Mship\Concerns;
+
+use App\Enums\EmailType;
+use App\Models\Mship\Account\EmailSetting;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+trait HasEmailSettings
+{
+    public function emailSettings(): HasMany
+    {
+        return $this->hasMany(EmailSetting::class, 'account_id');
+    }
+
+    public function isEmailEnabled(EmailType $type): bool
+    {
+        $setting = $this->emailSettings()
+            ->where('email_type', $type->value)
+            ->first();
+
+        if (! $setting) {
+            return true;
+        }
+
+        return $setting->enabled;
+    }
+
+    public function setEmailEnabled(EmailType $type, bool $enabled): void
+    {
+        if ($enabled) {
+            $this->emailSettings()
+                ->where('email_type', $type->value)
+                ->delete();
+        } else {
+            $this->emailSettings()->updateOrCreate(
+                ['email_type' => $type->value],
+                ['enabled' => false]
+            );
+        }
+    }
+
+    public function setEmailPreferences(array $preferences): void
+    {
+        foreach ($preferences as $key => $enabled) {
+            if ($key instanceof EmailType) {
+                $type = $key;
+            } elseif (is_string($key)) {
+                $type = EmailType::tryFrom($key);
+            } else {
+                continue;
+            }
+
+            if ($type instanceof EmailType) {
+                $this->setEmailEnabled($type, (bool) $enabled);
+            }
+        }
+    }
+}

--- a/app/Notifications/Contracts/HasEmailType.php
+++ b/app/Notifications/Contracts/HasEmailType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Notifications\Contracts;
+
+use App\Enums\EmailType;
+
+interface HasEmailType
+{
+    public function getEmailType(): EmailType;
+}

--- a/app/Notifications/Training/AvailabilityWarningCreated.php
+++ b/app/Notifications/Training/AvailabilityWarningCreated.php
@@ -2,9 +2,7 @@
 
 namespace App\Notifications\Training;
 
-use App\Enums\EmailType;
 use App\Models\Training\TrainingPlace\AvailabilityWarning;
-use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -14,18 +12,13 @@ use Illuminate\Support\Str;
  * This notification is sent to an account when an availability warning is created for their training place.
  * This is deliberately not queued, as it's sent within the same database transaction as creating the warning.
  */
-class AvailabilityWarningCreated extends Notification implements HasEmailType
+class AvailabilityWarningCreated extends Notification
 {
     use Queueable;
 
     public function __construct(public AvailabilityWarning $availabilityWarning)
     {
         //
-    }
-
-    public function getEmailType(): EmailType
-    {
-        return EmailType::AvailabilityReminder;
     }
 
     /**

--- a/app/Notifications/Training/AvailabilityWarningCreated.php
+++ b/app/Notifications/Training/AvailabilityWarningCreated.php
@@ -2,7 +2,9 @@
 
 namespace App\Notifications\Training;
 
+use App\Enums\EmailType;
 use App\Models\Training\TrainingPlace\AvailabilityWarning;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -12,13 +14,18 @@ use Illuminate\Support\Str;
  * This notification is sent to an account when an availability warning is created for their training place.
  * This is deliberately not queued, as it's sent within the same database transaction as creating the warning.
  */
-class AvailabilityWarningCreated extends Notification
+class AvailabilityWarningCreated extends Notification implements HasEmailType
 {
     use Queueable;
 
     public function __construct(public AvailabilityWarning $availabilityWarning)
     {
         //
+    }
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::AvailabilityReminder;
     }
 
     /**

--- a/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
@@ -2,12 +2,14 @@
 
 namespace App\Notifications\Training\Exams;
 
+use App\Enums\EmailType;
 use App\Models\Cts\ExamBooking;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExamAcceptedExaminerNotification extends Notification
+class ExamAcceptedExaminerNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
@@ -15,6 +17,11 @@ class ExamAcceptedExaminerNotification extends Notification
      * Create a new notification instance.
      */
     public function __construct(private ExamBooking $examBooking) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::ExaminerExamAccepted;
+    }
 
     /**
      * Get the notification's delivery channels.

--- a/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
@@ -2,12 +2,14 @@
 
 namespace App\Notifications\Training\Exams;
 
+use App\Enums\EmailType;
 use App\Models\Cts\ExamBooking;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExamAcceptedStudentNotification extends Notification
+class ExamAcceptedStudentNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
@@ -15,6 +17,11 @@ class ExamAcceptedStudentNotification extends Notification
      * Create a new notification instance.
      */
     public function __construct(private ExamBooking $examBooking) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::ExamAccepted;
+    }
 
     /**
      * Get the notification's delivery channels.

--- a/app/Notifications/Training/Exams/ExamCancelledByExaminerStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamCancelledByExaminerStudentNotification.php
@@ -2,13 +2,15 @@
 
 namespace App\Notifications\Training\Exams;
 
+use App\Enums\EmailType;
 use App\Models\Cts\ExamBooking;
 use App\Models\Mship\Account;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExamCancelledByExaminerStudentNotification extends Notification
+class ExamCancelledByExaminerStudentNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
@@ -16,6 +18,11 @@ class ExamCancelledByExaminerStudentNotification extends Notification
         private ExamBooking $examBooking,
         private Account $cancelledByExaminer,
     ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::ExamCancelled;
+    }
 
     /**
      * @return array<int, string>

--- a/app/Notifications/Training/Exams/ExamCancelledExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamCancelledExaminerNotification.php
@@ -2,12 +2,14 @@
 
 namespace App\Notifications\Training\Exams;
 
+use App\Enums\EmailType;
 use App\Models\Cts\ExamBooking;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExamCancelledExaminerNotification extends Notification
+class ExamCancelledExaminerNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
@@ -15,6 +17,11 @@ class ExamCancelledExaminerNotification extends Notification
         private ExamBooking $examBooking,
         private string $reason,
     ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::ExaminerExamCancelled;
+    }
 
     /**
      * @return array<int, string>

--- a/app/Notifications/Training/Exams/ExamCancelledStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamCancelledStudentNotification.php
@@ -2,18 +2,25 @@
 
 namespace App\Notifications\Training\Exams;
 
+use App\Enums\EmailType;
 use App\Models\Cts\ExamBooking;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExamCancelledStudentNotification extends Notification
+class ExamCancelledStudentNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
     public function __construct(
         private ExamBooking $examBooking,
     ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::ExamCancelled;
+    }
 
     public function via(object $notifiable): array
     {

--- a/app/Notifications/Training/Exams/ExamSessionCancelledForCoExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamSessionCancelledForCoExaminerNotification.php
@@ -2,13 +2,15 @@
 
 namespace App\Notifications\Training\Exams;
 
+use App\Enums\EmailType;
 use App\Models\Cts\ExamBooking;
 use App\Models\Mship\Account;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExamSessionCancelledForCoExaminerNotification extends Notification
+class ExamSessionCancelledForCoExaminerNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
@@ -16,6 +18,11 @@ class ExamSessionCancelledForCoExaminerNotification extends Notification
         private ExamBooking $examBooking,
         private Account $cancelledByExaminer,
     ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::ExaminerExamCancelled;
+    }
 
     /**
      * @return array<int, string>

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
@@ -2,16 +2,23 @@
 
 namespace App\Notifications\Training\Mentoring;
 
+use App\Enums\EmailType;
 use App\Models\Cts\Session;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class MentoringSessionAcceptedMentorNotification extends Notification
+class MentoringSessionAcceptedMentorNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
     public function __construct(private Session $session) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::MentorSessionConfirmation;
+    }
 
     /**
      * @return array<int, string>

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
@@ -2,16 +2,23 @@
 
 namespace App\Notifications\Training\Mentoring;
 
+use App\Enums\EmailType;
 use App\Models\Cts\Session;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class MentoringSessionAcceptedStudentNotification extends Notification
+class MentoringSessionAcceptedStudentNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
     public function __construct(private Session $session) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::SessionAcceptedByMentor;
+    }
 
     /**
      * @return array<int, string>

--- a/app/Notifications/Training/Mentoring/MentoringSessionCancelledMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionCancelledMentorNotification.php
@@ -2,12 +2,14 @@
 
 namespace App\Notifications\Training\Mentoring;
 
+use App\Enums\EmailType;
 use App\Models\Cts\Session;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class MentoringSessionCancelledMentorNotification extends Notification
+class MentoringSessionCancelledMentorNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
@@ -15,6 +17,11 @@ class MentoringSessionCancelledMentorNotification extends Notification
         private Session $session,
         private string $reason,
     ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::MentorSessionCancelled;
+    }
 
     /**
      * @return array<int, string>

--- a/app/Notifications/Training/Mentoring/MentoringSessionCancelledStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionCancelledStudentNotification.php
@@ -2,13 +2,15 @@
 
 namespace App\Notifications\Training\Mentoring;
 
+use App\Enums\EmailType;
 use App\Models\Cts\Session;
 use App\Models\Mship\Account;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class MentoringSessionCancelledStudentNotification extends Notification
+class MentoringSessionCancelledStudentNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
@@ -17,6 +19,11 @@ class MentoringSessionCancelledStudentNotification extends Notification
         private Account $cancelledByMentor,
         private string $reason,
     ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::SessionCancelledByMentor;
+    }
 
     /**
      * @return array<int, string>

--- a/app/Notifications/Training/Mentoring/MentoringSessionRescheduledMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionRescheduledMentorNotification.php
@@ -2,12 +2,14 @@
 
 namespace App\Notifications\Training\Mentoring;
 
+use App\Enums\EmailType;
 use App\Models\Cts\Session;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class MentoringSessionRescheduledMentorNotification extends Notification
+class MentoringSessionRescheduledMentorNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
@@ -15,6 +17,11 @@ class MentoringSessionRescheduledMentorNotification extends Notification
         private Session $session,
         private string $previousDateTime,
     ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::MentorSessionRescheduled;
+    }
 
     /**
      * @return array<int, string>

--- a/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
@@ -2,12 +2,14 @@
 
 namespace App\Notifications\Training\Mentoring;
 
+use App\Enums\EmailType;
 use App\Models\Cts\Session;
+use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class MentoringSessionRescheduledStudentNotification extends Notification
+class MentoringSessionRescheduledStudentNotification extends Notification implements HasEmailType
 {
     use Queueable;
 
@@ -15,6 +17,11 @@ class MentoringSessionRescheduledStudentNotification extends Notification
         private Session $session,
         private string $previousDateTime,
     ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::SessionRescheduledByMentor;
+    }
 
     /**
      * @return array<int, string>

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -6,7 +6,9 @@ use App\Events\Discord\DiscordLinked;
 use App\Events\Discord\DiscordUnlinked;
 use App\Listeners\Discord\RemoveDiscordUser;
 use App\Listeners\Discord\SetupDiscordUser;
+use App\Listeners\Mship\CheckEmailPreferences;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Notifications\Events\NotificationSending;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -72,6 +74,10 @@ class EventServiceProvider extends ServiceProvider
         ],
         \App\Events\Mship\Endorsement\PositionEndorsementAdded::class => [
             \App\Listeners\Mship\Endorsement\NotifyOfPositionEndorsement::class,
+        ],
+
+        NotificationSending::class => [
+            CheckEmailPreferences::class,
         ],
     ];
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -75,11 +75,11 @@ class EventServiceProvider extends ServiceProvider
         \App\Events\Mship\Endorsement\PositionEndorsementAdded::class => [
             \App\Listeners\Mship\Endorsement\NotifyOfPositionEndorsement::class,
         ],
-      
+
         NotificationSending::class => [
             CheckEmailPreferences::class,
         ],
-      
+
         \App\Events\NetworkData\AtcSessionStarted::class => [
             \App\Listeners\TeamSpeak\AssignAtcServerGroup::class,
         ],

--- a/app/Providers/Filament/TrainingPanelProvider.php
+++ b/app/Providers/Filament/TrainingPanelProvider.php
@@ -3,10 +3,12 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Training\Pages\Dashboard;
+use App\Filament\Training\Pages\EmailSettings;
 use App\Filament\Widgets\AccountInfoWidget;
 use App\Http\Middleware\MandatoryTwoFactor;
 use App\Http\Middleware\TrackInactivity;
 use App\Http\Middleware\TrainingPanelAccessMiddleware;
+use Filament\Actions\Action;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -35,6 +37,7 @@ class TrainingPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Training/Pages'), for: 'App\\Filament\\Training\\Pages')
             ->pages([
                 Dashboard::class,
+                EmailSettings::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Training/Widgets'), for: 'App\\Filament\\Training\\Widgets')
             ->widgets([
@@ -71,6 +74,11 @@ class TrainingPanelProvider extends PanelProvider
                     ->url(fn () => route('filament.app.pages.dashboard'))
                     ->icon('heroicon-o-briefcase')
                     ->visible(fn () => request()->user()->hasPermissionTo('admin.access')),
+            ])
+            ->userMenuItems([
+                Action::make('Email Settings')
+                    ->url(fn () => route('filament.training.pages.email-settings'))
+                    ->icon('heroicon-m-envelope'),
             ])
             ->viteTheme('resources/assets/css/tailwind.css')
             ->renderHook(

--- a/database/migrations/2026_06_04_000001_create_email_settings_table.php
+++ b/database/migrations/2026_06_04_000001_create_email_settings_table.php
@@ -22,6 +22,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('email_settings');
+        Schema::dropIfExists('mship_email_settings');
     }
 };

--- a/database/migrations/2026_06_04_000001_create_email_settings_table.php
+++ b/database/migrations/2026_06_04_000001_create_email_settings_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mship_email_settings', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('account_id');
+            $table->string('email_type', 100);
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['account_id', 'email_type']);
+            $table->foreign('account_id')->references('id')->on('mship_account')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('email_settings');
+    }
+};

--- a/database/migrations/2026_06_04_000002_migrate_cts_email_settings_to_core.php
+++ b/database/migrations/2026_06_04_000002_migrate_cts_email_settings_to_core.php
@@ -1,0 +1,91 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $cts = DB::connection('cts');
+
+        $rtsMapping = [
+            'stu_seshacc' => 'session_accepted_by_mentor',
+            'stu_seshcancel' => 'session_cancelled_by_mentor',
+            'stu_examacc' => 'exam_accepted',
+            'stu_examcancel' => 'exam_cancelled',
+            'men_seshcancel' => 'mentor_session_cancelled',
+        ];
+
+        $genMapping = [
+            'exam_conf' => 'examiner_exam_accepted',
+            'exam_cancel' => 'examiner_exam_cancelled',
+        ];
+
+        $rows = [];
+
+        $rtsRows = $cts->table('email_settings_rts')
+            ->join('members', 'members.id', '=', 'email_settings_rts.member_id')
+            ->select('members.cid as account_id', 'email_settings_rts.*')
+            ->get();
+
+        foreach ($rtsRows as $row) {
+            if (! $row->account_id) {
+                continue;
+            }
+
+            foreach ($rtsMapping as $ctsField => $emailType) {
+                if (! isset($row->$ctsField)) {
+                    continue;
+                }
+
+                if ($row->$ctsField == 0) {
+                    $rows[] = [
+                        'account_id' => $row->account_id,
+                        'email_type' => $emailType,
+                        'enabled' => false,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ];
+                }
+            }
+        }
+
+        $genRows = $cts->table('email_settings_gen')
+            ->join('members', 'members.id', '=', 'email_settings_gen.member_id')
+            ->select('members.cid as account_id', 'email_settings_gen.*')
+            ->get();
+
+        foreach ($genRows as $row) {
+            if (! $row->account_id) {
+                continue;
+            }
+
+            foreach ($genMapping as $ctsField => $emailType) {
+                if (! isset($row->$ctsField)) {
+                    continue;
+                }
+
+                if ($row->$ctsField == 0) {
+                    $rows[] = [
+                        'account_id' => $row->account_id,
+                        'email_type' => $emailType,
+                        'enabled' => false,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ];
+                }
+            }
+        }
+
+        // Chunk insert to avoid memory issues
+        $chunks = array_chunk($rows, 500);
+
+        foreach ($chunks as $chunk) {
+            DB::table('mship_email_settings')->insertOrIgnore($chunk);
+        }
+
+        Log::info('CTS email settings migrated, '.count($rows).' preferences disabled.');
+    }
+};

--- a/database/migrations/2026_06_04_000002_migrate_cts_email_settings_to_core.php
+++ b/database/migrations/2026_06_04_000002_migrate_cts_email_settings_to_core.php
@@ -23,69 +23,64 @@ return new class extends Migration
             'exam_cancel' => 'examiner_exam_cancelled',
         ];
 
-        $rows = [];
+        $total = 0;
+        $buffer = [];
+        $chunkSize = 500;
 
-        $rtsRows = $cts->table('email_settings_rts')
-            ->join('members', 'members.id', '=', 'email_settings_rts.member_id')
-            ->select('members.cid as account_id', 'email_settings_rts.*')
-            ->get();
-
-        foreach ($rtsRows as $row) {
-            if (! $row->account_id) {
-                continue;
+        $flush = function () use (&$buffer, &$total) {
+            if (empty($buffer)) {
+                return;
             }
 
-            foreach ($rtsMapping as $ctsField => $emailType) {
-                if (! isset($row->$ctsField)) {
+            DB::table('mship_email_settings')->insertOrIgnore($buffer);
+            $total += count($buffer);
+            $buffer = [];
+        };
+
+        $process = function (iterable $rows, array $mapping) use (&$buffer, &$total, $chunkSize, $flush) {
+            foreach ($rows as $row) {
+                if (! $row->account_id) {
                     continue;
                 }
 
-                if ($row->$ctsField == 0) {
-                    $rows[] = [
+                foreach ($mapping as $ctsField => $emailType) {
+                    if (! isset($row->$ctsField) || $row->$ctsField != 0) {
+                        continue;
+                    }
+
+                    $buffer[] = [
                         'account_id' => $row->account_id,
                         'email_type' => $emailType,
                         'enabled' => false,
                         'created_at' => now(),
                         'updated_at' => now(),
                     ];
+
+                    if (count($buffer) >= $chunkSize) {
+                        $flush();
+                    }
                 }
             }
-        }
+        };
 
-        $genRows = $cts->table('email_settings_gen')
-            ->join('members', 'members.id', '=', 'email_settings_gen.member_id')
-            ->select('members.cid as account_id', 'email_settings_gen.*')
-            ->get();
+        $process(
+            $cts->table('email_settings_rts')
+                ->join('members', 'members.id', '=', 'email_settings_rts.member_id')
+                ->select('members.cid as account_id', 'email_settings_rts.*')
+                ->cursor(),
+            $rtsMapping
+        );
 
-        foreach ($genRows as $row) {
-            if (! $row->account_id) {
-                continue;
-            }
+        $process(
+            $cts->table('email_settings_gen')
+                ->join('members', 'members.id', '=', 'email_settings_gen.member_id')
+                ->select('members.cid as account_id', 'email_settings_gen.*')
+                ->cursor(),
+            $genMapping
+        );
 
-            foreach ($genMapping as $ctsField => $emailType) {
-                if (! isset($row->$ctsField)) {
-                    continue;
-                }
+        $flush();
 
-                if ($row->$ctsField == 0) {
-                    $rows[] = [
-                        'account_id' => $row->account_id,
-                        'email_type' => $emailType,
-                        'enabled' => false,
-                        'created_at' => now(),
-                        'updated_at' => now(),
-                    ];
-                }
-            }
-        }
-
-        // Chunk insert to avoid memory issues
-        $chunks = array_chunk($rows, 500);
-
-        foreach ($chunks as $chunk) {
-            DB::table('mship_email_settings')->insertOrIgnore($chunk);
-        }
-
-        Log::info('CTS email settings migrated, '.count($rows).' preferences disabled.');
+        Log::info("CTS email settings migrated, {$total} preferences disabled.");
     }
 };

--- a/resources/views/filament/training/pages/email-settings.blade.php
+++ b/resources/views/filament/training/pages/email-settings.blade.php
@@ -1,0 +1,11 @@
+<x-filament-panels::page>
+    <form wire:submit="save">
+        {{ $this->form }}
+
+        <div class="mt-6 flex justify-end">
+            <x-filament::button type="submit">
+                Save Settings
+            </x-filament::button>
+        </div>
+    </form>
+</x-filament-panels::page>

--- a/resources/views/filament/training/pages/email-settings.blade.php
+++ b/resources/views/filament/training/pages/email-settings.blade.php
@@ -1,11 +1,11 @@
 <x-filament-panels::page>
-    <form wire:submit="save">
-        {{ $this->form }}
+	<form wire:submit="save">
+		{{ $this->form }}
 
-        <div class="mt-6 flex justify-end">
-            <x-filament::button type="submit">
-                Save Settings
-            </x-filament::button>
-        </div>
-    </form>
+		<div class="mt-6 flex justify-end">
+			<x-filament::button type="submit">
+				Save Settings
+			</x-filament::button>
+		</div>
+	</form>
 </x-filament-panels::page>

--- a/tests/Database/MockCtsDatabase.php
+++ b/tests/Database/MockCtsDatabase.php
@@ -549,6 +549,50 @@ class MockCtsDatabase
             PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"
         );
+
+        DB::connection('cts')->statement(
+            "CREATE TABLE `email_settings_rts` (
+            `id` smallint unsigned NOT NULL AUTO_INCREMENT,
+            `member_id` int unsigned NOT NULL DEFAULT '0',
+            `rts_id` smallint unsigned NOT NULL DEFAULT '0',
+            `stu_seshconf` tinyint unsigned NOT NULL DEFAULT '1',
+            `stu_groupseshconf` tinyint unsigned NOT NULL DEFAULT '1',
+            `stu_seshacc` tinyint unsigned NOT NULL DEFAULT '1',
+            `stu_seshcancel` tinyint unsigned NOT NULL DEFAULT '1',
+            `stu_seshfail` tinyint unsigned NOT NULL DEFAULT '1',
+            `stu_avail` tinyint unsigned NOT NULL DEFAULT '1',
+            `stu_examconf` tinyint unsigned NOT NULL DEFAULT '1',
+            `stu_examacc` tinyint unsigned NOT NULL DEFAULT '1',
+            `stu_examcancel` tinyint unsigned NOT NULL DEFAULT '1',
+            `stu_examfail` tinyint unsigned NOT NULL DEFAULT '1',
+            `men_newsesh` tinyint unsigned NOT NULL DEFAULT '1',
+            `men_seshconf` tinyint unsigned NOT NULL DEFAULT '1',
+            `men_seshcancel` tinyint unsigned NOT NULL DEFAULT '1',
+            `men_seshfail` tinyint unsigned NOT NULL DEFAULT '1',
+            `rtsm_join` tinyint unsigned NOT NULL DEFAULT '1',
+            `updated` datetime DEFAULT NULL,
+            PRIMARY KEY (`id`),
+            KEY `member_id` (`member_id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"
+        );
+
+        DB::connection('cts')->statement(
+            "CREATE TABLE `email_settings_gen` (
+            `id` smallint unsigned NOT NULL AUTO_INCREMENT,
+            `member_id` int unsigned NOT NULL DEFAULT '0',
+            `exam_new` tinyint unsigned NOT NULL DEFAULT '0',
+            `exam_conf` tinyint unsigned NOT NULL DEFAULT '0',
+            `exam_cancel` tinyint unsigned NOT NULL DEFAULT '0',
+            `exam_fail` tinyint unsigned NOT NULL DEFAULT '0',
+            `exam_fwd` tinyint unsigned NOT NULL DEFAULT '0',
+            `adm_unver` tinyint unsigned NOT NULL DEFAULT '0',
+            `adm_treex` tinyint unsigned NOT NULL DEFAULT '0',
+            `mem_hrts` tinyint(1) NOT NULL DEFAULT '0',
+            `updated` datetime DEFAULT NULL,
+            PRIMARY KEY (`id`),
+            KEY `member_id` (`member_id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"
+        );
     }
 
     public static function destroy()
@@ -646,5 +690,7 @@ class MockCtsDatabase
         DB::connection('cts')->statement('DROP TABLE IF EXISTS `prog_sheet_fields`;');
         DB::connection('cts')->statement('DROP TABLE IF EXISTS `report_sheet`;');
         DB::connection('cts')->statement('DROP TABLE IF EXISTS `report_notes`;');
+        DB::connection('cts')->statement('DROP TABLE IF EXISTS `email_settings_rts`;');
+        DB::connection('cts')->statement('DROP TABLE IF EXISTS `email_settings_gen`;');
     }
 }

--- a/tests/Feature/TrainingPanel/EmailSettings/EmailSettingsTest.php
+++ b/tests/Feature/TrainingPanel/EmailSettings/EmailSettingsTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature\TrainingPanel\EmailSettings;
+
+use App\Enums\EmailType;
+use App\Filament\Training\Pages\EmailSettings;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class EmailSettingsTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    private function buildFormData(array $overrides = []): array
+    {
+        $data = [];
+        foreach (EmailType::cases() as $type) {
+            $data[$type->value] = true;
+        }
+
+        return array_merge($data, $overrides);
+    }
+
+    #[Test]
+    public function it_renders_for_authenticated_user(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_defaults_every_checkbox_to_checked_for_new_users(): void
+    {
+        $this->assertCount(0, $this->panelUser->fresh()->emailSettings);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class);
+
+        foreach (EmailType::cases() as $type) {
+            $component->assertSet("data.{$type->value}", true);
+        }
+    }
+
+    #[Test]
+    public function it_pre_fills_disabled_types_as_unchecked(): void
+    {
+        $this->panelUser->setEmailEnabled(EmailType::ExamAccepted, false);
+        $this->panelUser->setEmailEnabled(EmailType::ExamCancelled, false);
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class);
+
+        $component->assertSet('data.exam_accepted', false);
+        $component->assertSet('data.exam_cancelled', false);
+        $component->assertSet('data.session_accepted_by_mentor', true);
+    }
+
+    #[Test]
+    public function submitting_with_all_checked_clears_all_rows(): void
+    {
+        $this->panelUser->setEmailEnabled(EmailType::ExamAccepted, false);
+        $this->panelUser->setEmailEnabled(EmailType::SessionAcceptedByMentor, false);
+        $this->assertCount(2, $this->panelUser->fresh()->emailSettings);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->set('data', $this->buildFormData())
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertCount(0, $this->panelUser->fresh()->emailSettings);
+    }
+
+    #[Test]
+    public function submitting_with_one_unchecked_creates_one_row(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->set('data', $this->buildFormData(['exam_accepted' => false]))
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertCount(1, $this->panelUser->fresh()->emailSettings);
+        $this->assertDatabaseHas('mship_email_settings', [
+            'account_id' => $this->panelUser->id,
+            'email_type' => 'exam_accepted',
+            'enabled' => false,
+        ]);
+    }
+
+    #[Test]
+    public function submitting_then_resubmitting_all_checked_removes_rows(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->set('data', $this->buildFormData(['exam_accepted' => false, 'exam_cancelled' => false]))
+            ->call('save');
+
+        $this->assertCount(2, $this->panelUser->fresh()->emailSettings);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->set('data', $this->buildFormData())
+            ->call('save');
+
+        $this->assertCount(0, $this->panelUser->fresh()->emailSettings);
+    }
+
+    #[Test]
+    public function submitting_a_known_active_type_persists_correctly(): void
+    {
+        $formData = $this->buildFormData();
+        $formData['session_cancelled_by_mentor'] = false;
+
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->set('data', $formData)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('mship_email_settings', [
+            'account_id' => $this->panelUser->id,
+            'email_type' => 'session_cancelled_by_mentor',
+            'enabled' => false,
+        ]);
+
+        $this->assertDatabaseMissing('mship_email_settings', [
+            'account_id' => $this->panelUser->id,
+            'email_type' => 'exam_accepted',
+        ]);
+    }
+
+    #[Test]
+    public function it_persists_only_falses_even_after_multiple_saves(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->set('data', $this->buildFormData(['exam_accepted' => false, 'session_accepted_by_mentor' => false]))
+            ->call('save');
+
+        $this->assertCount(2, $this->panelUser->fresh()->emailSettings);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->set('data', $this->buildFormData([
+                'exam_accepted' => false,
+                'session_accepted_by_mentor' => false,
+                'session_cancelled_by_mentor' => false,
+            ]))
+            ->call('save');
+
+        $this->assertCount(3, $this->panelUser->fresh()->emailSettings);
+    }
+
+    #[Test]
+    public function re_enabling_a_previously_disabled_type_deletes_its_row(): void
+    {
+        $this->panelUser->setEmailEnabled(EmailType::ExamAccepted, false);
+        $this->assertCount(1, $this->panelUser->fresh()->emailSettings);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->set('data', $this->buildFormData(['exam_accepted' => true]))
+            ->call('save');
+
+        $this->assertCount(0, $this->panelUser->fresh()->emailSettings);
+    }
+
+    #[Test]
+    public function saving_only_persists_data_for_active_enum_cases(): void
+    {
+        $formData = $this->buildFormData();
+        $formData['not_a_real_type'] = false;
+
+        Livewire::actingAs($this->panelUser)
+            ->test(EmailSettings::class)
+            ->set('data', $formData)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertCount(0, $this->panelUser->fresh()->emailSettings);
+    }
+}

--- a/tests/Unit/Listeners/Mship/CheckEmailPreferencesTest.php
+++ b/tests/Unit/Listeners/Mship/CheckEmailPreferencesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit\Listeners\Mship;
+
+use App\Enums\EmailType;
+use App\Listeners\Mship\CheckEmailPreferences;
+use App\Models\Mship\Account;
+use App\Notifications\Contracts\HasEmailType;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Notifications\Notification;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CheckEmailPreferencesTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private CheckEmailPreferences $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->listener = new CheckEmailPreferences;
+    }
+
+    private function buildEvent(object $notifiable, Notification $notification): NotificationSending
+    {
+        return new NotificationSending(
+            $notifiable,
+            $notification,
+            'mail'
+        );
+    }
+
+    #[Test]
+    public function it_returns_true_for_notifications_without_email_type(): void
+    {
+        $account = Account::factory()->create();
+        $notification = new class extends Notification
+        {
+            public function via($notifiable)
+            {
+                return ['mail'];
+            }
+        };
+
+        $result = $this->listener->handle($this->buildEvent($account, $notification));
+
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function it_returns_true_when_email_is_enabled(): void
+    {
+        $account = Account::factory()->create();
+        $notification = $this->notificationFor(EmailType::ExamAccepted);
+
+        $result = $this->listener->handle($this->buildEvent($account, $notification));
+
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function it_returns_false_when_email_is_disabled(): void
+    {
+        $account = Account::factory()->create();
+        $account->setEmailEnabled(EmailType::ExamAccepted, false);
+
+        $notification = $this->notificationFor(EmailType::ExamAccepted);
+
+        $result = $this->listener->handle($this->buildEvent($account, $notification));
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function it_returns_true_when_notifiable_lacks_is_email_enabled_method(): void
+    {
+        $notifiable = new class
+        {
+            // No isEmailEnabled method
+        };
+        $notification = $this->notificationFor(EmailType::ExamAccepted);
+
+        $result = $this->listener->handle($this->buildEvent($notifiable, $notification));
+
+        $this->assertTrue($result);
+    }
+
+    private function notificationFor(EmailType $type): Notification
+    {
+        return new class($type) extends Notification implements HasEmailType
+        {
+            public function __construct(private EmailType $type) {}
+
+            public function getEmailType(): EmailType
+            {
+                return $this->type;
+            }
+
+            public function via($notifiable)
+            {
+                return ['mail'];
+            }
+        };
+    }
+}


### PR DESCRIPTION
# Summary of changes
Replicates the email settings logic of the cts on core.

- Uses `mship_email_settings` table to store preferences (only stores where users have opted out of an email)
- `EmailType` enum holds all email types that you can opt out of
- Notifications can be assigned a `EmailType`, which will then make them automatically follow the users preferences
- Notifications without an email type are always sent

# Screenshots (if necessary)
<img width="243" height="197" alt="image" src="https://github.com/user-attachments/assets/2826d0eb-3384-4164-bfb3-b31432ea7cb2" />
<img width="1123" height="1299" alt="image" src="https://github.com/user-attachments/assets/ac82c2dc-a4a3-4813-83a2-d9d5405c81de" />
