### PR TITLE
feat: allow students to cancel their own sessions

### DIFF
--- a/app/Enums/EmailType.php
+++ b/app/Enums/EmailType.php
@@ -8,6 +8,7 @@ enum EmailType: string
     case SessionAcceptedByMentor = 'session_accepted_by_mentor';
     case SessionCancelledByMentor = 'session_cancelled_by_mentor';
     case SessionRescheduledByMentor = 'session_rescheduled_by_mentor';
+    case SessionCancelledByStudent = 'session_cancelled_by_student';
 
     // Student - Exams
     case ExamAccepted = 'exam_accepted';
@@ -29,6 +30,7 @@ enum EmailType: string
             self::SessionAcceptedByMentor => 'Mentor accepts session',
             self::SessionCancelledByMentor => 'Mentor cancels session',
             self::SessionRescheduledByMentor => 'Mentor reschedules session',
+            self::SessionCancelledByStudent => 'Student cancels session',
 
             // Student - Exams
             self::ExamAccepted => 'Exam accepted',
@@ -52,6 +54,7 @@ enum EmailType: string
             self::SessionAcceptedByMentor => 'Sent when a mentor accepts your session request',
             self::SessionCancelledByMentor => 'Sent when a mentor cancels your session',
             self::SessionRescheduledByMentor => 'Sent when a mentor reschedules your session',
+            self::SessionCancelledByStudent => 'Sent when you cancel your own session',
 
             // Student - Exams
             self::ExamAccepted => 'Sent when an examiner accepts your exam request',
@@ -74,6 +77,7 @@ enum EmailType: string
             self::SessionAcceptedByMentor,
             self::SessionCancelledByMentor,
             self::SessionRescheduledByMentor,
+            self::SessionCancelledByStudent,
             self::ExamAccepted,
             self::ExamCancelled => 'Student',
 

--- a/app/Livewire/Training/MyAcceptedMentoringSessionsTable.php
+++ b/app/Livewire/Training/MyAcceptedMentoringSessionsTable.php
@@ -3,11 +3,16 @@
 namespace App\Livewire\Training;
 
 use App\Models\Cts\Session;
+use App\Services\Training\MentoringSessionsService;
 use Carbon\Carbon;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
@@ -70,7 +75,47 @@ class MyAcceptedMentoringSessionsTable extends Component implements HasActions, 
                         ->orderBy('taken_from', $direction)
                     ),
             ])
+            ->actions([
+                ActionGroup::make([
+                    $this->cancelSessionAction(),
+                ]),
+            ])
             ->emptyStateHeading('No upcoming mentoring sessions found');
+    }
+
+    public function cancelSessionAction(): Action
+    {
+        return Action::make('cancel')
+            ->label('Cancel Session')
+            ->icon('heroicon-m-x-circle')
+            ->color('danger')
+            ->visible(fn (Session $record): bool => Carbon::parse("{$record->taken_date} {$record->taken_from}")->isFuture())
+            ->modalHeading(fn (Session $record) => 'Cancel Session')
+            ->modalDescription(fn (Session $record) => 'Please provide a reason for cancelling this session, it will be visible to the mentor and relevent training staff.')
+            ->modalSubmitActionLabel('Cancel Session')
+            ->form([
+                Textarea::make('reason')
+                    ->label('Cancellation Reason')
+                    ->required()
+                    ->minLength(10),
+            ])
+            ->action(function (array $data, Session $record, MentoringSessionsService $mentoringService) {
+                $success = $mentoringService->cancelSession($record->id, $data['reason'], auth()->user());
+
+                if ($success) {
+                    Notification::make()
+                        ->title('Session Cancelled')
+                        ->body('Your seession has been successfully cancelled.')
+                        ->success()
+                        ->send();
+                } else {
+                    Notification::make()
+                        ->title('Cancellation Failed')
+                        ->body('Could not cancel the session. It may have already been modified or completed.')
+                        ->danger()
+                        ->send();
+                }
+            });
     }
 
     public function render()

--- a/app/Notifications/Training/Mentoring/MentoringSessionCancelledByStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionCancelledByStudentNotification.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications\Training\Mentoring;
+
+use App\Enums\EmailType;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use App\Notifications\Contracts\HasEmailType;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MentoringSessionCancelledByStudentNotification extends Notification implements HasEmailType
+{
+    use Queueable;
+
+    public function __construct(
+        private Session $session,
+        private string $reason,
+    ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::MentorSessionCancelled;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $session = $this->session->loadMissing('student');
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
+            ->subject('VATSIM UK - Mentoring Session Cancelled')
+            ->view('emails.training.mentoring.session_cancelled_by_student', [
+                'recipient' => $notifiable,
+                'session' => $session,
+                'reason' => $this->reason,
+            ]);
+    }
+}

--- a/app/Notifications/Training/Mentoring/MentoringSessionCancelledByStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionCancelledByStudentNotification.php
@@ -4,7 +4,6 @@ namespace App\Notifications\Training\Mentoring;
 
 use App\Enums\EmailType;
 use App\Models\Cts\Session;
-use App\Models\Mship\Account;
 use App\Notifications\Contracts\HasEmailType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;

--- a/app/Notifications/Training/Mentoring/MentoringSessionCancelledStudentConfirmationNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionCancelledStudentConfirmationNotification.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Notifications\Training\Mentoring;
+
+use App\Enums\EmailType;
+use App\Models\Cts\Session;
+use App\Notifications\Contracts\HasEmailType;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MentoringSessionCancelledStudentConfirmationNotification extends Notification implements HasEmailType
+{
+    use Queueable;
+
+    public function __construct(
+        private Session $session,
+    ) {}
+
+    public function getEmailType(): EmailType
+    {
+        return EmailType::SessionCancelledByStudent;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $this->session->loadMissing('student');
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
+            ->subject('VATSIM UK - Mentoring Session Cancelled')
+            ->view('emails.training.mentoring.session_cancelled_student_confirmation', [
+                'recipient' => $notifiable,
+                'session' => $this->session,
+            ]);
+    }
+}

--- a/app/Policies/Training/Mentoring/MentoringPolicy.php
+++ b/app/Policies/Training/Mentoring/MentoringPolicy.php
@@ -144,7 +144,13 @@ class MentoringPolicy
             return true;
         }
 
-        return $this->isAssignedMentor($user, $session);
+        if ($this->isAssignedMentor($user, $session)) {
+            return true;
+        }
+
+        $member = Member::where('cid', $user->id)->first();
+
+        return $member && $session->student_id === $member->id;
     }
 
     /**

--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -10,7 +10,9 @@ use App\Models\Cts\Session;
 use App\Models\Mship\Account;
 use App\Notifications\Training\Mentoring\MentoringSessionAcceptedMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionAcceptedStudentNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionCancelledByStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledMentorNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionCancelledStudentConfirmationNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionReallocatedNewMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionReallocatedOldMentorNotification;
@@ -204,8 +206,15 @@ class MentoringSessionsService
                 break;
 
             case 'cancelled':
-                $studentAccount->notify(new MentoringSessionCancelledStudentNotification($session, $data['cancellerAccount'], $data['reason']));
-                $mentorAccount->notify(new MentoringSessionCancelledMentorNotification($session, $data['reason']));
+                $cancellerAccount = $data['cancellerAccount'];
+
+                if ($cancellerAccount->id === $studentAccount->id) {
+                    $mentorAccount->notify(new MentoringSessionCancelledByStudentNotification($session, $data['reason']));
+                    $studentAccount->notify(new MentoringSessionCancelledStudentConfirmationNotification($session));
+                } else {
+                    $studentAccount->notify(new MentoringSessionCancelledStudentNotification($session, $cancellerAccount, $data['reason']));
+                    $mentorAccount->notify(new MentoringSessionCancelledMentorNotification($session, $data['reason']));
+                }
                 break;
 
             case 'reallocated':

--- a/resources/views/emails/training/mentoring/session_cancelled_by_student.blade.php
+++ b/resources/views/emails/training/mentoring/session_cancelled_by_student.blade.php
@@ -1,0 +1,24 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>{{ $session->student->name }} has cancelled your mentoring session, which was due to take place on {{ $session->position }} on {{ \Carbon\Carbon::parse($session->taken_date)->format('l jS M y') }} at {{ \Carbon\Carbon::parse($session->taken_from)->format('H:i') }}Z.</p>
+
+    @if(!empty($reason))
+        <p>Your student left this message for you:</p>
+        <p>{{ $reason }}</p>
+    @endif
+
+    <p>We apologise for any inconvenience caused. If you are still available:</p>
+
+    <ul>
+        <li>Please consider picking up another session if there is sufficient availability in the system.</li>
+        <li>If the session was due to take place within the next 24 hours, please solicit the availability of students in the training group's students channel in the VATSIM UK Discord.</li>
+        <li>If no students are available, please try to support other mentoring by other controlling adjacent positions or flying.</li>
+    </ul>
+
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
+@stop
+
+@section('signature')
+    VATSIM UK Training Department
+@stop

--- a/resources/views/emails/training/mentoring/session_cancelled_student_confirmation.blade.php
+++ b/resources/views/emails/training/mentoring/session_cancelled_student_confirmation.blade.php
@@ -1,0 +1,11 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>You have cancelled your mentoring session, which was due to take place on {{ $session->position }} on {{ \Carbon\Carbon::parse($session->taken_date)->format('l jS M y') }} at {{ \Carbon\Carbon::parse($session->taken_from)->format('H:i') }}Z.</p>
+
+    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+@stop
+
+@section('signature')
+    VATSIM UK Training Department
+@stop

--- a/resources/views/emails/training/mentoring/session_cancelled_student_confirmation.blade.php
+++ b/resources/views/emails/training/mentoring/session_cancelled_student_confirmation.blade.php
@@ -3,7 +3,7 @@
 @section('body')
     <p>You have cancelled your mentoring session, which was due to take place on {{ $session->position }} on {{ \Carbon\Carbon::parse($session->taken_date)->format('l jS M y') }} at {{ \Carbon\Carbon::parse($session->taken_from)->format('H:i') }}Z.</p>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')

--- a/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
@@ -13,7 +13,9 @@ use App\Models\Training\Mentoring\MentorTrainingPosition;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Notifications\Training\Mentoring\MentoringSessionAcceptedMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionAcceptedStudentNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionCancelledByStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledMentorNotification;
+use App\Notifications\Training\Mentoring\MentoringSessionCancelledStudentConfirmationNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionCancelledStudentNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionReallocatedNewMentorNotification;
 use App\Notifications\Training\Mentoring\MentoringSessionReallocatedOldMentorNotification;
@@ -468,6 +470,109 @@ class MentoringSessionsServiceTest extends TestCase
 
         Notification::assertSentTo($this->studentAccount, MentoringSessionCancelledStudentNotification::class);
         Notification::assertSentTo($this->mentorAccount, MentoringSessionCancelledMentorNotification::class);
+    }
+
+    #[Test]
+    public function cancel_session_by_student_marks_session_as_cancelled(): void
+    {
+        Notification::fake();
+
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+            'cancelled_datetime' => null,
+        ]);
+
+        $this->assertTrue($this->service->cancelSession($session->id, 'Unable to attend.', $this->studentAccount));
+
+        $this->assertNotNull($session->fresh()->cancelled_datetime);
+    }
+
+    #[Test]
+    public function cancel_session_by_student_inserts_cancel_reason_record_with_student_id(): void
+    {
+        Notification::fake();
+
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+        ]);
+
+        $reason = 'Student has a prior commitment.';
+
+        $this->service->cancelSession($session->id, $reason, $this->studentAccount);
+
+        $this->assertDatabaseHas('cancel_reason', [
+            'sesh_id' => $session->id,
+            'sesh_type' => 'ME',
+            'reason' => $reason,
+            'reason_by' => $this->studentMember->id,
+        ], 'cts');
+    }
+
+    #[Test]
+    public function cancel_session_by_student_creates_new_pending_session_request(): void
+    {
+        Notification::fake();
+
+        $session = Session::factory()->create([
+            'rts_id' => 42,
+            'position' => 'EGLL_APP',
+            'progress_sheet_id' => 7,
+            'student_id' => $this->studentMember->id,
+            'student_rating' => 3,
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+        ]);
+
+        $this->service->cancelSession(
+            $session->id,
+            'Unable to attend.',
+            $this->studentAccount,
+        );
+
+        $newPending = Session::query()
+            ->where('student_id', $this->studentMember->id)
+            ->whereNull('mentor_id')
+            ->whereNull('cancelled_datetime')
+            ->where('id', '!=', $session->id)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($newPending);
+        $this->assertSame(42, $newPending->rts_id);
+        $this->assertSame('EGLL_APP', $newPending->position);
+        $this->assertSame(7, $newPending->progress_sheet_id);
+        $this->assertSame(3, $newPending->student_rating);
+        $this->assertNotNull($newPending->request_time);
+    }
+
+    #[Test]
+    public function cancel_session_by_student_sends_correct_notifications(): void
+    {
+        Notification::fake();
+
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+        ]);
+
+        $this->assertTrue($this->service->cancelSession(
+            $session->id,
+            'Unable to attend.',
+            $this->studentAccount,
+        ));
+
+        Notification::assertSentTo($this->mentorAccount, MentoringSessionCancelledByStudentNotification::class);
+        Notification::assertSentTo($this->studentAccount, MentoringSessionCancelledStudentConfirmationNotification::class);
+        Notification::assertNotSentTo($this->studentAccount, MentoringSessionCancelledStudentNotification::class);
+        Notification::assertNotSentTo($this->mentorAccount, MentoringSessionCancelledMentorNotification::class);
     }
 
     #[Test]


### PR DESCRIPTION
# Summary of changes
- Allows students to cancel their own sessions

# Screenshots (if necessary)
<img width="1030" height="314" alt="image" src="https://github.com/user-attachments/assets/d0d4f64a-8d21-49f8-bddb-d963aedc5379" />
<img width="1008" height="340" alt="image" src="https://github.com/user-attachments/assets/29bcba2a-ea65-470b-a94c-1ac0ea2d9e50" />
<img width="781" height="517" alt="image" src="https://github.com/user-attachments/assets/195edbe2-35e0-413f-9227-293429917e18" />
<img width="785" height="279" alt="image" src="https://github.com/user-attachments/assets/358a8572-35b0-4a90-8c4c-7fdb89f4627d" />
