### PR TITLE
feat: add new quarterly ATC stats

### DIFF
--- a/app/Filament/Admin/Pages/ATCTraining/GenerateATCTrainingQuarterlyStats.php
+++ b/app/Filament/Admin/Pages/ATCTraining/GenerateATCTrainingQuarterlyStats.php
@@ -80,9 +80,14 @@ class GenerateATCTrainingQuarterlyStats extends BasePage implements HasForms
         $endDate = $startDate->copy()->addMonths(3);
 
         $this->statistics = collect([
-            'Completed Mentoring Sessions' => ATCTrainingStats::completedMentoringSessions($startDate, $endDate),
-            'Exam Passes' => ATCTrainingStats::examPasses($startDate, $endDate),
+            'Mentoring Sessions' => ATCTrainingStats::completedMentoringSessionsByTG($startDate, $endDate),
+            'Exams Conducted' => ATCTrainingStats::examsConductedByTG($startDate, $endDate),
+            'Rating Upgrades Per TG' => ATCTrainingStats::ratingUpgradesByTG($startDate, $endDate),
             'Issued Position Group Endorsements' => ATCTrainingStats::issuedPositionGroupEndorsements($startDate, $endDate),
+            'Heathrow Endorsements Issued' => ATCTrainingStats::heathrowEndorsementsIssued($startDate, $endDate),
+            'ATC Waiting List Counts' => ATCTrainingStats::atcWaitingListCounts(),
+            'ATC Waiting List Removals (Inactivity)' => ATCTrainingStats::atcWaitingListRemovals($startDate, $endDate),
+            'Mentors Per TG' => ATCTrainingStats::mentorsByTG($startDate, $endDate),
             'Roster' => [
                 ['name' => 'Roster Update', 'value' => ATCTrainingStats::rosterUpdateLink($startDate, $endDate)],
             ],

--- a/app/Services/Admin/ATCTrainingStats.php
+++ b/app/Services/Admin/ATCTrainingStats.php
@@ -3,26 +3,14 @@
 namespace App\Services\Admin;
 
 use App\Models\Mship\Account\Endorsement;
+use App\Models\Training\WaitingList;
+use App\Models\Training\WaitingList\RemovalReason;
+use App\Models\Training\WaitingList\WaitingListAccount;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 
 class ATCTrainingStats
 {
-    public static function completedMentoringSessions(Carbon $startDate, Carbon $endDate)
-    {
-        return DB::connection('cts')
-            ->table('sessions')
-            ->select('rts.name', DB::raw('count(*) as total'))
-            ->join('rts', 'sessions.rts_id', '=', 'rts.id')
-            ->whereBetween('taken_date', [$startDate, $endDate])
-            ->whereNull('cancelled_datetime')
-            ->where('noShow', '=', 0)
-            ->groupBy('rts_id')
-            ->get()
-            ->flatMap(fn ($value) => [['name' => $value->name, 'value' => $value->total]])
-            ->toArray();
-    }
-
     public static function issuedPositionGroupEndorsements(Carbon $startDate, Carbon $endDate)
     {
         return Endorsement::with('endorsable')
@@ -32,20 +20,6 @@ class ATCTrainingStats
             ->select(['position_groups.name', 'position_groups.id', DB::raw('count(*) as total')])
             ->get()
             ->flatMap(fn ($value) => [['name' => $value->name, 'value' => $value->total]])
-            ->toArray();
-    }
-
-    public static function examPasses(Carbon $startDate, Carbon $endDate)
-    {
-        return DB::connection('cts')
-            ->table('practical_results')
-            ->select('exam', DB::raw('count(*) as total'))
-            ->whereBetween('date', [$startDate, $endDate])
-            ->where('result', '=', 'P')
-            ->whereNotIn('exam', ['P1', 'P2', 'P3'])
-            ->groupBy('exam')
-            ->get()
-            ->flatMap(fn ($value) => [['name' => $value->exam, 'value' => $value->total]])
             ->toArray();
     }
 
@@ -156,5 +130,216 @@ class ATCTrainingStats
 
         return null;
 
+    }
+
+    private static function getCallsignToCategoryMap(): array
+    {
+        $positions = DB::table('training_positions')
+            ->whereNotNull('category')
+            ->whereNotNull('cts_positions')
+            ->get(['category', 'cts_positions']);
+
+        $map = [];
+        foreach ($positions as $tp) {
+            $callsigns = json_decode($tp->cts_positions, true) ?? [];
+            foreach ($callsigns as $callsign) {
+                $map[$callsign] = $tp->category;
+            }
+        }
+
+        return $map;
+    }
+
+    public static function completedMentoringSessionsByTG(Carbon $startDate, Carbon $endDate): array
+    {
+        $callsignToCategory = self::getCallsignToCategoryMap();
+
+        $sessions = DB::connection('cts')
+            ->table('sessions')
+            ->select('position', DB::raw('count(*) as total'))
+            ->whereBetween('taken_date', [$startDate, $endDate])
+            ->whereNull('cancelled_datetime')
+            ->where('noShow', '=', 0)
+            ->groupBy('position')
+            ->get();
+
+        $categoryCounts = [];
+        foreach ($sessions as $session) {
+            $category = $callsignToCategory[$session->position] ?? 'Other';
+            $categoryCounts[$category] = ($categoryCounts[$category] ?? 0) + $session->total;
+        }
+
+        ksort($categoryCounts);
+
+        $result = collect($categoryCounts)
+            ->map(fn ($count, $name) => ['name' => $name, 'value' => $count])
+            ->values()
+            ->toArray();
+        $result[] = ['name' => 'Total', 'value' => array_sum($categoryCounts)];
+
+        return $result;
+    }
+
+    public static function examsConductedByTG(Carbon $startDate, Carbon $endDate): array
+    {
+        $examToCategory = [
+            'OBS' => 'OBS to S1 Training',
+            'TWR' => 'S2 Training',
+            'APP' => 'S3 Training',
+            'CTR' => 'C1 Training',
+        ];
+
+        $results = DB::connection('cts')
+            ->table('practical_results')
+            ->select('exam', DB::raw('count(*) as total'))
+            ->whereBetween('date', [$startDate, $endDate])
+            ->whereNotIn('exam', ['P1', 'P2', 'P3'])
+            ->groupBy('exam')
+            ->get();
+
+        $categoryCounts = [];
+        foreach ($results as $result) {
+            $category = $examToCategory[$result->exam] ?? $result->exam;
+            $categoryCounts[$category] = ($categoryCounts[$category] ?? 0) + $result->total;
+        }
+
+        ksort($categoryCounts);
+
+        $result = collect($categoryCounts)
+            ->map(fn ($count, $name) => ['name' => $name, 'value' => $count])
+            ->values()
+            ->toArray();
+        $result[] = ['name' => 'Total', 'value' => array_sum($categoryCounts)];
+
+        return $result;
+    }
+
+    public static function ratingUpgradesByTG(Carbon $startDate, Carbon $endDate): array
+    {
+        $qualToCategory = [
+            'S1' => 'OBS to S1 Training',
+            'S2' => 'S2 Training',
+            'S3' => 'S3 Training',
+            'C1' => 'C1 Training',
+        ];
+
+        $upgrades = DB::table('mship_account_qualification')
+            ->join('mship_qualification', 'mship_qualification.id', '=', 'mship_account_qualification.qualification_id')
+            ->where('mship_qualification.type', '=', 'atc')
+            ->whereBetween('mship_account_qualification.created_at', [$startDate, $endDate])
+            ->whereNull('mship_account_qualification.deleted_at')
+            ->select('mship_qualification.code')
+            ->get();
+
+        $categoryCounts = [];
+        foreach ($upgrades as $upgrade) {
+            $category = $qualToCategory[$upgrade->code] ?? null;
+
+            if ($category) {
+                $categoryCounts[$category] = ($categoryCounts[$category] ?? 0) + 1;
+            }
+        }
+
+        ksort($categoryCounts);
+
+        $result = collect($categoryCounts)
+            ->map(fn ($count, $name) => ['name' => $name, 'value' => $count])
+            ->values()
+            ->toArray();
+        $result[] = ['name' => 'Total', 'value' => array_sum($categoryCounts)];
+
+        return $result;
+    }
+
+    public static function heathrowEndorsementsIssued(Carbon $startDate, Carbon $endDate): array
+    {
+        $endorsements = Endorsement::with('endorsable')
+            ->whereBetween('mship_account_endorsement.created_at', [$startDate, $endDate])
+            ->join('position_groups', 'position_groups.id', 'mship_account_endorsement.endorsable_id')
+            ->whereIn('position_groups.name', ['Heathrow (TWR)', 'Heathrow (APP)', 'Heathrow (GND)'])
+            ->groupBy('position_groups.id', 'position_groups.name')
+            ->select(['position_groups.name', 'position_groups.id', DB::raw('count(*) as total')])
+            ->get()
+            ->flatMap(fn ($value) => [['name' => $value->name, 'value' => $value->total]])
+            ->toArray();
+
+        $total = collect($endorsements)->sum('value');
+        $endorsements[] = ['name' => 'Total', 'value' => $total];
+
+        return $endorsements;
+    }
+
+    public static function atcWaitingListCounts(): array
+    {
+        $lists = WaitingList::where('department', WaitingList::ATC_DEPARTMENT)->get();
+
+        $counts = $lists->map(fn ($list) => [
+            'name' => $list->name,
+            'value' => $list->waitingListAccounts->count(),
+        ])->toArray();
+
+        $total = collect($counts)->sum('value');
+        $counts[] = ['name' => 'Total', 'value' => $total];
+
+        return $counts;
+    }
+
+    public static function atcWaitingListRemovals(Carbon $startDate, Carbon $endDate): array
+    {
+        $lists = WaitingList::where('department', WaitingList::ATC_DEPARTMENT)->get();
+        $listIds = $lists->pluck('id');
+
+        $removals = WaitingListAccount::onlyTrashed()
+            ->whereIn('list_id', $listIds)
+            ->where('removal_type', RemovalReason::Inactivity->value)
+            ->whereBetween('deleted_at', [$startDate, $endDate])
+            ->select('list_id', DB::raw('count(*) as total'))
+            ->groupBy('list_id')
+            ->get()
+            ->keyBy('list_id');
+
+        $counts = $lists->map(fn ($list) => [
+            'name' => $list->name,
+            'value' => $removals->get($list->id)?->total ?? 0,
+        ])->toArray();
+
+        $total = collect($counts)->sum('value');
+        $counts[] = ['name' => 'Total', 'value' => $total];
+
+        return $counts;
+    }
+
+    public static function mentorsByTG(Carbon $startDate, Carbon $endDate): array
+    {
+        $callsignToCategory = self::getCallsignToCategoryMap();
+
+        $mentorSessions = DB::connection('cts')
+            ->table('sessions')
+            ->select('sessions.position', 'sessions.mentor_id')
+            ->whereBetween('taken_date', [$startDate, $endDate])
+            ->whereNull('cancelled_datetime')
+            ->whereNotNull('mentor_id')
+            ->where('noShow', '=', 0)
+            ->whereIn('sessions.position', array_keys($callsignToCategory))
+            ->get();
+
+        $mentorsByCategory = [];
+        foreach ($mentorSessions as $session) {
+            $category = $callsignToCategory[$session->position] ?? null;
+            if ($category) {
+                $mentorsByCategory[$category][$session->mentor_id] = true;
+            }
+        }
+
+        $result = collect($mentorsByCategory)
+            ->map(fn ($mentors, $category) => ['name' => $category, 'value' => count($mentors)])
+            ->sortBy('name')
+            ->values()
+            ->toArray();
+
+        $total = collect($result)->sum('value');
+        $result[] = ['name' => 'Total', 'value' => $total];
+
+        return $result;
     }
 }

--- a/tests/Unit/Admin/ATCTraining/ATCTrainingStatsTest.php
+++ b/tests/Unit/Admin/ATCTraining/ATCTrainingStatsTest.php
@@ -1,0 +1,842 @@
+<?php
+
+namespace Tests\Unit\Admin\ATCTraining;
+
+use App\Models\Atc\PositionGroup;
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalResult;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use App\Models\Mship\Account\Endorsement;
+use App\Models\Mship\Qualification;
+use App\Models\Training\Mentoring\MentorTrainingPosition;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Models\Training\WaitingList;
+use App\Models\Training\WaitingList\RemovalReason;
+use App\Services\Admin\ATCTrainingStats;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ATCTrainingStatsTest extends TestCase
+{
+    private Carbon $startDate;
+
+    private Carbon $endDate;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->startDate = Carbon::parse('2026-01-01');
+        $this->endDate = Carbon::parse('2026-04-01');
+    }
+
+    // completedMentoringSessionsByTG
+    #[Test]
+    public function it_groups_sessions_by_tg_via_callsign_mapping()
+    {
+        TrainingPosition::factory()->create([
+            'category' => 'S2 Training',
+            'cts_positions' => ['EGKK_TWR'],
+        ]);
+        TrainingPosition::factory()->create([
+            'category' => 'S3 Training',
+            'cts_positions' => ['EGLL_N_APP'],
+        ]);
+
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-02-01',
+        ]);
+        Session::factory()->accepted()->create([
+            'position' => 'EGLL_N_APP',
+            'taken_date' => '2026-02-15',
+        ]);
+
+        $result = ATCTrainingStats::completedMentoringSessionsByTG($this->startDate, $this->endDate);
+
+        $this->assertCount(3, $result);
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'S3 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 2], $result);
+    }
+
+    #[Test]
+    public function it_aggregates_multiple_sessions_on_same_position_into_one_tg()
+    {
+        TrainingPosition::factory()->create([
+            'category' => 'S2 Training',
+            'cts_positions' => ['EGKK_TWR'],
+        ]);
+
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-01-10',
+        ]);
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-02-14',
+        ]);
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-03-20',
+        ]);
+
+        $result = ATCTrainingStats::completedMentoringSessionsByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 3], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 3], $result);
+    }
+
+    #[Test]
+    public function it_groups_multiple_positions_under_same_tg()
+    {
+        TrainingPosition::factory()->create([
+            'category' => 'S2 Training',
+            'cts_positions' => ['EGKK_TWR', 'EGBB_TWR'],
+        ]);
+
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-01-10',
+        ]);
+        Session::factory()->accepted()->create([
+            'position' => 'EGBB_TWR',
+            'taken_date' => '2026-02-14',
+        ]);
+
+        $result = ATCTrainingStats::completedMentoringSessionsByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 2], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 2], $result);
+    }
+
+    #[Test]
+    public function it_excludes_cancelled_sessions()
+    {
+        TrainingPosition::factory()->create([
+            'category' => 'S2 Training',
+            'cts_positions' => ['EGKK_TWR'],
+        ]);
+
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-01-10',
+        ]);
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-02-14',
+            'cancelled_datetime' => '2026-02-10 12:00:00',
+        ]);
+
+        $result = ATCTrainingStats::completedMentoringSessionsByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    #[Test]
+    public function it_excludes_no_show_sessions()
+    {
+        TrainingPosition::factory()->create([
+            'category' => 'S2 Training',
+            'cts_positions' => ['EGKK_TWR'],
+        ]);
+
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-01-10',
+        ]);
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-02-14',
+            'noShow' => 1,
+        ]);
+
+        $result = ATCTrainingStats::completedMentoringSessionsByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    #[Test]
+    public function it_only_counts_sessions_within_date_range()
+    {
+        TrainingPosition::factory()->create([
+            'category' => 'S2 Training',
+            'cts_positions' => ['EGKK_TWR'],
+        ]);
+
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-01-10',
+        ]);
+        Session::factory()->accepted()->create([
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-05-01',
+        ]);
+
+        $result = ATCTrainingStats::completedMentoringSessionsByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    #[Test]
+    public function it_returns_only_total_when_no_sessions_match()
+    {
+        $result = ATCTrainingStats::completedMentoringSessionsByTG($this->startDate, $this->endDate);
+
+        $this->assertCount(1, $result);
+        $this->assertContains(['name' => 'Total', 'value' => 0], $result);
+    }
+
+    // examsConductedByTG
+
+    #[Test]
+    public function it_maps_exam_types_to_correct_tgs()
+    {
+        PracticalResult::factory()->create([
+            'exam' => 'OBS',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'TWR',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'APP',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'CTR',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+
+        $result = ATCTrainingStats::examsConductedByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'OBS to S1 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'S3 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'C1 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 4], $result);
+    }
+
+    #[Test]
+    public function it_aggregates_multiple_passes_of_same_exam_type()
+    {
+        PracticalResult::factory()->create([
+            'exam' => 'TWR',
+            'result' => 'P',
+            'date' => '2026-01-10',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'TWR',
+            'result' => 'P',
+            'date' => '2026-02-14',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'TWR',
+            'result' => 'P',
+            'date' => '2026-03-20',
+        ]);
+
+        $result = ATCTrainingStats::examsConductedByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 3], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 3], $result);
+    }
+
+    #[Test]
+    public function it_counts_all_exams_regardless_of_result()
+    {
+        PracticalResult::factory()->create([
+            'exam' => 'TWR',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'TWR',
+            'result' => 'F',
+            'date' => '2026-02-01',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'APP',
+            'result' => 'S',
+            'date' => '2026-02-01',
+        ]);
+
+        $result = ATCTrainingStats::examsConductedByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 2], $result);
+        $this->assertContains(['name' => 'S3 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 3], $result);
+    }
+
+    #[Test]
+    public function it_excludes_pilot_exams()
+    {
+        PracticalResult::factory()->create([
+            'exam' => 'TWR',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'P1',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'P2',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'P3',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+
+        $result = ATCTrainingStats::examsConductedByTG($this->startDate, $this->endDate);
+
+        $this->assertNotContains(['name' => 'P1', 'value' => 1], $result);
+        $this->assertNotContains(['name' => 'P2', 'value' => 1], $result);
+        $this->assertNotContains(['name' => 'P3', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    #[Test]
+    public function it_only_counts_exams_within_date_range()
+    {
+        PracticalResult::factory()->create([
+            'exam' => 'TWR',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+        PracticalResult::factory()->create([
+            'exam' => 'TWR',
+            'result' => 'P',
+            'date' => '2026-05-01',
+        ]);
+
+        $result = ATCTrainingStats::examsConductedByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    #[Test]
+    public function it_uses_raw_exam_name_when_no_tg_mapping_exists()
+    {
+        PracticalResult::factory()->create([
+            'exam' => 'OBS',
+            'result' => 'P',
+            'date' => '2026-02-01',
+        ]);
+
+        $result = ATCTrainingStats::examsConductedByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'OBS to S1 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    // ratingUpgradesByTG
+    private function makeQual(string $code, int $vatsim): Qualification
+    {
+        return Qualification::firstOrCreate(
+            ['code' => $code],
+            ['type' => 'atc', 'vatsim' => $vatsim, 'name_small' => $code, 'name_long' => $code, 'name_grp' => $code]
+        );
+    }
+
+    #[Test]
+    public function it_maps_qualification_codes_to_correct_tgs()
+    {
+        $account = Account::factory()->create();
+        $s1 = $this->makeQual('S1', 2);
+        $s2 = $this->makeQual('S2', 3);
+        $s3 = $this->makeQual('S3', 4);
+        $c1 = $this->makeQual('C1', 5);
+
+        DB::table('mship_account_qualification')->insert([
+            ['account_id' => $account->id, 'qualification_id' => $s1->id, 'created_at' => '2026-02-01', 'updated_at' => '2026-02-01'],
+            ['account_id' => $account->id, 'qualification_id' => $s2->id, 'created_at' => '2026-02-01', 'updated_at' => '2026-02-01'],
+            ['account_id' => $account->id, 'qualification_id' => $s3->id, 'created_at' => '2026-02-01', 'updated_at' => '2026-02-01'],
+            ['account_id' => $account->id, 'qualification_id' => $c1->id, 'created_at' => '2026-02-01', 'updated_at' => '2026-02-01'],
+        ]);
+
+        $result = ATCTrainingStats::ratingUpgradesByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'OBS to S1 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'S3 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'C1 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 4], $result);
+    }
+
+    #[Test]
+    public function it_only_counts_atc_qualifications()
+    {
+        $account = Account::factory()->create();
+        $s2 = $this->makeQual('S2', 3);
+        $p1 = Qualification::factory()->pilot()->create();
+
+        DB::table('mship_account_qualification')->insert([
+            ['account_id' => $account->id, 'qualification_id' => $s2->id, 'created_at' => '2026-02-01', 'updated_at' => '2026-02-01'],
+            ['account_id' => $account->id, 'qualification_id' => $p1->id, 'created_at' => '2026-02-01', 'updated_at' => '2026-02-01'],
+        ]);
+
+        $result = ATCTrainingStats::ratingUpgradesByTG($this->startDate, $this->endDate);
+
+        $this->assertCount(2, $result);
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    #[Test]
+    public function it_only_counts_upgrades_within_date_range()
+    {
+        $account = Account::factory()->create();
+        $s2 = $this->makeQual('S2', 3);
+
+        DB::table('mship_account_qualification')->insert([
+            ['account_id' => $account->id, 'qualification_id' => $s2->id, 'created_at' => '2026-05-01', 'updated_at' => '2026-05-01'],
+        ]);
+
+        $result = ATCTrainingStats::ratingUpgradesByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'Total', 'value' => 0], $result);
+    }
+
+    // heathrowEndorsementsIssued
+
+    #[Test]
+    public function it_counts_heathrow_endorsements_by_type()
+    {
+        $account = Account::factory()->create();
+        $twr = PositionGroup::factory()->create(['name' => 'Heathrow (TWR)']);
+        $app = PositionGroup::factory()->create(['name' => 'Heathrow (APP)']);
+        $gnd = PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $military = PositionGroup::factory()->create(['name' => 'Military (TWR)']);
+
+        Endorsement::factory()->create([
+            'account_id' => $account->id,
+            'endorsable_type' => PositionGroup::class,
+            'endorsable_id' => $twr->id,
+            'created_at' => '2026-02-01',
+        ]);
+        Endorsement::factory()->create([
+            'account_id' => $account->id,
+            'endorsable_type' => PositionGroup::class,
+            'endorsable_id' => $app->id,
+            'created_at' => '2026-02-01',
+        ]);
+        Endorsement::factory()->create([
+            'account_id' => $account->id,
+            'endorsable_type' => PositionGroup::class,
+            'endorsable_id' => $gnd->id,
+            'created_at' => '2026-02-01',
+        ]);
+        Endorsement::factory()->create([
+            'account_id' => $account->id,
+            'endorsable_type' => PositionGroup::class,
+            'endorsable_id' => $military->id,
+            'created_at' => '2026-02-01',
+        ]);
+
+        $result = ATCTrainingStats::heathrowEndorsementsIssued($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'Heathrow (TWR)', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Heathrow (APP)', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Heathrow (GND)', 'value' => 1], $result);
+        $this->assertNotContains(['name' => 'Military (TWR)', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 3], $result);
+    }
+
+    #[Test]
+    public function it_counts_multiple_issuances_of_same_type()
+    {
+        $account1 = Account::factory()->create();
+        $account2 = Account::factory()->create();
+        $twr = PositionGroup::factory()->create(['name' => 'Heathrow (TWR)']);
+
+        Endorsement::factory()->create([
+            'account_id' => $account1->id,
+            'endorsable_type' => PositionGroup::class,
+            'endorsable_id' => $twr->id,
+            'created_at' => '2026-02-01',
+        ]);
+        Endorsement::factory()->create([
+            'account_id' => $account2->id,
+            'endorsable_type' => PositionGroup::class,
+            'endorsable_id' => $twr->id,
+            'created_at' => '2026-02-15',
+        ]);
+
+        $result = ATCTrainingStats::heathrowEndorsementsIssued($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'Heathrow (TWR)', 'value' => 2], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 2], $result);
+    }
+
+    #[Test]
+    public function it_only_counts_endorsements_within_date_range()
+    {
+        $account = Account::factory()->create();
+        $twr = PositionGroup::factory()->create(['name' => 'Heathrow (TWR)']);
+
+        Endorsement::factory()->create([
+            'account_id' => $account->id,
+            'endorsable_type' => PositionGroup::class,
+            'endorsable_id' => $twr->id,
+            'created_at' => '2026-05-01',
+        ]);
+
+        $result = ATCTrainingStats::heathrowEndorsementsIssued($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'Total', 'value' => 0], $result);
+    }
+
+    #[Test]
+    public function it_returns_total_only_when_no_heathrow_endorsements_exist()
+    {
+        PositionGroup::factory()->create(['name' => 'Military (TWR)']);
+
+        $result = ATCTrainingStats::heathrowEndorsementsIssued($this->startDate, $this->endDate);
+
+        $this->assertCount(1, $result);
+        $this->assertContains(['name' => 'Total', 'value' => 0], $result);
+    }
+
+    // atcWaitingListCounts
+
+    #[Test]
+    public function it_counts_active_members_on_each_atc_waiting_list()
+    {
+        $listA = WaitingList::factory()->create(['name' => 'ATC List A', 'department' => 'atc']);
+        $listB = WaitingList::factory()->create(['name' => 'ATC List B', 'department' => 'atc']);
+
+        $acc1 = Account::factory()->create();
+        $acc2 = Account::factory()->create();
+        $acc3 = Account::factory()->create();
+
+        $listA->addToWaitingList($acc1, $this->privacc);
+        $listA->addToWaitingList($acc2, $this->privacc);
+        $listB->addToWaitingList($acc3, $this->privacc);
+
+        $result = ATCTrainingStats::atcWaitingListCounts();
+
+        $this->assertContains(['name' => 'ATC List A', 'value' => 2], $result);
+        $this->assertContains(['name' => 'ATC List B', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 3], $result);
+    }
+
+    #[Test]
+    public function it_excludes_pilot_waiting_lists()
+    {
+        WaitingList::factory()->create(['name' => 'ATC List', 'department' => 'atc']);
+        WaitingList::factory()->create(['name' => 'Pilot List', 'department' => 'pilot']);
+
+        $result = ATCTrainingStats::atcWaitingListCounts();
+
+        $names = array_column($result, 'name');
+        $this->assertContains('ATC List', $names);
+        $this->assertNotContains('Pilot List', $names);
+    }
+
+    #[Test]
+    public function it_excludes_removed_members()
+    {
+        $list = WaitingList::factory()->create(['name' => 'ATC List', 'department' => 'atc']);
+        $acc1 = Account::factory()->create();
+        $acc2 = Account::factory()->create();
+
+        $list->addToWaitingList($acc1, $this->privacc);
+        $list->addToWaitingList($acc2, $this->privacc);
+
+        $wla = $list->waitingListAccounts()->where('account_id', $acc2->id)->first();
+        $wla->delete();
+
+        $result = ATCTrainingStats::atcWaitingListCounts();
+
+        $this->assertContains(['name' => 'ATC List', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    // atcWaitingListRemovals
+
+    #[Test]
+    public function it_counts_inactivity_removals_per_list()
+    {
+        $listA = WaitingList::factory()->create(['name' => 'ATC List A', 'department' => 'atc']);
+        $listB = WaitingList::factory()->create(['name' => 'ATC List B', 'department' => 'atc']);
+        $acc1 = Account::factory()->create();
+        $acc2 = Account::factory()->create();
+        $acc3 = Account::factory()->create();
+
+        $now = now();
+
+        DB::table('training_waiting_list_account')->insert([
+            ['list_id' => $listA->id, 'account_id' => $acc1->id, 'removal_type' => RemovalReason::Inactivity->value, 'deleted_at' => $now, 'created_at' => '2026-01-01', 'updated_at' => $now],
+            ['list_id' => $listA->id, 'account_id' => $acc2->id, 'removal_type' => RemovalReason::Inactivity->value, 'deleted_at' => $now, 'created_at' => '2026-01-01', 'updated_at' => $now],
+            ['list_id' => $listB->id, 'account_id' => $acc3->id, 'removal_type' => RemovalReason::Inactivity->value, 'deleted_at' => $now, 'created_at' => '2026-01-01', 'updated_at' => $now],
+        ]);
+
+        $result = ATCTrainingStats::atcWaitingListRemovals(Carbon::parse('2026-01-01'), Carbon::parse('2026-12-31'));
+
+        $this->assertContains(['name' => 'ATC List A', 'value' => 2], $result, 'Result: '.json_encode($result));
+        $this->assertContains(['name' => 'ATC List B', 'value' => 1], $result, 'Result: '.json_encode($result));
+    }
+
+    #[Test]
+    public function it_excludes_other_removal_types()
+    {
+        $listA = WaitingList::factory()->create(['name' => 'ATC List', 'department' => 'atc']);
+        $acc1 = Account::factory()->create();
+        $acc2 = Account::factory()->create();
+
+        $now = now();
+
+        DB::table('training_waiting_list_account')->insert([
+            ['list_id' => $listA->id, 'account_id' => $acc1->id, 'removal_type' => RemovalReason::Inactivity->value, 'deleted_at' => $now, 'created_at' => '2026-01-01', 'updated_at' => $now],
+            ['list_id' => $listA->id, 'account_id' => $acc2->id, 'removal_type' => RemovalReason::FailedRetention->value, 'deleted_at' => $now, 'created_at' => '2026-01-01', 'updated_at' => $now],
+        ]);
+
+        $result = ATCTrainingStats::atcWaitingListRemovals(Carbon::parse('2026-01-01'), Carbon::parse('2026-12-31'));
+
+        $this->assertContains(['name' => 'ATC List', 'value' => 1], $result, 'Result: '.json_encode($result));
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result, 'Result: '.json_encode($result));
+    }
+
+    #[Test]
+    public function it_only_counts_removals_within_date_range()
+    {
+        $list = WaitingList::factory()->create(['name' => 'ATC List', 'department' => 'atc']);
+        $acc1 = Account::factory()->create();
+        $acc2 = Account::factory()->create();
+
+        DB::table('training_waiting_list_account')->insert([
+            ['list_id' => $list->id, 'account_id' => $acc1->id, 'removal_type' => RemovalReason::Inactivity->value, 'deleted_at' => '2026-02-01', 'created_at' => '2026-01-01', 'updated_at' => '2026-02-01'],
+            ['list_id' => $list->id, 'account_id' => $acc2->id, 'removal_type' => RemovalReason::Inactivity->value, 'deleted_at' => '2026-06-01', 'created_at' => '2026-01-01', 'updated_at' => '2026-06-01'],
+        ]);
+
+        $result = ATCTrainingStats::atcWaitingListRemovals(Carbon::parse('2026-01-01'), Carbon::parse('2026-04-01'));
+
+        $this->assertContains(['name' => 'ATC List', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    #[Test]
+    public function it_excludes_pilot_list_removals()
+    {
+        $atcList = WaitingList::factory()->create(['name' => 'ATC List', 'department' => 'atc']);
+        $pilotList = WaitingList::factory()->create(['name' => 'Pilot List', 'department' => 'pilot']);
+        $acc1 = Account::factory()->create();
+        $acc2 = Account::factory()->create();
+
+        DB::table('training_waiting_list_account')->insert([
+            ['list_id' => $atcList->id, 'account_id' => $acc1->id, 'removal_type' => RemovalReason::Inactivity->value, 'deleted_at' => '2026-02-01', 'created_at' => '2026-01-01', 'updated_at' => '2026-02-01'],
+            ['list_id' => $pilotList->id, 'account_id' => $acc2->id, 'removal_type' => RemovalReason::Inactivity->value, 'deleted_at' => '2026-02-15', 'created_at' => '2026-01-01', 'updated_at' => '2026-02-15'],
+        ]);
+
+        $result = ATCTrainingStats::atcWaitingListRemovals(Carbon::parse('2026-01-01'), Carbon::parse('2026-12-31'));
+
+        $names = array_column($result, 'name');
+        $this->assertContains('ATC List', $names);
+        $this->assertNotContains('Pilot List', $names);
+    }
+
+    // mentorsByTG
+
+    #[Test]
+    public function it_counts_mentors_who_mentored_per_tg()
+    {
+        $account1 = Account::factory()->create(['id' => 100001]);
+        $account2 = Account::factory()->create(['id' => 100002]);
+        Member::factory()->create(['id' => 100001, 'cid' => 100001]);
+        Member::factory()->create(['id' => 100002, 'cid' => 100002]);
+
+        $tpS2 = TrainingPosition::factory()->create(['category' => 'S2 Training', 'cts_positions' => ['EGKK_TWR']]);
+        $tpS3 = TrainingPosition::factory()->create(['category' => 'S3 Training', 'cts_positions' => ['EGLL_N_APP']]);
+
+        MentorTrainingPosition::create([
+            'account_id' => $account1->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $tpS2->id,
+            'created_by' => $account1->id,
+        ]);
+        MentorTrainingPosition::create([
+            'account_id' => $account2->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $tpS3->id,
+            'created_by' => $account2->id,
+        ]);
+
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100001,
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-02-01',
+        ]);
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100002,
+            'position' => 'EGLL_N_APP',
+            'taken_date' => '2026-02-15',
+        ]);
+
+        $result = ATCTrainingStats::mentorsByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'S3 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 2], $result);
+    }
+
+    #[Test]
+    public function it_counts_mentor_once_even_with_multiple_sessions_in_same_tg()
+    {
+        $account = Account::factory()->create(['id' => 100001]);
+        Member::factory()->create(['id' => 100001, 'cid' => 100001]);
+
+        $tp = TrainingPosition::factory()->create(['category' => 'S2 Training', 'cts_positions' => ['EGKK_TWR']]);
+
+        MentorTrainingPosition::create([
+            'account_id' => $account->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $tp->id,
+            'created_by' => $account->id,
+        ]);
+
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100001,
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-01-10',
+        ]);
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100001,
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-02-14',
+        ]);
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100001,
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-03-20',
+        ]);
+
+        $result = ATCTrainingStats::mentorsByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    #[Test]
+    public function it_only_counts_mentors_with_sessions_in_date_range()
+    {
+        $account1 = Account::factory()->create(['id' => 100001]);
+        $account2 = Account::factory()->create(['id' => 100002]);
+        Member::factory()->create(['id' => 100001, 'cid' => 100001]);
+        Member::factory()->create(['id' => 100002, 'cid' => 100002]);
+
+        $tp = TrainingPosition::factory()->create(['category' => 'S2 Training', 'cts_positions' => ['EGKK_TWR']]);
+
+        MentorTrainingPosition::create([
+            'account_id' => $account1->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $tp->id,
+            'created_by' => $account1->id,
+        ]);
+        MentorTrainingPosition::create([
+            'account_id' => $account2->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $tp->id,
+            'created_by' => $account2->id,
+        ]);
+
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100001,
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-02-01',
+        ]);
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100002,
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-05-01',
+        ]);
+
+        $result = ATCTrainingStats::mentorsByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 1], $result);
+    }
+
+    #[Test]
+    public function it_excludes_cancelled_and_no_show_sessions()
+    {
+        $account = Account::factory()->create(['id' => 100001]);
+        Member::factory()->create(['id' => 100001, 'cid' => 100001]);
+
+        $tp = TrainingPosition::factory()->create(['category' => 'S2 Training', 'cts_positions' => ['EGKK_TWR']]);
+
+        MentorTrainingPosition::create([
+            'account_id' => $account->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $tp->id,
+            'created_by' => $account->id,
+        ]);
+
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100001,
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-02-01',
+            'cancelled_datetime' => '2026-01-15 12:00:00',
+        ]);
+
+        $result = ATCTrainingStats::mentorsByTG($this->startDate, $this->endDate);
+
+        $s2Entry = collect($result)->firstWhere('name', 'S2 Training');
+        $this->assertNull($s2Entry);
+        $this->assertContains(['name' => 'Total', 'value' => 0], $result);
+    }
+
+    #[Test]
+    public function it_handles_mentor_in_multiple_tgs()
+    {
+        $account = Account::factory()->create(['id' => 100001]);
+        Member::factory()->create(['id' => 100001, 'cid' => 100001]);
+
+        $tpS2 = TrainingPosition::factory()->create(['category' => 'S2 Training', 'cts_positions' => ['EGKK_TWR']]);
+        $tpS3 = TrainingPosition::factory()->create(['category' => 'S3 Training', 'cts_positions' => ['EGLL_N_APP']]);
+
+        MentorTrainingPosition::create([
+            'account_id' => $account->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $tpS2->id,
+            'created_by' => $account->id,
+        ]);
+        MentorTrainingPosition::create([
+            'account_id' => $account->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $tpS3->id,
+            'created_by' => $account->id,
+        ]);
+
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100001,
+            'position' => 'EGKK_TWR',
+            'taken_date' => '2026-02-01',
+        ]);
+        Session::factory()->accepted()->create([
+            'mentor_id' => 100001,
+            'position' => 'EGLL_N_APP',
+            'taken_date' => '2026-02-15',
+        ]);
+
+        $result = ATCTrainingStats::mentorsByTG($this->startDate, $this->endDate);
+
+        $this->assertContains(['name' => 'S2 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'S3 Training', 'value' => 1], $result);
+        $this->assertContains(['name' => 'Total', 'value' => 2], $result);
+    }
+}


### PR DESCRIPTION
# Summary of changes
Adds the below to ATC quarterly stats:
- How many mentoring sessions per TG, and total
- How many exams per TG, and total
- How many rating upgrades per TG, and total
- How many of each Heathrow endorsement was issued, and total
- After the roster activity removal process has been run, a count of how many people are on each ATC Training waiting lit
- How many people were removed from each waiting list as a result of the roster activity removal process
- How many mentors mentored within the quarter at each training group, and total

# Screenshots (if necessary)
<img width="930" height="861" alt="image" src="https://github.com/user-attachments/assets/9bcf8fac-1af9-48fe-8351-1df7408bc81d" />
