### PR TITLE
fix: organise actions on the accepted mentoring sessions page

### DIFF
--- a/app/Livewire/Training/AcceptedMentoringSessionsTable.php
+++ b/app/Livewire/Training/AcceptedMentoringSessionsTable.php
@@ -80,206 +80,23 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
             ])
             ->actions([
                 Action::make('conduct')
-                    ->label('Conduct')
+                    ->label('Conduct Session')
                     ->url(fn (Session $record): string => ConductMentoringSession::getUrl(['sessionId' => $record->id]))
                     ->visible(fn (Session $record): bool => auth()->user()?->can('conduct', $record) ?? false),
 
-                $this->markNoShowTableAction(),
-
-                $this->postMentoringSessionAnnouncementAction(),
-
                 ActionGroup::make([
-                    Action::make('reschedule')
-                        ->label('Reschedule')
-                        ->icon('heroicon-m-clock')
-                        ->color('warning')
-                        ->modalHeading(fn (Session $record) => "Reschedule Session: {$record->student->name}")
-                        ->modalSubmitActionLabel('Reschedule Session')
-                        ->form([
-                            Select::make('selected_availability_id')
-                                ->label('Student Availability Slot')
-                                ->required()
-                                ->live()
-                                ->options(fn (Session $record) => Availability::query()
-                                    ->where('student_id', $record->student_id)
-                                    ->whereDate('date', '>=', now())
-                                    ->orderBy('date')
-                                    ->orderBy('from')
-                                    ->get()
-                                    ->mapWithKeys(function ($avail) {
-                                        $date = Carbon::parse($avail->date)->format('D, d M Y');
-                                        $start = Carbon::parse($avail->from)->format('H:i');
-                                        $end = Carbon::parse($avail->to)->format('H:i');
+                    ActionGroup::make([
+                        $this->postMentoringSessionAnnouncementAction(),
+                        $this->markNoShowTableAction(),
+                    ])->dropdown(false),
 
-                                        return [$avail->id => "{$date} ({$start} to {$end})"];
-                                    })
-                                )
-                                ->afterStateUpdated(function (Set $set, $state) {
-                                    if (! $state || ! $newAvail = Availability::find($state)) {
-                                        $set('taken_from', null);
-                                        $set('taken_to', null);
-
-                                        return;
-                                    }
-
-                                    $minTime = Carbon::parse($newAvail->from)->format('H:i');
-                                    $maxTime = Carbon::parse($newAvail->to)->format('H:i');
-                                    $options = $this->generateTimeOptions($minTime, $maxTime);
-
-                                    if (Carbon::parse($newAvail->date)->isToday()) {
-                                        $nowTime = now()->format('H:i');
-                                        $options = array_filter($options, fn ($time) => $time >= $nowTime, ARRAY_FILTER_USE_KEY);
-                                    }
-
-                                    $set('taken_from', array_key_first($options));
-                                    $set('taken_to', array_key_last($options));
-                                }),
-
-                            Grid::make(2)->schema([
-                                Select::make('taken_from')
-                                    ->label('New Start Time')
-                                    ->required()
-                                    ->searchable()
-                                    ->allowHtml(false)
-                                    ->live()
-                                    ->optionsLimit(100)
-                                    ->options(function (Get $get) {
-                                        if (! $availId = $get('selected_availability_id')) {
-                                            return [];
-                                        }
-
-                                        $avail = Availability::find($availId);
-                                        if (! $avail) {
-                                            return [];
-                                        }
-
-                                        $options = $this->generateTimeOptions(
-                                            Carbon::parse($avail->from)->format('H:i'),
-                                            Carbon::parse($avail->to)->format('H:i')
-                                        );
-
-                                        if (Carbon::parse($avail->date)->isToday()) {
-                                            $nowTime = now()->format('H:i');
-                                            $options = array_filter($options, fn ($time) => $time >= $nowTime, ARRAY_FILTER_USE_KEY);
-                                        }
-
-                                        return $options;
-                                    }),
-
-                                Select::make('taken_to')
-                                    ->label('New End Time')
-                                    ->required()
-                                    ->searchable()
-                                    ->allowHtml(false)
-                                    ->optionsLimit(100)
-                                    ->options(function (Get $get) {
-                                        if (! $availId = $get('selected_availability_id')) {
-                                            return [];
-                                        }
-
-                                        $avail = Availability::find($availId);
-                                        if (! $avail) {
-                                            return [];
-                                        }
-
-                                        $options = $this->generateTimeOptions(
-                                            Carbon::parse($avail->from)->format('H:i'),
-                                            Carbon::parse($avail->to)->format('H:i')
-                                        );
-
-                                        $startTime = $get('taken_from');
-                                        if (! $startTime) {
-                                            return $options;
-                                        }
-
-                                        return collect($options)
-                                            ->filter(fn ($label, $key) => $key > $startTime)
-                                            ->toArray();
-                                    }),
-                            ]),
-                        ])
-                        ->action(function (array $data, Session $record, MentoringSessionsService $mentoringService) {
-                            $availability = Availability::find($data['selected_availability_id']);
-
-                            if (! $availability) {
-                                Notification::make()
-                                    ->title('Reschedule Failed')
-                                    ->body('The selected availability slot could no longer be found.')
-                                    ->danger()
-                                    ->send();
-
-                                return;
-                            }
-
-                            $proposedStart = Carbon::parse($availability->date)->setTimeFromTimeString($data['taken_from']);
-                            if ($proposedStart->isPast()) {
-                                Notification::make()
-                                    ->title('Invalid Time Chosen')
-                                    ->body('You cannot reschedule a mentoring session to a time that has already passed.')
-                                    ->danger()
-                                    ->send();
-
-                                return;
-                            }
-
-                            $success = $mentoringService->rescheduleSession(
-                                $record->id,
-                                $availability->id,
-                                $data['taken_from'],
-                                $data['taken_to'],
-                                auth()->user(),
-                            );
-
-                            if ($success) {
-                                $dateFormatted = Carbon::parse($availability->date)->format('d/m/Y');
-
-                                Notification::make()
-                                    ->title('Session Rescheduled')
-                                    ->body("The session with {$record->student->name} has been moved to {$dateFormatted} from {$data['taken_from']} to {$data['taken_to']}.")
-                                    ->success()
-                                    ->send();
-                            } else {
-                                Notification::make()
-                                    ->title('Error')
-                                    ->body('Could not reschedule the session. Please confirm the request is still valid.')
-                                    ->danger()
-                                    ->send();
-                            }
-                        }),
-
-                    Action::make('cancel')
-                        ->label('Cancel Session')
-                        ->icon('heroicon-m-x-circle')
-                        ->color('danger')
-                        ->modalHeading(fn (Session $record) => "Cancel Session: {$record->student->name}")
-                        ->modalDescription('Please provide a reason for cancelling this session. This will be recorded and visible to the student.')
-                        ->modalSubmitActionLabel('Cancel Session')
-                        ->form([
-                            Textarea::make('reason')
-                                ->label('Cancellation Reason')
-                                ->required()
-                                ->minLength(10),
-                        ])
-                        ->action(function (array $data, Session $record, MentoringSessionsService $mentoringService) {
-                            $success = $mentoringService->cancelSession($record->id, $data['reason'], auth()->user());
-
-                            if ($success) {
-                                Notification::make()
-                                    ->title('Session Cancelled')
-                                    ->body("The session with {$record->student->name} has been successfully cancelled.")
-                                    ->success()
-                                    ->send();
-                            } else {
-                                Notification::make()
-                                    ->title('Cancellation Failed')
-                                    ->body('Could not cancel the session. It may have already been modified or completed.')
-                                    ->danger()
-                                    ->send();
-                            }
-                        }),
+                    ActionGroup::make([
+                        $this->rescheduleSessionAction(),
+                        $this->cancelSessionAction(),
+                    ])->dropdown(false),
                 ])
                     ->icon('heroicon-m-ellipsis-vertical')
-                    ->tooltip('Manage Session'),
+                    ->tooltip('Session Actions'),
             ])
             ->emptyStateHeading('No upcoming mentoring sessions found');
     }
@@ -407,6 +224,201 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
                 } catch (\Throwable) {
                     Notification::make()
                         ->title('Failed to post to Discord')
+                        ->danger()
+                        ->send();
+                }
+            });
+    }
+
+    private function rescheduleSessionAction(): Action
+    {
+        return Action::make('reschedule')
+            ->label('Reschedule Session')
+            ->icon('heroicon-m-clock')
+            ->color('warning')
+            ->modalHeading(fn (Session $record) => "Reschedule Session: {$record->student->name}")
+            ->modalSubmitActionLabel('Reschedule Session')
+            ->form([
+                Select::make('selected_availability_id')
+                    ->label('Student Availability Slot')
+                    ->required()
+                    ->live()
+                    ->options(fn (Session $record) => Availability::query()
+                        ->where('student_id', $record->student_id)
+                        ->whereDate('date', '>=', now())
+                        ->orderBy('date')
+                        ->orderBy('from')
+                        ->get()
+                        ->mapWithKeys(function ($avail) {
+                            $date = Carbon::parse($avail->date)->format('D, d M Y');
+                            $start = Carbon::parse($avail->from)->format('H:i');
+                            $end = Carbon::parse($avail->to)->format('H:i');
+
+                            return [$avail->id => "{$date} ({$start} to {$end})"];
+                        })
+                    )
+                    ->afterStateUpdated(function (Set $set, $state) {
+                        if (! $state || ! $newAvail = Availability::find($state)) {
+                            $set('taken_from', null);
+                            $set('taken_to', null);
+
+                            return;
+                        }
+
+                        $minTime = Carbon::parse($newAvail->from)->format('H:i');
+                        $maxTime = Carbon::parse($newAvail->to)->format('H:i');
+                        $options = $this->generateTimeOptions($minTime, $maxTime);
+
+                        if (Carbon::parse($newAvail->date)->isToday()) {
+                            $nowTime = now()->format('H:i');
+                            $options = array_filter($options, fn ($time) => $time >= $nowTime, ARRAY_FILTER_USE_KEY);
+                        }
+
+                        $set('taken_from', array_key_first($options));
+                        $set('taken_to', array_key_last($options));
+                    }),
+
+                Grid::make(2)->schema([
+                    Select::make('taken_from')
+                        ->label('New Start Time')
+                        ->required()
+                        ->searchable()
+                        ->allowHtml(false)
+                        ->live()
+                        ->optionsLimit(100)
+                        ->options(function (Get $get) {
+                            if (! $availId = $get('selected_availability_id')) {
+                                return [];
+                            }
+
+                            $avail = Availability::find($availId);
+                            if (! $avail) {
+                                return [];
+                            }
+
+                            $options = $this->generateTimeOptions(
+                                Carbon::parse($avail->from)->format('H:i'),
+                                Carbon::parse($avail->to)->format('H:i')
+                            );
+
+                            if (Carbon::parse($avail->date)->isToday()) {
+                                $nowTime = now()->format('H:i');
+                                $options = array_filter($options, fn ($time) => $time >= $nowTime, ARRAY_FILTER_USE_KEY);
+                            }
+
+                            return $options;
+                        }),
+
+                    Select::make('taken_to')
+                        ->label('New End Time')
+                        ->required()
+                        ->searchable()
+                        ->allowHtml(false)
+                        ->optionsLimit(100)
+                        ->options(function (Get $get) {
+                            if (! $availId = $get('selected_availability_id')) {
+                                return [];
+                            }
+
+                            $avail = Availability::find($availId);
+                            if (! $avail) {
+                                return [];
+                            }
+
+                            $options = $this->generateTimeOptions(
+                                Carbon::parse($avail->from)->format('H:i'),
+                                Carbon::parse($avail->to)->format('H:i')
+                            );
+
+                            $startTime = $get('taken_from');
+                            if (! $startTime) {
+                                return $options;
+                            }
+
+                            return collect($options)
+                                ->filter(fn ($label, $key) => $key > $startTime)
+                                ->toArray();
+                        }),
+                ]),
+            ])
+            ->action(function (array $data, Session $record, MentoringSessionsService $mentoringService) {
+                $availability = Availability::find($data['selected_availability_id']);
+
+                if (! $availability) {
+                    Notification::make()
+                        ->title('Reschedule Failed')
+                        ->body('The selected availability slot could no longer be found.')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                $proposedStart = Carbon::parse($availability->date)->setTimeFromTimeString($data['taken_from']);
+                if ($proposedStart->isPast()) {
+                    Notification::make()
+                        ->title('Invalid Time Chosen')
+                        ->body('You cannot reschedule a mentoring session to a time that has already passed.')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                $success = $mentoringService->rescheduleSession(
+                    $record->id,
+                    $availability->id,
+                    $data['taken_from'],
+                    $data['taken_to'],
+                    auth()->user(),
+                );
+
+                if ($success) {
+                    $dateFormatted = Carbon::parse($availability->date)->format('d/m/Y');
+
+                    Notification::make()
+                        ->title('Session Rescheduled')
+                        ->body("The session with {$record->student->name} has been moved to {$dateFormatted} from {$data['taken_from']} to {$data['taken_to']}.")
+                        ->success()
+                        ->send();
+                } else {
+                    Notification::make()
+                        ->title('Error')
+                        ->body('Could not reschedule the session. Please confirm the request is still valid.')
+                        ->danger()
+                        ->send();
+                }
+            });
+    }
+
+    private function cancelSessionAction(): Action
+    {
+        return Action::make('cancel')
+            ->label('Cancel Session')
+            ->icon('heroicon-m-x-circle')
+            ->color('danger')
+            ->modalHeading(fn (Session $record) => "Cancel Session: {$record->student->name}")
+            ->modalDescription('Please provide a reason for cancelling this session. This will be recorded and visible to the student.')
+            ->modalSubmitActionLabel('Cancel Session')
+            ->form([
+                Textarea::make('reason')
+                    ->label('Cancellation Reason')
+                    ->required()
+                    ->minLength(10),
+            ])
+            ->action(function (array $data, Session $record, MentoringSessionsService $mentoringService) {
+                $success = $mentoringService->cancelSession($record->id, $data['reason'], auth()->user());
+
+                if ($success) {
+                    Notification::make()
+                        ->title('Session Cancelled')
+                        ->body("The session with {$record->student->name} has been successfully cancelled.")
+                        ->success()
+                        ->send();
+                } else {
+                    Notification::make()
+                        ->title('Cancellation Failed')
+                        ->body('Could not cancel the session. It may have already been modified or completed.')
                         ->danger()
                         ->send();
                 }

--- a/app/Livewire/Training/PendingMentoringReportsTable.php
+++ b/app/Livewire/Training/PendingMentoringReportsTable.php
@@ -4,26 +4,20 @@ declare(strict_types=1);
 
 namespace App\Livewire\Training;
 
-use App\Filament\Training\Pages\Mentor\ConductMentoringSession;
 use App\Filament\Training\Support\MentoringTrainingGroupBadgeColor;
 use App\Models\Cts\Session;
 use App\Repositories\Cts\SessionRepository;
-use App\Services\Training\MentoringReportService;
 use App\Services\Training\MentorPermissionService;
 use Carbon\Carbon;
-use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
-use Filament\Forms\Components\Toggle;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
-use Filament\Notifications\Notification;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 
 class PendingMentoringReportsTable extends Component implements HasActions, HasForms, HasTable
@@ -80,59 +74,6 @@ class PendingMentoringReportsTable extends Component implements HasActions, HasF
                         ->orderBy('taken_date', $direction)
                         ->orderBy('taken_from', $direction)
                     ),
-            ])
-            ->recordActions([
-                Action::make('conduct')
-                    ->label('Conduct')
-                    ->url(fn (Session $record): string => ConductMentoringSession::getUrl(['sessionId' => $record->id]))
-                    ->visible(fn (Session $record): bool => auth()->user()?->can('conduct', $record) ?? false),
-                Action::make('markNoShow')
-                    ->label('Mark no-show')
-                    ->color('danger')
-                    ->icon('heroicon-o-user-minus')
-                    ->visible(fn (Session $record): bool => auth()->user()?->can('markNoShow', $record)
-                        && app(MentoringReportService::class)->canMarkNoShow($record))
-                    ->requiresConfirmation()
-                    ->modalHeading('Mark session as no-show')
-                    ->modalDescription(fn (Session $record) => app(MentoringReportService::class)->wasBookedWithShortNotice($record)
-                        ? 'This session was booked with less than 24 hours notice. Did the student confirm their non-attendance via Discord?'
-                        : 'Are you sure you want to mark this session as a no-show? The report will be filed automatically.')
-                    ->schema(fn (Session $record) => app(MentoringReportService::class)->wasBookedWithShortNotice($record)
-                        ? [
-                            Toggle::make('student_confirmed_discord')
-                                ->label('Student confirmed non-attendance via Discord')
-                                ->required(),
-                        ]
-                        : [])
-                    ->action(function (Session $record, array $data, MentoringReportService $service): void {
-                        $wasShortNotice = $service->wasBookedWithShortNotice($record);
-                        $confirmed = (bool) ($data['student_confirmed_discord'] ?? false);
-
-                        try {
-                            $service->markNoShow($record, $confirmed);
-                        } catch (ValidationException $exception) {
-                            Notification::make()
-                                ->title('Unable to mark no-show')
-                                ->body(collect($exception->errors())->flatten()->first())
-                                ->danger()
-                                ->send();
-
-                            return;
-                        }
-
-                        if ($wasShortNotice && ! $confirmed) {
-                            Notification::make()
-                                ->title('Session cancelled')
-                                ->body('The session was cancelled on your behalf. No no-show has been recorded for the student.')
-                                ->success()
-                                ->send();
-                        } else {
-                            Notification::make()
-                                ->title('Session marked as no-show')
-                                ->success()
-                                ->send();
-                        }
-                    }),
             ])
             ->emptyStateHeading('No pending mentoring reports in this training group');
     }

--- a/tests/Feature/TrainingPanel/Mentor/ConductMentoringSessionTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ConductMentoringSessionTest.php
@@ -7,7 +7,6 @@ namespace Tests\Feature\TrainingPanel\Mentor;
 use App\Enums\FieldScore;
 use App\Filament\Training\Pages\Mentor\ConductMentoringSession;
 use App\Livewire\Training\AcceptedMentoringSessionsTable;
-use App\Livewire\Training\PendingMentoringReportsTable;
 use App\Models\Cts\Member;
 use App\Models\Cts\ProgSheet;
 use App\Models\Cts\ProgSheetCategory;
@@ -239,16 +238,6 @@ class ConductMentoringSessionTest extends BaseTrainingPanelTestCase
     {
         Livewire::actingAs($this->mentor)
             ->test(AcceptedMentoringSessionsTable::class)
-            ->assertTableActionVisible('conduct', $this->session);
-    }
-
-    #[Test]
-    public function pending_reports_table_shows_conduct_action_for_assigned_mentor(): void
-    {
-        $this->panelUser->givePermissionTo('training.mentors.view.atc');
-
-        Livewire::actingAs($this->mentor)
-            ->test(PendingMentoringReportsTable::class, ['category' => 'S3 Training'])
             ->assertTableActionVisible('conduct', $this->session);
     }
 }


### PR DESCRIPTION
# Summary of changes
- Moves actions into one joint action group with a divider to keep them separated
- Removes actions from the pending reports table as I'm not sure why they were there

# Screenshots (if necessary)
Before:
<img width="462" height="218" alt="image" src="https://github.com/user-attachments/assets/a8d41469-900b-4c6f-9f10-3a7186602f20" />
<img width="390" height="255" alt="image" src="https://github.com/user-attachments/assets/d82ae8ea-6f91-4435-a1cb-3ae3ca0a1bc0" />

After:
<img width="905" height="261" alt="image" src="https://github.com/user-attachments/assets/44d70570-c362-4593-a412-d0bd845828bc" />

<img width="354" height="237" alt="image" src="https://github.com/user-attachments/assets/38a7b929-aea4-4f70-98e1-3bfdd042ec97" />
<img width="343" height="240" alt="image" src="https://github.com/user-attachments/assets/48e6abd2-bd98-4330-a3cf-a2c61900c507" />

