### PR TITLE
feat: add My Accepted Mentoring Sessions to My Training

### DIFF
--- a/app/Livewire/Training/MyAcceptedMentoringSessionsTable.php
+++ b/app/Livewire/Training/MyAcceptedMentoringSessionsTable.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Livewire\Training;
+
+use App\Models\Cts\Session;
+use Carbon\Carbon;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Component;
+
+class MyAcceptedMentoringSessionsTable extends Component implements HasActions, HasForms, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+    use InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->heading('My Accepted Mentoring Sessions')
+            ->description('Your mentoring sessions that have been accepted')
+            ->query(
+                Session::query()
+                    ->with(['student', 'mentor'])
+                    ->where('student_id', auth()->user()->member->id)
+                    ->whereNull('filed')
+                    ->whereNull('cancelled_datetime')
+                    ->where('taken', 1)
+                    ->where('noShow', 0)
+            )
+            ->defaultSort('taken_date', 'asc')
+            ->columns([
+                TextColumn::make('mentor_name')
+                    ->label('Mentor')
+                    ->getStateUsing(fn (Session $record) => $record->mentor?->name ?? 'Unknown')
+                    ->description(fn (Session $record) => $record->mentor?->cid ?? 'Unknown'),
+
+                TextColumn::make('position')
+                    ->label('Position')
+                    ->badge()
+                    ->color('gray'),
+
+                TextColumn::make('taken_date')
+                    ->label('Date & Time')
+                    ->getStateUsing(function (Session $record) {
+                        $date = Carbon::parse($record->taken_date)->format('d/m/Y');
+                        $start = Carbon::parse($record->taken_from)->format('H:i');
+                        $end = Carbon::parse($record->taken_to)->format('H:i');
+
+                        return trim("{$date} {$start} - {$end}");
+                    })
+                    ->description(function (Session $record) {
+                        $sessionStart = Carbon::parse("{$record->taken_date} {$record->taken_from}");
+
+                        if ($sessionStart->isPast()) {
+                            return 'Started '.$sessionStart->diffForHumans();
+                        }
+
+                        return 'Starts '.$sessionStart->diffForHumans();
+                    })
+                    ->sortable(query: fn (Builder $query, string $direction) => $query
+                        ->orderBy('taken_date', $direction)
+                        ->orderBy('taken_from', $direction)
+                    ),
+            ])
+            ->emptyStateHeading('No upcoming mentoring sessions found');
+    }
+
+    public function render()
+    {
+        return view('livewire.training.my-accepted-mentoring-sessions-table');
+    }
+}

--- a/app/Livewire/Training/MyAcceptedMentoringSessionsTable.php
+++ b/app/Livewire/Training/MyAcceptedMentoringSessionsTable.php
@@ -54,7 +54,7 @@ class MyAcceptedMentoringSessionsTable extends Component implements HasActions, 
                         $start = Carbon::parse($record->taken_from)->format('H:i');
                         $end = Carbon::parse($record->taken_to)->format('H:i');
 
-                        return trim("{$date} {$start}Z - {$end}Z");
+                        return trim("{$date} {$start} - {$end}");
                     })
                     ->description(function (Session $record) {
                         $sessionStart = Carbon::parse("{$record->taken_date} {$record->taken_from}");

--- a/app/Livewire/Training/MyAcceptedMentoringSessionsTable.php
+++ b/app/Livewire/Training/MyAcceptedMentoringSessionsTable.php
@@ -54,7 +54,7 @@ class MyAcceptedMentoringSessionsTable extends Component implements HasActions, 
                         $start = Carbon::parse($record->taken_from)->format('H:i');
                         $end = Carbon::parse($record->taken_to)->format('H:i');
 
-                        return trim("{$date} {$start} - {$end}");
+                        return trim("{$date} {$start}Z - {$end}Z");
                     })
                     ->description(function (Session $record) {
                         $sessionStart = Carbon::parse("{$record->taken_date} {$record->taken_from}");

--- a/resources/views/filament/training/pages/my-training/my-availability.blade.php
+++ b/resources/views/filament/training/pages/my-training/my-availability.blade.php
@@ -57,4 +57,7 @@ $watch('$wire.data.date_range', (value) => {
 		</div>
 	</div>
 	<x-filament-actions::modals />
+
+	@livewire(\App\Livewire\Training\MyAcceptedMentoringSessionsTable::class)
+
 </x-filament-panels::page>

--- a/resources/views/livewire/training/my-accepted-mentoring-sessions-table.blade.php
+++ b/resources/views/livewire/training/my-accepted-mentoring-sessions-table.blade.php
@@ -1,0 +1,3 @@
+<div>
+	{{ $this->table }}
+</div>

--- a/tests/Feature/TrainingPanel/MyTraining/MyAcceptedMentoringSessionsTableTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyAcceptedMentoringSessionsTableTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\MyTraining;
+
+use App\Livewire\Training\MyAcceptedMentoringSessionsTable;
+use App\Models\Cts\Member;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class MyAcceptedMentoringSessionsTableTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    protected Account $studentAccount;
+
+    protected Member $studentMember;
+
+    protected Member $mentorMember;
+
+    protected Session $acceptedSession;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->studentAccount = Account::factory()->create();
+        $this->studentMember = Member::factory()->create([
+            'id' => $this->studentAccount->id,
+            'cid' => $this->studentAccount->id,
+        ]);
+
+        $mentorAccount = Account::factory()->create();
+        $this->mentorMember = Member::factory()->create([
+            'id' => $mentorAccount->id,
+            'cid' => $mentorAccount->id,
+        ]);
+
+        $this->acceptedSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => now()->addDays(1)->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+            'noShow' => 0,
+        ]);
+
+        $this->studentAccount->givePermissionTo('training.access');
+    }
+
+    #[Test]
+    public function member_with_training_access_can_view_the_table(): void
+    {
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAcceptedMentoringSessionsTable::class)
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_shows_accepted_sessions_for_the_authenticated_member(): void
+    {
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAcceptedMentoringSessionsTable::class)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$this->acceptedSession]);
+    }
+
+    #[Test]
+    public function it_excludes_sessions_for_other_students(): void
+    {
+        $otherAccount = Account::factory()->create();
+        $otherMember = Member::factory()->create([
+            'id' => $otherAccount->id,
+            'cid' => $otherAccount->id,
+        ]);
+
+        $otherSession = Session::factory()->create([
+            'student_id' => $otherMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGKK_APP',
+            'taken' => 1,
+            'taken_date' => now()->addDays(2)->format('Y-m-d'),
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+            'noShow' => 0,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAcceptedMentoringSessionsTable::class)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$this->acceptedSession])
+            ->assertCanNotSeeTableRecords([$otherSession]);
+    }
+
+    #[Test]
+    public function it_excludes_cancelled_sessions(): void
+    {
+        $cancelledSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_GND',
+            'taken' => 1,
+            'taken_date' => now()->addDays(3)->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'filed' => null,
+            'cancelled_datetime' => now(),
+            'noShow' => 0,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAcceptedMentoringSessionsTable::class)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$this->acceptedSession])
+            ->assertCanNotSeeTableRecords([$cancelledSession]);
+    }
+
+    #[Test]
+    public function it_excludes_filed_sessions(): void
+    {
+        $filedSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_TWR',
+            'taken' => 1,
+            'taken_date' => now()->addDays(3)->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'filed' => now(),
+            'cancelled_datetime' => null,
+            'noShow' => 0,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAcceptedMentoringSessionsTable::class)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$this->acceptedSession])
+            ->assertCanNotSeeTableRecords([$filedSession]);
+    }
+
+    #[Test]
+    public function it_excludes_sessions_marked_as_no_show(): void
+    {
+        $noShowSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => now()->addDays(3)->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+            'noShow' => 1,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAcceptedMentoringSessionsTable::class)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$this->acceptedSession])
+            ->assertCanNotSeeTableRecords([$noShowSession]);
+    }
+
+    #[Test]
+    public function it_shows_empty_state_when_no_sessions_exist(): void
+    {
+        $emptyAccount = Account::factory()->create();
+        Member::factory()->create([
+            'id' => $emptyAccount->id,
+            'cid' => $emptyAccount->id,
+        ]);
+        $emptyAccount->givePermissionTo('training.access');
+
+        Livewire::actingAs($emptyAccount)
+            ->test(MyAcceptedMentoringSessionsTable::class)
+            ->assertSuccessful()
+            ->assertSee('No upcoming mentoring sessions found');
+    }
+}


### PR DESCRIPTION
# Summary of changes
- Adds student facing table of accepted mentoring sessions
- Sessions stay in the table until a report is filed
- Will eventually hold the student cancel action
- Doesn't do timezone conversion like the rest of my availability

# Screenshots (if necessary)
<img width="1325" height="980" alt="image" src="https://github.com/user-attachments/assets/496f4cfb-b80b-4c70-9e41-a4611ee89292" />