### PR TITLE
fix: add temporary handling for `to` being set to `24:00` by legacy CTS system

### DIFF
--- a/app/Models/Cts/Availability.php
+++ b/app/Models/Cts/Availability.php
@@ -2,6 +2,8 @@
 
 namespace App\Models\Cts;
 
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -21,12 +23,17 @@ class Availability extends Model
     protected $casts = [
         'date' => 'date',
         'from' => 'datetime',
-        'to' => 'datetime',
     ];
 
     protected $attributes = [
         'type' => 'S',
     ];
+
+    // Temporary handling for `to` being set to "24:00" from legacy CTS system
+    protected function to(): Attribute
+    {
+        return Attribute::make(get: fn ($value) => $value ? Carbon::parse(str_replace('24:00', '23:45', $value)) : null);
+    }
 
     public function student(): BelongsTo
     {


### PR DESCRIPTION
# Summary of changes
- CTS allows availability to be set as "24:00", carbon parses this as "00:00" causing a host of issues.
- Replace "24:00" with "23:45" then carbon parse

# Screenshots (if necessary)
