### PR TITLE
Add ICS attachment to booking emails

### DIFF
--- a/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
@@ -53,7 +53,7 @@ class ExamAcceptedExaminerNotification extends Notification implements HasEmailT
         $icsContent = IcsService::generate(
             uid: "exam-{$examBooking->id}@vatsim.uk",
             summary: "Practical Exam - {$examType}",
-            description: "Student: {$studentName} ({$studentCid})\nExam Type: {$examType}\nPosition: {$position}\nPrimary Examiner: {$primaryExaminer}\n\nPlease ensure you are prepared to conduct this exam.",
+            description: "Student: {$studentName} ({$studentCid})\nExam Type: {$examType}\nPosition: {$position}\nPrimary Examiner: {$primaryExaminer}",
             start: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_from}"),
             end: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_to}"),
             location: $position,

--- a/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
@@ -5,6 +5,8 @@ namespace App\Notifications\Training\Exams;
 use App\Enums\EmailType;
 use App\Models\Cts\ExamBooking;
 use App\Notifications\Contracts\HasEmailType;
+use App\Services\IcsService;
+use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -48,6 +50,15 @@ class ExamAcceptedExaminerNotification extends Notification implements HasEmailT
         $studentCid = $examBooking->student?->account?->id ?? 'Unknown';
         $primaryExaminer = $examBooking->examiners?->primaryExaminer?->account?->name ?? 'TBD';
 
+        $icsContent = IcsService::generate(
+            uid: "exam-{$examBooking->id}@vatsim.uk",
+            summary: "Practical Exam - {$examType}",
+            description: "Student: {$studentName} ({$studentCid})\nExam Type: {$examType}\nPosition: {$position}\nPrimary Examiner: {$primaryExaminer}\n\nPlease ensure you are prepared to conduct this exam.",
+            start: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_from}"),
+            end: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_to}"),
+            location: $position,
+        );
+
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject("Exam Assignment Confirmation - {$examType} Practical Exam")
@@ -60,6 +71,7 @@ class ExamAcceptedExaminerNotification extends Notification implements HasEmailT
                 'studentName' => $studentName,
                 'studentCid' => $studentCid,
                 'primaryExaminer' => $primaryExaminer,
-            ]);
+            ])
+            ->attachData($icsContent, 'event.ics', ['mime' => 'text/calendar']);
     }
 }

--- a/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
@@ -50,7 +50,7 @@ class ExamAcceptedExaminerNotification extends Notification implements HasEmailT
         $studentCid = $examBooking->student?->account?->cid ?? 'Unknown';
         $primaryExaminer = $examBooking->examiners?->primaryExaminer?->account?->name ?? 'TBD';
 
-        $sessionDate = $examBooking->taken_date->format('Y-m-d');
+        $sessionDate = Carbon::parse($examBooking->taken_date)->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "exam-{$examBooking->id}@vatsim.uk",
             summary: "Practical Exam - {$examType}",

--- a/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
@@ -47,7 +47,7 @@ class ExamAcceptedExaminerNotification extends Notification implements HasEmailT
         $position = $examBooking->position_1 ?? 'N/A';
         $examDateTime = $examBooking->startDate;
         $studentName = $examBooking->student?->account?->name ?? 'Unknown';
-        $studentCid = $examBooking->student?->account?->id ?? 'Unknown';
+        $studentCid = $examBooking->student?->account?->cid ?? 'Unknown';
         $primaryExaminer = $examBooking->examiners?->primaryExaminer?->account?->name ?? 'TBD';
 
         $icsContent = IcsService::generate(

--- a/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedExaminerNotification.php
@@ -50,12 +50,13 @@ class ExamAcceptedExaminerNotification extends Notification implements HasEmailT
         $studentCid = $examBooking->student?->account?->cid ?? 'Unknown';
         $primaryExaminer = $examBooking->examiners?->primaryExaminer?->account?->name ?? 'TBD';
 
+        $sessionDate = $examBooking->taken_date->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "exam-{$examBooking->id}@vatsim.uk",
             summary: "Practical Exam - {$examType}",
             description: "Student: {$studentName} ({$studentCid})\nExam Type: {$examType}\nPosition: {$position}\nPrimary Examiner: {$primaryExaminer}",
-            start: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_from}"),
-            end: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_to}"),
+            start: Carbon::parse("{$sessionDate} {$examBooking->taken_from}"),
+            end: Carbon::parse("{$sessionDate} {$examBooking->taken_to}"),
             location: $position,
         );
 

--- a/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
@@ -48,7 +48,7 @@ class ExamAcceptedStudentNotification extends Notification implements HasEmailTy
         $examDateTime = $examBooking->startDate;
         $primaryExaminer = $examBooking->examiners?->primaryExaminer?->account?->name ?? 'TBD';
 
-        $sessionDate = $examBooking->taken_date->format('Y-m-d');
+        $sessionDate = Carbon::parse($examBooking->taken_date)->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "exam-{$examBooking->id}@vatsim.uk",
             summary: "Practical Exam - {$examType}",

--- a/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
@@ -48,12 +48,13 @@ class ExamAcceptedStudentNotification extends Notification implements HasEmailTy
         $examDateTime = $examBooking->startDate;
         $primaryExaminer = $examBooking->examiners?->primaryExaminer?->account?->name ?? 'TBD';
 
+        $sessionDate = $examBooking->taken_date->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "exam-{$examBooking->id}@vatsim.uk",
             summary: "Practical Exam - {$examType}",
             description: "Exam Type: {$examType}\nPosition: {$position}\nPrimary Examiner: {$primaryExaminer}",
-            start: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_from}"),
-            end: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_to}"),
+            start: Carbon::parse("{$sessionDate} {$examBooking->taken_from}"),
+            end: Carbon::parse("{$sessionDate} {$examBooking->taken_to}"),
             location: $position,
         );
 

--- a/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
@@ -51,7 +51,7 @@ class ExamAcceptedStudentNotification extends Notification implements HasEmailTy
         $icsContent = IcsService::generate(
             uid: "exam-{$examBooking->id}@vatsim.uk",
             summary: "Practical Exam - {$examType}",
-            description: "Exam Type: {$examType}\nPosition: {$position}\nPrimary Examiner: {$primaryExaminer}\n\nPlease ensure you are prepared and on time for your exam. Most importantly - good luck!",
+            description: "Exam Type: {$examType}\nPosition: {$position}\nPrimary Examiner: {$primaryExaminer}",
             start: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_from}"),
             end: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_to}"),
             location: $position,

--- a/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Exams/ExamAcceptedStudentNotification.php
@@ -5,6 +5,8 @@ namespace App\Notifications\Training\Exams;
 use App\Enums\EmailType;
 use App\Models\Cts\ExamBooking;
 use App\Notifications\Contracts\HasEmailType;
+use App\Services\IcsService;
+use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -46,6 +48,15 @@ class ExamAcceptedStudentNotification extends Notification implements HasEmailTy
         $examDateTime = $examBooking->startDate;
         $primaryExaminer = $examBooking->examiners?->primaryExaminer?->account?->name ?? 'TBD';
 
+        $icsContent = IcsService::generate(
+            uid: "exam-{$examBooking->id}@vatsim.uk",
+            summary: "Practical Exam - {$examType}",
+            description: "Exam Type: {$examType}\nPosition: {$position}\nPrimary Examiner: {$primaryExaminer}\n\nPlease ensure you are prepared and on time for your exam. Most importantly - good luck!",
+            start: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_from}"),
+            end: Carbon::parse("{$examBooking->taken_date} {$examBooking->taken_to}"),
+            location: $position,
+        );
+
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject("Your {$examType} Practical Exam has been Accepted")
@@ -56,6 +67,7 @@ class ExamAcceptedStudentNotification extends Notification implements HasEmailTy
                 'position' => $position,
                 'examDateTime' => $examDateTime,
                 'primaryExaminer' => $primaryExaminer,
-            ]);
+            ])
+            ->attachData($icsContent, 'event.ics', ['mime' => 'text/calendar']);
     }
 }

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
@@ -36,12 +36,13 @@ class MentoringSessionAcceptedMentorNotification extends Notification implements
         $studentName = $session->student?->account?->name ?? 'Unknown';
         $studentCid = $session->student?->cid ?? 'Unknown';
 
+        $sessionDate = $session->taken_date->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",
             description: "Student: {$studentName} ({$studentCid})\nPosition: {$session->position}",
-            start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
-            end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
+            start: Carbon::parse("{$sessionDate} {$session->taken_from}"),
+            end: Carbon::parse("{$sessionDate} {$session->taken_to}"),
             location: $session->position,
         );
 

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
@@ -39,7 +39,7 @@ class MentoringSessionAcceptedMentorNotification extends Notification implements
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",
-            description: "Student: {$studentName} ({$studentCid})\nPosition: {$session->position}\n\nPlease ensure you are prepared to conduct this mentoring session.",
+            description: "Student: {$studentName} ({$studentCid})\nPosition: {$session->position}",
             start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
             end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
             location: $session->position,

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
@@ -36,7 +36,7 @@ class MentoringSessionAcceptedMentorNotification extends Notification implements
         $studentName = $session->student?->account?->name ?? 'Unknown';
         $studentCid = $session->student?->cid ?? 'Unknown';
 
-        $sessionDate = $session->taken_date->format('Y-m-d');
+        $sessionDate = Carbon::parse($session->taken_date)->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedMentorNotification.php
@@ -5,6 +5,8 @@ namespace App\Notifications\Training\Mentoring;
 use App\Enums\EmailType;
 use App\Models\Cts\Session;
 use App\Notifications\Contracts\HasEmailType;
+use App\Services\IcsService;
+use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -31,6 +33,17 @@ class MentoringSessionAcceptedMentorNotification extends Notification implements
     public function toMail(object $notifiable): MailMessage
     {
         $session = $this->session->loadMissing(['student', 'mentor']);
+        $studentName = $session->student?->account?->name ?? 'Unknown';
+        $studentCid = $session->student?->cid ?? 'Unknown';
+
+        $icsContent = IcsService::generate(
+            uid: "session-{$session->id}@vatsim.uk",
+            summary: "Mentoring Session - {$session->position}",
+            description: "Student: {$studentName} ({$studentCid})\nPosition: {$session->position}\n\nPlease ensure you are prepared to conduct this mentoring session.",
+            start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
+            end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
+            location: $session->position,
+        );
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
@@ -40,8 +53,9 @@ class MentoringSessionAcceptedMentorNotification extends Notification implements
                 'session' => $session,
                 'position' => $session->position,
                 'sessionDateTime' => $session->formattedSessionDateTime(),
-                'studentName' => $session->student?->account?->name ?? 'Unknown',
-                'studentCid' => $session->student?->cid ?? 'Unknown',
-            ]);
+                'studentName' => $studentName,
+                'studentCid' => $studentCid,
+            ])
+            ->attachData($icsContent, 'event.ics', ['mime' => 'text/calendar']);
     }
 }

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
@@ -5,6 +5,8 @@ namespace App\Notifications\Training\Mentoring;
 use App\Enums\EmailType;
 use App\Models\Cts\Session;
 use App\Notifications\Contracts\HasEmailType;
+use App\Services\IcsService;
+use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -31,6 +33,16 @@ class MentoringSessionAcceptedStudentNotification extends Notification implement
     public function toMail(object $notifiable): MailMessage
     {
         $session = $this->session->loadMissing(['student', 'mentor']);
+        $mentorName = $session->mentor?->account?->name ?? 'TBD';
+
+        $icsContent = IcsService::generate(
+            uid: "session-{$session->id}@vatsim.uk",
+            summary: "Mentoring Session - {$session->position}",
+            description: "Position: {$session->position}\nMentor: {$mentorName}\n\nPlease ensure you are prepared for your mentoring session.",
+            start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
+            end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
+            location: $session->position,
+        );
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
@@ -40,7 +52,8 @@ class MentoringSessionAcceptedStudentNotification extends Notification implement
                 'session' => $session,
                 'position' => $session->position,
                 'sessionDateTime' => $session->formattedSessionDateTime(),
-                'mentorName' => $session->mentor?->account?->name ?? 'TBD',
-            ]);
+                'mentorName' => $mentorName,
+            ])
+            ->attachData($icsContent, 'event.ics', ['mime' => 'text/calendar']);
     }
 }

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
@@ -38,7 +38,7 @@ class MentoringSessionAcceptedStudentNotification extends Notification implement
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",
-            description: "Position: {$session->position}\nMentor: {$mentorName}\n\nPlease ensure you are prepared for your mentoring session.",
+            description: "Position: {$session->position}\nMentor: {$mentorName}",
             start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
             end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
             location: $session->position,

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
@@ -35,12 +35,13 @@ class MentoringSessionAcceptedStudentNotification extends Notification implement
         $session = $this->session->loadMissing(['student', 'mentor']);
         $mentorName = $session->mentor?->account?->name ?? 'TBD';
 
+        $sessionDate = $session->taken_date->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",
             description: "Position: {$session->position}\nMentor: {$mentorName}",
-            start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
-            end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
+            start: Carbon::parse("{$sessionDate} {$session->taken_from}"),
+            end: Carbon::parse("{$sessionDate} {$session->taken_to}"),
             location: $session->position,
         );
 

--- a/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionAcceptedStudentNotification.php
@@ -35,7 +35,7 @@ class MentoringSessionAcceptedStudentNotification extends Notification implement
         $session = $this->session->loadMissing(['student', 'mentor']);
         $mentorName = $session->mentor?->account?->name ?? 'TBD';
 
-        $sessionDate = $session->taken_date->format('Y-m-d');
+        $sessionDate = Carbon::parse($session->taken_date)->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",

--- a/app/Notifications/Training/Mentoring/MentoringSessionRescheduledMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionRescheduledMentorNotification.php
@@ -5,6 +5,8 @@ namespace App\Notifications\Training\Mentoring;
 use App\Enums\EmailType;
 use App\Models\Cts\Session;
 use App\Notifications\Contracts\HasEmailType;
+use App\Services\IcsService;
+use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -34,6 +36,17 @@ class MentoringSessionRescheduledMentorNotification extends Notification impleme
     public function toMail(object $notifiable): MailMessage
     {
         $session = $this->session->loadMissing(['student', 'mentor']);
+        $studentName = $session->student?->account?->name ?? 'Unknown';
+        $studentCid = $session->student?->cid ?? 'Unknown';
+
+        $icsContent = IcsService::generate(
+            uid: "session-{$session->id}@vatsim.uk",
+            summary: "Mentoring Session - {$session->position}",
+            description: "Student: {$studentName} ({$studentCid})\nPosition: {$session->position}\n\nThis session has been rescheduled from its original time.",
+            start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
+            end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
+            location: $session->position,
+        );
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
@@ -44,8 +57,9 @@ class MentoringSessionRescheduledMentorNotification extends Notification impleme
                 'position' => $session->position,
                 'previousDateTime' => $this->previousDateTime,
                 'sessionDateTime' => $session->formattedSessionDateTime(),
-                'studentName' => $session->student?->account?->name ?? 'Unknown',
-                'studentCid' => $session->student?->cid ?? 'Unknown',
-            ]);
+                'studentName' => $studentName,
+                'studentCid' => $studentCid,
+            ])
+            ->attachData($icsContent, 'event.ics', ['mime' => 'text/calendar']);
     }
 }

--- a/app/Notifications/Training/Mentoring/MentoringSessionRescheduledMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionRescheduledMentorNotification.php
@@ -39,12 +39,13 @@ class MentoringSessionRescheduledMentorNotification extends Notification impleme
         $studentName = $session->student?->account?->name ?? 'Unknown';
         $studentCid = $session->student?->cid ?? 'Unknown';
 
+        $sessionDate = $session->taken_date->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",
             description: "Student: {$studentName} ({$studentCid})\nPosition: {$session->position}\n\nThis session has been rescheduled from its original time.",
-            start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
-            end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
+            start: Carbon::parse("{$sessionDate} {$session->taken_from}"),
+            end: Carbon::parse("{$sessionDate} {$session->taken_to}"),
             location: $session->position,
         );
 

--- a/app/Notifications/Training/Mentoring/MentoringSessionRescheduledMentorNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionRescheduledMentorNotification.php
@@ -39,7 +39,7 @@ class MentoringSessionRescheduledMentorNotification extends Notification impleme
         $studentName = $session->student?->account?->name ?? 'Unknown';
         $studentCid = $session->student?->cid ?? 'Unknown';
 
-        $sessionDate = $session->taken_date->format('Y-m-d');
+        $sessionDate = Carbon::parse($session->taken_date)->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",

--- a/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
@@ -38,12 +38,13 @@ class MentoringSessionRescheduledStudentNotification extends Notification implem
         $session = $this->session->loadMissing(['student', 'mentor']);
         $mentorName = $session->mentor?->account?->name ?? 'TBD';
 
+        $sessionDate = $session->taken_date->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",
             description: "Position: {$session->position}\nMentor: {$mentorName}\n\nThis session has been rescheduled from its original time.",
-            start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
-            end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
+            start: Carbon::parse("{$sessionDate} {$session->taken_from}"),
+            end: Carbon::parse("{$sessionDate} {$session->taken_to}"),
             location: $session->position,
         );
 

--- a/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
@@ -41,7 +41,7 @@ class MentoringSessionRescheduledStudentNotification extends Notification implem
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",
-            description: "Position: {$session->position}\nMentor: {$mentorName}\n\nThis session has been rescheduled from its original time. Please ensure you are prepared.",
+            description: "Position: {$session->position}\nMentor: {$mentorName}\n\nThis session has been rescheduled from its original time.",
             start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
             end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
             location: $session->position,

--- a/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
@@ -38,7 +38,7 @@ class MentoringSessionRescheduledStudentNotification extends Notification implem
         $session = $this->session->loadMissing(['student', 'mentor']);
         $mentorName = $session->mentor?->account?->name ?? 'TBD';
 
-        $sessionDate = $session->taken_date->format('Y-m-d');
+        $sessionDate = Carbon::parse($session->taken_date)->format('Y-m-d');
         $icsContent = IcsService::generate(
             uid: "session-{$session->id}@vatsim.uk",
             summary: "Mentoring Session - {$session->position}",

--- a/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionRescheduledStudentNotification.php
@@ -5,6 +5,8 @@ namespace App\Notifications\Training\Mentoring;
 use App\Enums\EmailType;
 use App\Models\Cts\Session;
 use App\Notifications\Contracts\HasEmailType;
+use App\Services\IcsService;
+use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -34,6 +36,16 @@ class MentoringSessionRescheduledStudentNotification extends Notification implem
     public function toMail(object $notifiable): MailMessage
     {
         $session = $this->session->loadMissing(['student', 'mentor']);
+        $mentorName = $session->mentor?->account?->name ?? 'TBD';
+
+        $icsContent = IcsService::generate(
+            uid: "session-{$session->id}@vatsim.uk",
+            summary: "Mentoring Session - {$session->position}",
+            description: "Position: {$session->position}\nMentor: {$mentorName}\n\nThis session has been rescheduled from its original time. Please ensure you are prepared.",
+            start: Carbon::parse("{$session->taken_date} {$session->taken_from}"),
+            end: Carbon::parse("{$session->taken_date} {$session->taken_to}"),
+            location: $session->position,
+        );
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
@@ -44,7 +56,8 @@ class MentoringSessionRescheduledStudentNotification extends Notification implem
                 'position' => $session->position,
                 'previousDateTime' => $this->previousDateTime,
                 'sessionDateTime' => $session->formattedSessionDateTime(),
-                'mentorName' => $session->mentor?->account?->name ?? 'TBD',
-            ]);
+                'mentorName' => $mentorName,
+            ])
+            ->attachData($icsContent, 'event.ics', ['mime' => 'text/calendar']);
     }
 }

--- a/app/Services/IcsService.php
+++ b/app/Services/IcsService.php
@@ -52,7 +52,7 @@ class IcsService
             $lines[] = "LOCATION:{$escapedLocation}";
         }
 
-        $lines[] = 'ORGANIZER;CN=VATSIM UK Training Department:mailto:training@vatsim.uk';
+        $lines[] = 'ORGANIZER;CN=VATSIM UK Training Department:mailto:atc-training@vatsim.uk';
         $lines[] = 'END:VEVENT';
         $lines[] = 'END:VCALENDAR';
 

--- a/app/Services/IcsService.php
+++ b/app/Services/IcsService.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+
+class IcsService
+{
+    /**
+     * Generate an ICS calendar attachment string.
+     *
+     * @param  string  $uid  Unique identifier for the event (e.g. 'exam-123@vatsim.uk')
+     * @param  string  $summary  Event title/summary
+     * @param  string  $description  Event description (plain text)
+     * @param  Carbon  $start  Event start date/time (will be treated as UTC)
+     * @param  Carbon  $end  Event end date/time (will be treated as UTC)
+     * @param  string  $location  Optional location (e.g. ATC position)
+     * @return string Raw ICS content
+     */
+    public static function generate(
+        string $uid,
+        string $summary,
+        string $description,
+        Carbon $start,
+        Carbon $end,
+        string $location = ''
+    ): string {
+        $dtStart = self::formatUtc($start);
+        $dtEnd = self::formatUtc($end);
+        $dtStamp = self::formatUtc(Carbon::now('UTC'));
+
+        $escapedSummary = self::escapeText($summary);
+        $escapedDescription = self::escapeText($description);
+
+        $lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//VATSIM UK//Core//EN',
+            'CALSCALE:GREGORIAN',
+            'METHOD:PUBLISH',
+            'BEGIN:VEVENT',
+            "UID:{$uid}",
+            "DTSTAMP:{$dtStamp}",
+            "DTSTART:{$dtStart}",
+            "DTEND:{$dtEnd}",
+            "SUMMARY:{$escapedSummary}",
+            "DESCRIPTION:{$escapedDescription}",
+        ];
+
+        if (! empty($location)) {
+            $escapedLocation = self::escapeText($location);
+            $lines[] = "LOCATION:{$escapedLocation}";
+        }
+
+        $lines[] = 'ORGANIZER;CN=VATSIM UK Training Department:mailto:training@vatsim.uk';
+        $lines[] = 'END:VEVENT';
+        $lines[] = 'END:VCALENDAR';
+
+        $icsContent = implode("\r\n", $lines);
+
+        return self::foldLines($icsContent);
+    }
+
+    /**
+     * Format a Carbon instance as a UTC ICS date-time string (e.g. 20260101T120000Z).
+     */
+    private static function formatUtc(Carbon $date): string
+    {
+        return $date->copy()->setTimezone('UTC')->format('Ymd\THis\Z');
+    }
+
+    /**
+     * Escape special characters in ICS text values
+     */
+    private static function escapeText(string $text): string
+    {
+        $replacements = [
+            '\\' => '\\\\',
+            ';' => '\\;',
+            ',' => '\\,',
+            "\n" => '\\n',
+            "\r" => '',
+        ];
+
+        return str_replace(array_keys($replacements), array_values($replacements), $text);
+    }
+
+    /**
+     * Fold lines longer than 75 octets
+     */
+    private static function foldLines(string $content): string
+    {
+        $lines = explode("\r\n", $content);
+        $foldedLines = [];
+
+        foreach ($lines as $line) {
+            if (strlen($line) > 75) {
+                $foldedLines[] = rtrim(chunk_split($line, 74, "\r\n "));
+            } else {
+                $foldedLines[] = $line;
+            }
+        }
+
+        return implode("\r\n", $foldedLines)."\r\n";
+    }
+}

--- a/app/Services/Training/MentoringReportService.php
+++ b/app/Services/Training/MentoringReportService.php
@@ -79,7 +79,8 @@ class MentoringReportService
             return false;
         }
 
-        $sessionStart = Carbon::parse($session->taken_date->format('Y-m-d').' '.$session->taken_from);
+        $sessionDate = Carbon::parse($session->taken_date)->format('Y-m-d');
+        $sessionStart = Carbon::parse("{$sessionDate} {$session->taken_from}");
         $delayMinutes = config('training.mentoring.no_show_delay_minutes', 5);
 
         return now()->greaterThanOrEqualTo($sessionStart->copy()->addMinutes($delayMinutes));
@@ -91,7 +92,8 @@ class MentoringReportService
             return false;
         }
 
-        $sessionStart = Carbon::parse($session->taken_date->format('Y-m-d').' '.$session->taken_from);
+        $sessionDate = Carbon::parse($session->taken_date)->format('Y-m-d');
+        $sessionStart = Carbon::parse("{$sessionDate} {$session->taken_from}");
         $bookedAt = Carbon::parse($session->taken_time);
         $shortNoticeHours = config('training.mentoring.short_notice_hours', 24);
 

--- a/app/Services/Training/MentoringReportService.php
+++ b/app/Services/Training/MentoringReportService.php
@@ -79,8 +79,7 @@ class MentoringReportService
             return false;
         }
 
-        $sessionDate = Carbon::parse($session->taken_date)->format('Y-m-d');
-        $sessionStart = Carbon::parse("{$sessionDate} {$session->taken_from}");
+        $sessionStart = Carbon::parse($session->taken_date->format('Y-m-d').' '.$session->taken_from);
         $delayMinutes = config('training.mentoring.no_show_delay_minutes', 5);
 
         return now()->greaterThanOrEqualTo($sessionStart->copy()->addMinutes($delayMinutes));
@@ -92,8 +91,7 @@ class MentoringReportService
             return false;
         }
 
-        $sessionDate = Carbon::parse($session->taken_date)->format('Y-m-d');
-        $sessionStart = Carbon::parse("{$sessionDate} {$session->taken_from}");
+        $sessionStart = Carbon::parse($session->taken_date->format('Y-m-d').' '.$session->taken_from);
         $bookedAt = Carbon::parse($session->taken_time);
         $shortNoticeHours = config('training.mentoring.short_notice_hours', 24);
 

--- a/app/Services/Training/MentoringReportService.php
+++ b/app/Services/Training/MentoringReportService.php
@@ -79,7 +79,7 @@ class MentoringReportService
             return false;
         }
 
-        $sessionStart = Carbon::parse("{$session->taken_date} {$session->taken_from}");
+        $sessionStart = Carbon::parse($session->taken_date->format('Y-m-d').' '.$session->taken_from);
         $delayMinutes = config('training.mentoring.no_show_delay_minutes', 5);
 
         return now()->greaterThanOrEqualTo($sessionStart->copy()->addMinutes($delayMinutes));
@@ -91,7 +91,7 @@ class MentoringReportService
             return false;
         }
 
-        $sessionStart = Carbon::parse("{$session->taken_date} {$session->taken_from}");
+        $sessionStart = Carbon::parse($session->taken_date->format('Y-m-d').' '.$session->taken_from);
         $bookedAt = Carbon::parse($session->taken_time);
         $shortNoticeHours = config('training.mentoring.short_notice_hours', 24);
 

--- a/app/Services/Training/MentoringReportService.php
+++ b/app/Services/Training/MentoringReportService.php
@@ -79,7 +79,7 @@ class MentoringReportService
             return false;
         }
 
-        $sessionStart = Carbon::parse($session->taken_date->format('Y-m-d').' '.$session->taken_from);
+        $sessionStart = Carbon::parse("{$session->taken_date} {$session->taken_from}");
         $delayMinutes = config('training.mentoring.no_show_delay_minutes', 5);
 
         return now()->greaterThanOrEqualTo($sessionStart->copy()->addMinutes($delayMinutes));
@@ -91,7 +91,7 @@ class MentoringReportService
             return false;
         }
 
-        $sessionStart = Carbon::parse($session->taken_date->format('Y-m-d').' '.$session->taken_from);
+        $sessionStart = Carbon::parse("{$session->taken_date} {$session->taken_from}");
         $bookedAt = Carbon::parse($session->taken_time);
         $shortNoticeHours = config('training.mentoring.short_notice_hours', 24);
 

--- a/tests/Unit/Services/IcsServiceTest.php
+++ b/tests/Unit/Services/IcsServiceTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\IcsService;
+use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class IcsServiceTest extends TestCase
+{
+    #[Test]
+    public function it_generates_valid_ics_content(): void
+    {
+        $start = Carbon::parse('2026-06-20 12:00:00', 'UTC');
+        $end = Carbon::parse('2026-06-20 13:30:00', 'UTC');
+
+        $ics = IcsService::generate(
+            uid: 'exam-42@vatsim.uk',
+            summary: 'Practical Exam - APP',
+            description: 'Exam Type: APP\nPosition: EGKK_APP\nPrimary Examiner: John Smith',
+            start: $start,
+            end: $end,
+            location: 'EGKK_APP',
+        );
+
+        $this->assertStringContainsString('BEGIN:VCALENDAR', $ics);
+        $this->assertStringContainsString('END:VCALENDAR', $ics);
+        $this->assertStringContainsString('BEGIN:VEVENT', $ics);
+        $this->assertStringContainsString('END:VEVENT', $ics);
+        $this->assertStringContainsString('VERSION:2.0', $ics);
+        $this->assertStringContainsString('PRODID:-//VATSIM UK//Core//EN', $ics);
+        $this->assertStringContainsString('METHOD:PUBLISH', $ics);
+        $this->assertStringContainsString('UID:exam-42@vatsim.uk', $ics);
+        $this->assertStringContainsString('DTSTART:20260620T120000Z', $ics);
+        $this->assertStringContainsString('DTEND:20260620T133000Z', $ics);
+        $this->assertStringContainsString('SUMMARY:Practical Exam - APP', $ics);
+        $this->assertStringContainsString('LOCATION:EGKK_APP', $ics);
+        $this->assertStringContainsString('ORGANIZER;CN=VATSIM UK Training Department:mailto:training@vatsim.uk', $ics);
+    }
+
+    #[Test]
+    public function it_escapes_special_characters(): void
+    {
+        $start = Carbon::parse('2026-06-20 12:00:00', 'UTC');
+        $end = Carbon::parse('2026-06-20 13:00:00', 'UTC');
+
+        $ics = IcsService::generate(
+            uid: 'test-1@vatsim.uk',
+            summary: 'Test;Summary,With:Special\\Chars',
+            description: "Line one\nLine two\nComma, semicolon; backslash\\",
+            start: $start,
+            end: $end,
+        );
+
+        $this->assertStringContainsString('SUMMARY:Test\\;Summary\\,With:Special\\\\Chars', $ics);
+        $this->assertStringContainsString('DESCRIPTION:Line one\\nLine two\\nComma\\, semicolon\\; backslash\\\\', $ics);
+    }
+
+    #[Test]
+    public function it_handles_empty_location(): void
+    {
+        $start = Carbon::parse('2026-06-20 12:00:00', 'UTC');
+        $end = Carbon::parse('2026-06-20 13:00:00', 'UTC');
+
+        $ics = IcsService::generate(
+            uid: 'session-1@vatsim.uk',
+            summary: 'Mentoring Session',
+            description: 'A mentoring session',
+            start: $start,
+            end: $end,
+        );
+
+        $this->assertStringContainsString('LOCATION:', $ics);
+        $this->assertStringContainsString('ORGANIZER;CN=VATSIM UK Training Department:mailto:training@vatsim.uk', $ics);
+    }
+
+    #[Test]
+    public function it_uses_deterministic_uid(): void
+    {
+        $start = Carbon::parse('2026-06-20 12:00:00', 'UTC');
+        $end = Carbon::parse('2026-06-20 13:00:00', 'UTC');
+
+        $ics1 = IcsService::generate(
+            uid: 'exam-42@vatsim.uk',
+            summary: 'Test',
+            description: 'Test',
+            start: $start,
+            end: $end,
+        );
+
+        $ics2 = IcsService::generate(
+            uid: 'exam-42@vatsim.uk',
+            summary: 'Test',
+            description: 'Test',
+            start: $start,
+            end: $end,
+        );
+
+        // Both should contain the same UID
+        $this->assertStringContainsString('UID:exam-42@vatsim.uk', $ics1);
+        $this->assertStringContainsString('UID:exam-42@vatsim.uk', $ics2);
+    }
+
+    #[Test]
+    public function it_formats_dates_in_utc_correctly(): void
+    {
+        // Test with a non-UTC input timezone
+        $start = Carbon::parse('2026-06-20 14:00:00', 'Europe/London');
+        $end = Carbon::parse('2026-06-20 15:00:00', 'Europe/London');
+
+        $ics = IcsService::generate(
+            uid: 'test-tz@vatsim.uk',
+            summary: 'Timezone Test',
+            description: 'Testing timezone conversion',
+            start: $start,
+            end: $end,
+        );
+
+        // Europe/London on 20 June is UTC+1 (BST), so 14:00 BST = 13:00 UTC
+        $this->assertStringContainsString('DTSTART:20260620T130000Z', $ics);
+        $this->assertStringContainsString('DTEND:20260620T140000Z', $ics);
+    }
+
+    #[Test]
+    public function it_includes_dtstamp(): void
+    {
+        $start = Carbon::parse('2026-06-20 12:00:00', 'UTC');
+        $end = Carbon::parse('2026-06-20 13:00:00', 'UTC');
+
+        $ics = IcsService::generate(
+            uid: 'test-stamp@vatsim.uk',
+            summary: 'Test',
+            description: 'Test',
+            start: $start,
+            end: $end,
+        );
+
+        // DTSTAMP should be in UTC format
+        $this->assertMatchesRegularExpression('/DTSTAMP:\d{8}T\d{6}Z/', $ics);
+    }
+}

--- a/tests/Unit/Services/IcsServiceTest.php
+++ b/tests/Unit/Services/IcsServiceTest.php
@@ -73,8 +73,8 @@ class IcsServiceTest extends TestCase
             end: $end,
         );
 
-        $this->assertStringContainsString('LOCATION:', $ics);
-        $this->assertStringContainsString('ORGANIZER;CN=VATSIM UK Training Department:mailto:training@vatsim.uk', $ics);
+        $this->assertStringNotContainsString('LOCATION:', $ics);
+        $this->assertStringContainsString('ORGANIZER;CN=VATSIM UK Training Department:mailto:atc-training@vatsim.uk', $ics);
     }
 
     #[Test]

--- a/tests/Unit/Services/IcsServiceTest.php
+++ b/tests/Unit/Services/IcsServiceTest.php
@@ -38,7 +38,7 @@ class IcsServiceTest extends TestCase
         $this->assertStringContainsString('DTEND:20260620T133000Z', $ics);
         $this->assertStringContainsString('SUMMARY:Practical Exam - APP', $ics);
         $this->assertStringContainsString('LOCATION:EGKK_APP', $ics);
-        $this->assertStringContainsString('ORGANIZER;CN=VATSIM UK Training Department:mailto:training@vatsim.uk', $ics);
+        $this->assertStringContainsString('ORGANIZER;CN=VATSIM UK Training Department:mailto:atc-training@vatsim.uk', $ics);
     }
 
     #[Test]


### PR DESCRIPTION
Adds an ICS attachment (https://en.wikipedia.org/wiki/ICalendar)  to booking emails which allows easy "add to calendar" buttons in most mail clients

<img width="475" height="308" alt="image" src="https://github.com/user-attachments/assets/d9f2bd44-bda7-4f22-8d07-d7b1df00e12d" />
