### PR TITLE
fix: add colours to mobile availability chart

### DIFF
--- a/resources/views/livewire/training/availability-gantt-mobile.blade.php
+++ b/resources/views/livewire/training/availability-gantt-mobile.blade.php
@@ -17,9 +17,18 @@
 						<div class="text-[10px] text-gray-500 dark:text-gray-400">
 							{{ $student->cid }}
 						</div>
+						@php
+							$isAllCategories = empty($category);
+							$badgeColor = $isAllCategories
+								? \App\Filament\Training\Support\MentoringTrainingGroupBadgeColor::forCtsCallsign(
+									$student->pending_position,
+								)
+								: 'gray';
+						@endphp
+
 						@if ($student->pending_position)
 							<div class="mt-0.5">
-								<x-filament::badge color="gray" size="sm">
+								<x-filament::badge :color="$badgeColor" size="sm">
 									{{ $student->pending_position }}
 								</x-filament::badge>
 							</div>

--- a/resources/views/livewire/training/availability-gantt-mobile.blade.php
+++ b/resources/views/livewire/training/availability-gantt-mobile.blade.php
@@ -20,10 +20,8 @@
 						@php
 							$isAllCategories = empty($category);
 							$badgeColor = $isAllCategories
-								? \App\Filament\Training\Support\MentoringTrainingGroupBadgeColor::forCtsCallsign(
-									$student->pending_position,
-								)
-								: 'gray';
+							    ? \App\Filament\Training\Support\MentoringTrainingGroupBadgeColor::forCtsCallsign($student->pending_position)
+							    : 'gray';
 						@endphp
 
 						@if ($student->pending_position)


### PR DESCRIPTION
# Summary of changes
- Adds colours to mobile availability chart

# Screenshots (if necessary)
<img width="463" height="237" alt="image" src="https://github.com/user-attachments/assets/9e3e2a0a-67a6-45d3-98e6-fdcfca59e365" />
