### PR TITLE
fix: replace "STUDENT menu" email preference text with "Training Panel" in all mentoring emails

### DIFF
--- a/resources/views/emails/training/mentoring/session_accepted_mentor.blade.php
+++ b/resources/views/emails/training/mentoring/session_accepted_mentor.blade.php
@@ -19,7 +19,7 @@
 
     <p>Your student has been sent an e-mail reminding them to prepare for the session, including referring to relevant reference material and previous mentoring session reports. If they have failed to do so, please inform the TGI and consider whether the session should be delayed.</p>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')

--- a/resources/views/emails/training/mentoring/session_accepted_student.blade.php
+++ b/resources/views/emails/training/mentoring/session_accepted_student.blade.php
@@ -29,7 +29,7 @@
 
     <p>If you need to cancel, please do so in plenty of time. Sessions can be cancelled via Manage Sessions. You should also ensure that your ongoing availability is up-to-date for future mentoring sessions.</p>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')

--- a/resources/views/emails/training/mentoring/session_cancelled_mentor.blade.php
+++ b/resources/views/emails/training/mentoring/session_cancelled_mentor.blade.php
@@ -3,7 +3,7 @@
 @section('body')
     <p>You have cancelled your mentoring session, which was due to take place on {{ $session->position }} on {{ \Carbon\Carbon::parse($session->taken_date)->format('l jS M y') }} at {{ \Carbon\Carbon::parse($session->taken_from)->format('H:i') }}Z.</p>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')

--- a/resources/views/emails/training/mentoring/session_cancelled_student.blade.php
+++ b/resources/views/emails/training/mentoring/session_cancelled_student.blade.php
@@ -11,7 +11,7 @@
 
     <p>We apologise for any inconvenience caused. It is possible that another mentor will pick your mentoring session up, so you should ensure that your ongoing availability is up-to-date.</p>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')

--- a/resources/views/emails/training/mentoring/session_reallocated_new_mentor.blade.php
+++ b/resources/views/emails/training/mentoring/session_reallocated_new_mentor.blade.php
@@ -14,7 +14,7 @@
     <p>The following reason was specified:</p>
     <p>{{ $reason }}</p>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')

--- a/resources/views/emails/training/mentoring/session_reallocated_old_mentor.blade.php
+++ b/resources/views/emails/training/mentoring/session_reallocated_old_mentor.blade.php
@@ -15,7 +15,7 @@
 
     <blockquote>{{ $reason }}</blockquote>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')

--- a/resources/views/emails/training/mentoring/session_reallocated_student.blade.php
+++ b/resources/views/emails/training/mentoring/session_reallocated_student.blade.php
@@ -11,7 +11,7 @@
 
     <p>Please note that the times displayed are in Zulu/GMT.</p>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')

--- a/resources/views/emails/training/mentoring/session_rescheduled_mentor.blade.php
+++ b/resources/views/emails/training/mentoring/session_rescheduled_mentor.blade.php
@@ -10,7 +10,7 @@
 
     <p>Please note that the times displayed are in Zulu/GMT.</p>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')

--- a/resources/views/emails/training/mentoring/session_rescheduled_student.blade.php
+++ b/resources/views/emails/training/mentoring/session_rescheduled_student.blade.php
@@ -12,7 +12,7 @@
 
     <p>Please try to be punctual and ensure that you are well prepared for the session. If you need to cancel, please do so in plenty of time. Sessions can be cancelled via Manage Sessions.</p>
 
-    <p>To stop receiving these alerts, you can amend your email settings in the STUDENT menu.</p>
+    <p>To stop receiving these alerts, you can amend your email settings in the <a href="{{ route('filament.training.pages.email-settings') }}">Training Panel</a>.</p>
 @stop
 
 @section('signature')


### PR DESCRIPTION
# Summary of changes
- Changes all emails to link to new email settings page on the training panel

# Screenshots (if necessary)
