### PR TITLE
feat: notify relevant ATC Training Staff when a training place offer is rejected

### DIFF
--- a/app/Notifications/Training/TrainingPlaceOfferDeclined.php
+++ b/app/Notifications/Training/TrainingPlaceOfferDeclined.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications\Training;
+
+use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+use App\Notifications\DiscordNotification;
+use App\Notifications\DiscordNotificationChannel;
+use App\Notifications\Notification;
+
+class TrainingPlaceOfferDeclined extends Notification implements DiscordNotification
+{
+    public function __construct(public TrainingPlaceOffer $trainingPlaceOffer) {}
+
+    public function via($notifiable): array
+    {
+        $channels = [];
+
+        if (! empty($this->getChannel())) {
+            $channels[] = DiscordNotificationChannel::class;
+        }
+
+        return $channels;
+    }
+
+    public function toDiscord($notifiable)
+    {
+        $position = $this->trainingPlaceOffer->trainingPosition->position;
+
+        return [
+            'content' => null,
+            'embeds' => [
+                [
+                    'title' => 'Training Place Offer Declined',
+                    'description' => "**{$notifiable->name} ({$notifiable->id})** has declined the training place offer for **{$position->name} ({$position->callsign})**.",
+                    'color' => 15158332,
+                    'timestamp' => now()->toIso8601String(),
+                ],
+            ],
+        ];
+    }
+
+    public function getChannel(): string
+    {
+        return $this->trainingPlaceOffer->trainingPosition?->training_team_discord_channel_id ?? '';
+    }
+}

--- a/app/Services/Training/TrainingPlaceOfferService.php
+++ b/app/Services/Training/TrainingPlaceOfferService.php
@@ -8,6 +8,7 @@ use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList\Removal;
 use App\Models\Training\WaitingList\RemovalReason;
 use App\Models\Training\WaitingList\WaitingListAccount;
+use App\Notifications\Training\TrainingPlaceOfferDeclined;
 use App\Notifications\Training\TrainingPlaceOffered;
 use App\Notifications\Training\TrainingPlaceOfferRescinded;
 use App\Notifications\Training\TrainingPlaceOfferRescindedAndRemoved;
@@ -63,6 +64,8 @@ class TrainingPlaceOfferService
                 'training',
                 "The member declined a training place offer for {$trainingPlaceOffer->trainingPosition->position->callsign}. Member removed from waiting list."
             );
+
+            $trainingPlaceOffer->waitingListAccount->account->notify(new TrainingPlaceOfferDeclined($trainingPlaceOffer));
         });
     }
 

--- a/tests/Feature/Training/TrainingPlace/TrainingPlaceOfferFlowTest.php
+++ b/tests/Feature/Training/TrainingPlace/TrainingPlaceOfferFlowTest.php
@@ -108,6 +108,10 @@ class TrainingPlaceOfferFlowTest extends TestCase
 
         $offer = TrainingPlaceOffer::where('waiting_list_account_id', $this->waitingListAccount->id)->firstOrFail();
 
+        $this->trainingPosition->update([
+            'training_team_discord_channel_id' => '123456789',
+        ]);
+
         Carbon::setTestNow($this->offerTime->copy()->addHours(12));
 
         $this->actingAs($this->student)

--- a/tests/Feature/Training/TrainingPlace/TrainingPlaceOfferFlowTest.php
+++ b/tests/Feature/Training/TrainingPlace/TrainingPlaceOfferFlowTest.php
@@ -13,6 +13,7 @@ use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
 use App\Models\Training\WaitingList\WaitingListAccount;
+use App\Notifications\Training\TrainingPlaceOfferDeclined;
 use App\Notifications\Training\TrainingPlaceOffered;
 use App\Notifications\Training\TrainingPlaceOfferRescinded;
 use App\Notifications\Training\TrainingPlaceOfferRescindedAndRemoved;
@@ -116,6 +117,7 @@ class TrainingPlaceOfferFlowTest extends TestCase
 
         $this->assertEquals(TrainingPlaceOfferStatus::Declined, $offer->fresh()->status);
         $this->assertNotNull($offer->fresh()->response_at);
+        Notification::assertSentTo($this->student, TrainingPlaceOfferDeclined::class);
 
         $this->assertDatabaseMissing('training_places', [
             'waiting_list_account_id' => $this->waitingListAccount->id,

--- a/tests/Unit/Notifications/Training/TrainingPlaceOfferDeclinedNotificationTest.php
+++ b/tests/Unit/Notifications/Training/TrainingPlaceOfferDeclinedNotificationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications\Training;
+
+use App\Models\Atc\Position;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Models\Training\WaitingList;
+use App\Notifications\DiscordNotificationChannel;
+use App\Notifications\Training\TrainingPlaceOfferDeclined;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TrainingPlaceOfferDeclinedNotificationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Account $account;
+
+    private TrainingPlaceOffer $offer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $ctsMember = Member::factory()->create();
+        $this->account = Account::factory()->create(['id' => $ctsMember->cid]);
+
+        $waitingList = WaitingList::factory()->create(['name' => 'Test Waiting List']);
+        $waitingListAccount = $waitingList->addToWaitingList($this->account, Account::factory()->create());
+
+        $position = Position::factory()->create(['name' => 'EGLL Tower', 'callsign' => 'EGLL_TWR']);
+        $trainingPosition = TrainingPosition::factory()->create([
+            'position_id' => $position->id,
+            'cts_positions' => [],
+            'training_team_discord_channel_id' => null,
+        ]);
+
+        $this->offer = TrainingPlaceOffer::factory()->create([
+            'waiting_list_account_id' => $waitingListAccount->id,
+            'training_position_id' => $trainingPosition->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_includes_discord_channel_in_via_if_channel_id_is_set(): void
+    {
+        $this->offer->trainingPosition->update([
+            'training_team_discord_channel_id' => '123456789',
+        ]);
+
+        $notification = new TrainingPlaceOfferDeclined($this->offer);
+
+        $channels = $notification->via($this->account);
+        $this->assertContains(DiscordNotificationChannel::class, $channels);
+    }
+
+    #[Test]
+    public function it_omits_discord_channel_in_via_if_channel_id_is_null_or_empty(): void
+    {
+        $notification = new TrainingPlaceOfferDeclined($this->offer);
+
+        $channels = $notification->via($this->account);
+        $this->assertNotContains(DiscordNotificationChannel::class, $channels);
+    }
+}

--- a/tests/Unit/Training/TrainingPlace/TrainingPlaceOfferServiceTest.php
+++ b/tests/Unit/Training/TrainingPlace/TrainingPlaceOfferServiceTest.php
@@ -215,6 +215,9 @@ class TrainingPlaceOfferServiceTest extends TestCase
         Notification::fake();
 
         $offer = $this->createOffer();
+        $offer->trainingPosition->update([
+            'training_team_discord_channel_id' => '123456789',
+        ]);
         $this->service->declineOffer($offer);
 
         Notification::assertSentTo($offer->waitingListAccount->account, TrainingPlaceOfferDeclined::class);

--- a/tests/Unit/Training/TrainingPlace/TrainingPlaceOfferServiceTest.php
+++ b/tests/Unit/Training/TrainingPlace/TrainingPlaceOfferServiceTest.php
@@ -9,6 +9,7 @@ use App\Models\Mship\Account;
 use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
+use App\Notifications\Training\TrainingPlaceOfferDeclined;
 use App\Notifications\Training\TrainingPlaceOffered;
 use App\Notifications\Training\TrainingPlaceOfferRescinded;
 use App\Notifications\Training\TrainingPlaceOfferRescindedAndRemoved;
@@ -206,6 +207,17 @@ class TrainingPlaceOfferServiceTest extends TestCase
         $this->assertDatabaseHas('mship_account_note', [
             'account_id' => $offer->waitingListAccount->account_id,
         ]);
+    }
+
+    #[Test]
+    public function it_sends_declined_notification_to_the_member()
+    {
+        Notification::fake();
+
+        $offer = $this->createOffer();
+        $this->service->declineOffer($offer);
+
+        Notification::assertSentTo($offer->waitingListAccount->account, TrainingPlaceOfferDeclined::class);
     }
 
     #[Test]


### PR DESCRIPTION
# Summary of changes
- Send a discord embed to the relevant training team channel upon a training place offer being rejected

# Screenshots (if necessary)
