### PR TITLE
Add 'My Mentoring History' page to training panel

### DIFF
--- a/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
+++ b/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
@@ -93,51 +93,49 @@ abstract class BaseMentoringHistoryPage extends Page implements HasTable
 
     protected function getTableColumns(): array
     {
-        $columns = [
-            TextColumn::make('student_name')
+        $columns = [];
+
+        if ($this->showStudentFilter()) {
+            $columns[] = TextColumn::make('student_name')
                 ->label('Student')
                 ->getStateUsing(fn ($record) => $record->student->name)
                 ->description(fn ($record) => $record->student->cid)
                 ->action(function ($record, $livewire) {
-                    if (! $this->showStudentFilter()) {
-                        return;
-                    }
-
                     $livewire->tableFilters['student']['value'] = $record->student->cid;
                     $livewire->updatedTableFilters();
-                }),
+                });
+        }
 
-            TextColumn::make('mentor_name')
-                ->label('Mentor')
-                ->getStateUsing(fn ($record) => $record->mentor->name)
-                ->description(fn ($record) => $record->mentor->cid)
-                ->action(function ($record, $livewire) {
-                    if (! $this->showMentorFilter()) {
-                        return;
-                    }
+        $columns[] = TextColumn::make('mentor_name')
+            ->label('Mentor')
+            ->getStateUsing(fn ($record) => $record->mentor->name)
+            ->description(fn ($record) => $record->mentor->cid)
+            ->action(function ($record, $livewire) {
+                if (! $this->showMentorFilter()) {
+                    return;
+                }
 
-                    $livewire->tableFilters['mentor']['value'] = $record->mentor->cid;
-                    $livewire->updatedTableFilters();
-                }),
+                $livewire->tableFilters['mentor']['value'] = $record->mentor->cid;
+                $livewire->updatedTableFilters();
+            });
 
-            TextColumn::make('position')
-                ->label('Position')
-                ->badge()
-                ->color($this->getPositionColumnBadgeColor()),
+        $columns[] = TextColumn::make('position')
+            ->label('Position')
+            ->badge()
+            ->color($this->getPositionColumnBadgeColor());
 
-            TextColumn::make('taken_date')
-                ->label('Date & Time')
-                ->getStateUsing(function ($record) {
-                    $date = Carbon::parse($record->taken_date)->format('d/m/Y');
-                    $time = Carbon::parse($record->taken_from)->format('H:i');
+        $columns[] = TextColumn::make('taken_date')
+            ->label('Date & Time')
+            ->getStateUsing(function ($record) {
+                $date = Carbon::parse($record->taken_date)->format('d/m/Y');
+                $time = Carbon::parse($record->taken_from)->format('H:i');
 
-                    return trim("{$date} {$time}");
-                })
-                ->sortable(query: fn (Builder $query, string $direction) => $query
-                    ->orderBy('taken_date', $direction)
-                    ->orderBy('taken_from', $direction)
-                ),
-        ];
+                return trim("{$date} {$time}");
+            })
+            ->sortable(query: fn (Builder $query, string $direction) => $query
+                ->orderBy('taken_date', $direction)
+                ->orderBy('taken_from', $direction)
+            );
 
         if ($this->includeStatusColumn()) {
             $columns[] = TextColumn::make('status')

--- a/app/Filament/Training/Pages/MyTraining/MyMentoringHistory.php
+++ b/app/Filament/Training/Pages/MyTraining/MyMentoringHistory.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Pages\MyTraining;
+
+use App\Filament\Training\Pages\Mentor\Base\BaseMentoringHistoryPage;
+use App\Models\Cts\Member;
+use App\Repositories\Cts\SessionRepository;
+use Illuminate\Database\Eloquent\Builder;
+
+class MyMentoringHistory extends BaseMentoringHistoryPage
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected string $view = 'filament.training.pages.my-training.my-mentoring-history';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'My Training';
+
+    protected static ?string $navigationLabel = 'My Mentoring History';
+
+    protected static ?int $navigationSort = 25;
+
+    public static function canAccess(): bool
+    {
+        if (! app()->runningUnitTests() && ! auth()->user()?->can('training.beta')) {
+            return false;
+        }
+
+        return auth()->user()?->can('training.access') ?? false;
+    }
+
+    protected function getSessionQuery(): Builder
+    {
+        $studentId = $this->studentMemberId();
+
+        if ($studentId === null) {
+            return (new SessionRepository)->getPastAcceptedSessionsForStudentQuery(0)->whereRaw('0 = 1');
+        }
+
+        return (new SessionRepository)->getPastAcceptedSessionsForStudentQuery($studentId);
+    }
+
+    protected function getPositionFilterOptions(): array
+    {
+        $studentId = $this->studentMemberId();
+
+        if ($studentId === null) {
+            return [];
+        }
+
+        $positions = (new SessionRepository)->getPositionsForStudent($studentId);
+
+        return array_combine($positions, $positions);
+    }
+
+    protected function showStudentFilter(): bool
+    {
+        return false;
+    }
+
+    protected function tableEmptyStateHeading(): string
+    {
+        return 'No mentoring sessions found';
+    }
+
+    private function studentMemberId(): ?int
+    {
+        return Member::query()
+            ->where('cid', auth()->id())
+            ->value('id');
+    }
+}

--- a/app/Repositories/Cts/SessionRepository.php
+++ b/app/Repositories/Cts/SessionRepository.php
@@ -29,6 +29,29 @@ class SessionRepository
             ->where('taken', 1);
     }
 
+    public function getPastAcceptedSessionsForStudentQuery(int $studentId): Builder
+    {
+        return Session::query()
+            ->with(['student', 'mentor'])
+            ->where('student_id', $studentId)
+            ->where('taken', 1)
+            ->where('taken_date', '<', now());
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getPositionsForStudent(int $studentId): array
+    {
+        return Session::query()
+            ->where('student_id', $studentId)
+            ->where('taken', 1)
+            ->distinct()
+            ->orderBy('position')
+            ->pluck('position')
+            ->all();
+    }
+
     public function getUpcomingAcceptedSessionsForPositionsQuery(array $positionCallsigns): Builder
     {
         return $this->getAllAcceptedSessionsForPositionsQuery($positionCallsigns)

--- a/resources/views/filament/training/pages/my-training/my-mentoring-history.blade.php
+++ b/resources/views/filament/training/pages/my-training/my-mentoring-history.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+	{{ $this->table }}
+</x-filament-panels::page>

--- a/tests/Feature/TrainingPanel/MyTraining/MyMentoringHistoryTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyMentoringHistoryTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\MyTraining;
+
+use App\Filament\Training\Pages\Mentor\ViewMentoringReport;
+use App\Filament\Training\Pages\MyTraining\MyMentoringHistory;
+use App\Models\Cts\Member;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class MyMentoringHistoryTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    protected Account $studentAccount;
+
+    protected Member $studentMember;
+
+    protected Member $mentorMember;
+
+    protected Session $filedSession;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->studentAccount = Account::factory()->create();
+        $this->studentMember = Member::factory()->create([
+            'id' => $this->studentAccount->id,
+            'cid' => $this->studentAccount->id,
+        ]);
+
+        $mentorAccount = Account::factory()->create();
+        $this->mentorMember = Member::factory()->create([
+            'id' => $mentorAccount->id,
+            'cid' => $mentorAccount->id,
+        ]);
+
+        $this->filedSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGKK_TWR',
+            'taken' => 1,
+            'taken_date' => now()->subDays(3)->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'filed' => now()->subDays(2),
+        ]);
+
+        $this->studentAccount->givePermissionTo('training.access');
+    }
+
+    #[Test]
+    public function member_with_training_access_can_view_my_mentoring_history_page(): void
+    {
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyMentoringHistory::class)
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function member_without_training_access_cannot_view_my_mentoring_history_page(): void
+    {
+        $accountWithoutAccess = Account::factory()->create();
+
+        Livewire::actingAs($accountWithoutAccess)
+            ->test(MyMentoringHistory::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_shows_past_mentoring_sessions_for_the_authenticated_member_including_pending_reports(): void
+    {
+        $pendingSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => now()->subDay()->format('Y-m-d'),
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+            'filed' => null,
+        ]);
+
+        $otherAccount = Account::factory()->create();
+        $otherMember = Member::factory()->create([
+            'id' => $otherAccount->id,
+            'cid' => $otherAccount->id,
+        ]);
+
+        Session::factory()->create([
+            'student_id' => $otherMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGKK_APP',
+            'taken' => 1,
+            'taken_date' => now()->subDays(5)->format('Y-m-d'),
+            'taken_from' => '18:00:00',
+            'taken_to' => '20:00:00',
+            'filed' => now()->subDays(4),
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyMentoringHistory::class)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$this->filedSession, $pendingSession]);
+    }
+
+    #[Test]
+    public function it_shows_view_action_only_for_filed_sessions(): void
+    {
+        $pendingSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => now()->subDay()->format('Y-m-d'),
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+            'filed' => null,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyMentoringHistory::class)
+            ->assertTableActionVisible('view', $this->filedSession)
+            ->assertTableActionHidden('view', $pendingSession);
+    }
+
+    #[Test]
+    public function it_displays_the_correct_status_badge_for_pending_sessions(): void
+    {
+        $pendingSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => now()->subDay()->format('Y-m-d'),
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+            'filed' => null,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyMentoringHistory::class)
+            ->assertTableColumnStateSet('status', 'Pending', record: $pendingSession);
+    }
+
+    #[Test]
+    public function it_shows_an_empty_table_when_member_has_no_past_mentoring_sessions(): void
+    {
+        $emptyAccount = Account::factory()->create();
+        Member::factory()->create([
+            'id' => $emptyAccount->id,
+            'cid' => $emptyAccount->id,
+        ]);
+        $emptyAccount->givePermissionTo('training.access');
+
+        Livewire::actingAs($emptyAccount)
+            ->test(MyMentoringHistory::class)
+            ->assertSuccessful()
+            ->assertSee('No mentoring sessions found');
+    }
+
+    #[Test]
+    public function member_can_view_their_own_mentoring_report_from_the_table(): void
+    {
+        Livewire::actingAs($this->studentAccount)
+            ->test(ViewMentoringReport::class, ['sessionId' => $this->filedSession->id])
+            ->assertSuccessful();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **My Mentoring History** page to the training panel under **My Training**, allowing members to view their own past mentoring sessions and filed reports.

The page extends `BaseMentoringHistoryPage` to reuse the existing mentoring history table (columns, status badges, filters, and View Report action) rather than duplicating table logic in a separate widget.

## Changes

- **New page:** `MyMentoringHistory` in the **My Training** navigation group
- **Session scoping:** Shows past accepted mentoring sessions (`taken = 1`, `taken_date < now()`) for the authenticated member only
- **Status support:** Includes pending, completed, cancelled, and no-show sessions — consistent with mentor **Mentoring History**
- **View Report:** Available only for filed sessions; links to the existing `ViewMentoringReport` page
- **Repository:** Adds `getPastAcceptedSessionsForStudentQuery()` and `getPositionsForStudent()` to `SessionRepository`
- **Base class:** Hides the student column when `showStudentlter()` is `false` (used on the member-facing page)

## Access control

- Requires `training.access`
- Requires `training.beta` in production (consistent with other **My Training** pages)

