### PR TITLE
fix: hide session report section if there is no session data 

### DIFF
--- a/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
+++ b/app/Filament/Training/Pages/Mentor/ViewMentoringReport.php
@@ -295,7 +295,8 @@ class ViewMentoringReport extends Page implements HasInfolists
         return $schema->record($this->session)->components([
             Section::make('Session Report')
                 ->columnSpanFull()
-                ->schema(count($categorySections) > 0 ? $categorySections : [TextEntry::make('empty')->label('')->state('No report data found for this session.')]),
+                ->visible(count($categorySections) > 0)
+                ->schema($categorySections),
         ]);
     }
 

--- a/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
@@ -593,28 +593,6 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
-    public function test_by_criteria_tab_returns_empty_state_when_no_sessions_have_report_sheets(): void
-    {
-        $newStudent = Account::factory()->create();
-        $newMember = Member::factory()->create([
-            'id' => $newStudent->id,
-            'cid' => $newStudent->id,
-        ]);
-
-        $bareSession = Session::factory()->create([
-            'student_id' => $newMember->id,
-            'mentor_id' => $this->mentorMember->id,
-            'position' => 'EGLL_APP',
-            'taken_date' => '2025-05-01',
-            'filed' => now(),
-        ]);
-
-        Livewire::actingAs($newStudent)
-            ->test(ViewMentoringReport::class, ['sessionId' => $bareSession->id])
-            ->assertSee('No report data found for this session.');
-    }
-
-    #[Test]
     public function test_it_displays_session_cancelled_callout_with_correct_details(): void
     {
         $cancellingMember = Member::factory()->create(['name' => 'John Doe']);


### PR DESCRIPTION
# Summary of changes
- hide session report section if there is no session data 

# Screenshots (if necessary)
Before:
<img width="1312" height="829" alt="image" src="https://github.com/user-attachments/assets/79045b6b-3cbb-438a-a4ff-d7017cd985b6" />

After:
<img width="1301" height="679" alt="image" src="https://github.com/user-attachments/assets/d690d1d4-e44a-4215-97b8-a819edf9559f" />
