### PR TITLE
fix: clean-up training panel urls

### DIFF
--- a/app/Filament/Training/Pages/Mentor/ManageMentors.php
+++ b/app/Filament/Training/Pages/Mentor/ManageMentors.php
@@ -44,6 +44,8 @@ class ManageMentors extends Page implements HasTable
 
     protected static ?string $title = 'Manage Mentors';
 
+    protected static ?string $slug = 'mentoring/mentors';
+
     #[Url]
     public string $category = '';
 

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -31,6 +31,8 @@ class MentoringHistory extends BaseMentoringHistoryPage
 
     protected static ?string $title = 'Mentoring History';
 
+    protected static ?string $slug = 'mentoring/history';
+
     #[Url]
     public string $category = '';
 

--- a/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
+++ b/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
@@ -40,6 +40,8 @@ class UpcomingMentoringSessions extends BaseMentoringHistoryPage
 
     protected static ?string $navigationLabel = 'Upcoming Sessions';
 
+    protected static ?string $slug = 'mentoring/upcoming-sessions';
+
     #[Url]
     public string $category = '';
 

--- a/app/Filament/Training/Pages/MyTraining/MyAvailability.php
+++ b/app/Filament/Training/Pages/MyTraining/MyAvailability.php
@@ -40,6 +40,8 @@ class MyAvailability extends Page implements HasForms, HasTable
 
     protected static ?string $navigationLabel = 'My Availability';
 
+    protected static ?string $slug = 'my-training/availability';
+
     protected static ?int $navigationSort = 5;
 
     public ?array $data = [];

--- a/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
+++ b/app/Filament/Training/Pages/MyTraining/MyExamHistory.php
@@ -14,6 +14,8 @@ class MyExamHistory extends Page
 
     protected static ?string $navigationLabel = 'My Exam History';
 
+    protected static ?string $slug = 'my-training/exam-history';
+
     protected static ?int $navigationSort = 20;
 
     public static function canAccess(): bool

--- a/app/Filament/Training/Pages/MyTraining/MyMentoringHistory.php
+++ b/app/Filament/Training/Pages/MyTraining/MyMentoringHistory.php
@@ -19,6 +19,8 @@ class MyMentoringHistory extends BaseMentoringHistoryPage
 
     protected static ?string $navigationLabel = 'My Mentoring History';
 
+    protected static ?string $slug = 'my-training/mentoring-history';
+
     protected static ?int $navigationSort = 25;
 
     public static function canAccess(): bool

--- a/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
+++ b/app/Filament/Training/Pages/MyTraining/MyPendingExams.php
@@ -28,6 +28,8 @@ class MyPendingExams extends Page implements HasTable
 
     protected static ?string $navigationLabel = 'My Pending Exams';
 
+    protected static ?string $slug = 'my-training/pending-exams';
+
     protected static ?int $navigationSort = 10;
 
     public static function canAccess(): bool

--- a/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityTest.php
@@ -56,7 +56,7 @@ class MyAvailabilityTest extends BaseTrainingPanelTestCase
         Member::factory()->recycle($noAccessAccount)->create(['cid' => $noAccessAccount->id]);
 
         $this->actingAs($noAccessAccount)
-            ->get('/training/my-availability')
+            ->get('/training/my-training/availability')
             ->assertNotFound();
     }
 
@@ -68,7 +68,7 @@ class MyAvailabilityTest extends BaseTrainingPanelTestCase
         $accountWithPermission->givePermissionTo('training.access');
 
         $this->actingAs($accountWithPermission)
-            ->get('/training/my-availability')
+            ->get('/training/my-training/availability')
             ->assertForbidden();
     }
 
@@ -89,7 +89,7 @@ class MyAvailabilityTest extends BaseTrainingPanelTestCase
         ]);
 
         $this->actingAs($accountWithValidation)
-            ->get('/training/my-availability')
+            ->get('/training/my-training/availability')
             ->assertSuccessful();
     }
 
@@ -110,7 +110,7 @@ class MyAvailabilityTest extends BaseTrainingPanelTestCase
         ]);
 
         $this->actingAs($accountWithNonPilot)
-            ->get('/training/my-availability')
+            ->get('/training/my-training/availability')
             ->assertForbidden();
     }
 

--- a/tests/Feature/TrainingPanel/MyTraining/MyPendingExamsTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyPendingExamsTest.php
@@ -74,7 +74,7 @@ class MyPendingExamsTest extends BaseTrainingPanelTestCase
         Member::factory()->recycle($noAccessAccount)->create(['cid' => $noAccessAccount->id]);
 
         $this->actingAs($noAccessAccount)
-            ->get('/training/my-pending-exams')
+            ->get('/training/my-training/pending-exams')
             ->assertNotFound();
     }
 

--- a/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
@@ -150,7 +150,7 @@ class MentoringSessionsServiceTest extends TestCase
 
         $availability = Availability::factory()->create([
             'student_id' => $this->studentMember->id,
-            'date' => Carbon::parse('2026-06-15'),
+            'date' => Carbon::tomorrow(),
             'from' => '10:00:00',
             'to' => '12:00:00',
         ]);
@@ -166,7 +166,7 @@ class MentoringSessionsServiceTest extends TestCase
 
         $this->assertSame($this->mentorMember->id, $pendingSession->mentor_id);
         $this->assertSame(1, $pendingSession->taken);
-        $this->assertSame('2026-06-15', Carbon::parse($pendingSession->taken_date)->format('Y-m-d'));
+        $this->assertSame(Carbon::tomorrow()->format('Y-m-d'), Carbon::parse($pendingSession->taken_date)->format('Y-m-d'));
         $this->assertSame('10:00:00', Carbon::parse($pendingSession->taken_from)->format('H:i:s'));
         $this->assertSame('12:00:00', Carbon::parse($pendingSession->taken_to)->format('H:i:s'));
     }


### PR DESCRIPTION
# Summary of changes
Clean up some of the links on the Training Panel to categorise everything better

My Training Pages:
`/training/my-availability` -> `/training/my-training/availability`
`/training/my-pending-exams` -> `/training/my-training/pending-exams`
`/training/my-exam-history` -> `/training/my-training/exam-history`
`/training/my-mentoring-history` -> `/training/my-training/mentoring-history`

Mentoring Pages:
`/training/mentoring` -> `/training/mentoring`
`/training/upcoming-mentoring-sessions` -> `/training/mentoring/upcoming-sessions`
`/training/mentoring-history` -> `/training/mentoring/history`
`/training/manage-mentors` -> `/training/mentoring/mentors`
