### PR TITLE
feat: ATC Training Stats page to display ongoing ATC Training stats

### DIFF
--- a/app/Filament/Training/Pages/Statistics/AtcTrainingStatistics.php
+++ b/app/Filament/Training/Pages/Statistics/AtcTrainingStatistics.php
@@ -21,7 +21,7 @@ class AtcTrainingStatistics extends Page
 
     protected ?string $subheading = 'Ongoing ATC training statistics for each Training Group.';
 
-    protected static ?string $slug = 'statistics/atc-training-groups';
+    protected static ?string $slug = 'statistics/atc-training';
 
     public static function canAccess(): bool
     {

--- a/app/Filament/Training/Pages/Statistics/AtcTrainingStatistics.php
+++ b/app/Filament/Training/Pages/Statistics/AtcTrainingStatistics.php
@@ -28,14 +28,6 @@ class AtcTrainingStatistics extends Page
         return auth()->user()?->can('training.statistics.view.atc') ?? false;
     }
 
-    public static function shouldRegisterNavigation(): bool
-    {
-        return auth()->user()?->can('training.statistics.view.atc') ?? false;
-    }
-
-    /**
-     * @return array<int, string>
-     */
     public function getCategories(): array
     {
         return MentorPermissionService::atcRatingTrainingCategories();

--- a/app/Filament/Training/Pages/Statistics/AtcTrainingStatistics.php
+++ b/app/Filament/Training/Pages/Statistics/AtcTrainingStatistics.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Pages\Statistics;
+
+use App\Services\Training\MentorPermissionService;
+use Filament\Pages\Page;
+
+class AtcTrainingStatistics extends Page
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-chart-bar';
+
+    protected string $view = 'filament.training.pages.atc-training-statistics';
+
+    protected static ?int $navigationSort = 10;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Statistics';
+
+    protected static ?string $title = 'ATC Training Stats';
+
+    protected ?string $subheading = 'Ongoing ATC training statistics for each Training Group.';
+
+    protected static ?string $slug = 'statistics/atc-training-groups';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->can('training.statistics.view.atc') ?? false;
+    }
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return auth()->user()?->can('training.statistics.view.atc') ?? false;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getCategories(): array
+    {
+        return MentorPermissionService::atcRatingTrainingCategories();
+    }
+}

--- a/app/Filament/Training/Pages/Statistics/Widgets/TrainingGroupStatisticsWidget.php
+++ b/app/Filament/Training/Pages/Statistics/Widgets/TrainingGroupStatisticsWidget.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Training\Pages\Statistics\Widgets;
+
+use App\Services\Training\TrainingGroupStatisticsService;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Number;
+
+class TrainingGroupStatisticsWidget extends StatsOverviewWidget
+{
+    public string $category = '';
+
+    protected static bool $isLazy = false;
+
+    protected ?string $pollingInterval = null;
+
+    protected static ?int $sort = 1;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected function getStats(): array
+    {
+        if ($this->category === '') {
+            return [];
+        }
+
+        $statistics = app(TrainingGroupStatisticsService::class)->statisticsForCategory($this->category);
+
+        return [
+            Stat::make('Active Training Places', Number::format($statistics['active_training_places'], precision: 0))
+                ->icon('heroicon-o-academic-cap'),
+
+            Stat::make('Avg. Sessions to Rating', $this->formatDecimal($statistics['average_sessions_to_rating']))
+                ->icon('heroicon-o-chart-bar'),
+
+            Stat::make('Avg. Training Duration', $this->formatDuration($statistics['average_training_duration_days']))
+                ->icon('heroicon-o-clock'),
+
+            Stat::make('Exam First Pass Rate', $this->formatPercentage($statistics['exam_first_pass_rate']))
+                ->icon('heroicon-o-trophy'),
+        ];
+    }
+
+    private function formatDecimal(?float $value): string
+    {
+        return $value !== null ? number_format($value, 1) : 'N/A';
+    }
+
+    private function formatDuration(?float $days): string
+    {
+        return $days !== null ? number_format($days, 0).' days' : 'N/A';
+    }
+
+    private function formatPercentage(?int $value): string
+    {
+        return $value !== null ? $value.'%' : 'N/A';
+    }
+}

--- a/app/Providers/Filament/TrainingPanelProvider.php
+++ b/app/Providers/Filament/TrainingPanelProvider.php
@@ -66,6 +66,7 @@ class TrainingPanelProvider extends PanelProvider
                 'My Training',
                 'Exams',
                 'Mentoring',
+                'Statistics',
                 'Training',
                 'Theory',
             ])

--- a/app/Services/Training/MentorPermissionService.php
+++ b/app/Services/Training/MentorPermissionService.php
@@ -59,6 +59,16 @@ class MentorPermissionService
         return array_keys(self::ATC_CATEGORY_ROLE_MAP);
     }
 
+    public static function atcRatingTrainingCategories(): array
+    {
+        return [
+            'OBS to S1 Training',
+            'S2 Training',
+            'S3 Training',
+            'C1 Training',
+        ];
+    }
+
     public static function pilotCategories(): array
     {
         return array_keys(self::PILOT_CATEGORY_ROLE_MAP);

--- a/app/Services/Training/TrainingGroupStatisticsService.php
+++ b/app/Services/Training/TrainingGroupStatisticsService.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Training;
+
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalResult;
+use App\Models\Cts\Session;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use Illuminate\Support\Collection;
+
+class TrainingGroupStatisticsService
+{
+    public const ATC_CATEGORY_EXAM_MAP = [
+        'OBS to S1 Training' => 'OBS',
+        'S2 Training' => 'TWR',
+        'S3 Training' => 'APP',
+        'C1 Training' => 'CTR',
+    ];
+
+    public function __construct(
+        private readonly MentorPermissionService $mentorPermissionService,
+    ) {}
+
+    public function statisticsForCategory(string $category): array
+    {
+        return [
+            'category' => $category,
+            'active_training_places' => $this->activeTrainingPlacesCount($category),
+            'average_sessions_to_rating' => $this->averageSessionsToRating($category),
+            'average_training_duration_days' => $this->averageTrainingDurationDays($category),
+            'exam_first_pass_rate' => $this->examFirstPassRate($category),
+        ];
+    }
+
+    public function activeTrainingPlacesCount(string $category): int
+    {
+        return TrainingPlace::query()
+            ->whereHas('trainingPosition', fn ($query) => $query->where('category', $category))
+            ->count();
+    }
+
+    public function averageSessionsToRating(string $category): ?float
+    {
+        $completedPlaces = $this->completedTrainingPlaces($category);
+
+        if ($completedPlaces->isEmpty()) {
+            return null;
+        }
+
+        $callsigns = $this->callsignsForCategory($category);
+
+        if ($callsigns === []) {
+            return null;
+        }
+
+        $sessionCounts = $completedPlaces->map(function (TrainingPlace $place) use ($callsigns): ?int {
+            $ctsMemberId = $place->account?->member?->id;
+
+            if ($ctsMemberId === null || $place->deleted_at === null) {
+                return null;
+            }
+
+            return Session::query()
+                ->where('student_id', $ctsMemberId)
+                ->whereIn('position', $callsigns)
+                ->whereNull('cancelled_datetime')
+                ->where('noShow', 0)
+                ->where('session_done', 1)
+                ->whereDate('taken_date', '>=', $place->created_at->toDateString())
+                ->whereDate('taken_date', '<=', $place->deleted_at->toDateString())
+                ->count();
+        })->filter(fn (?int $count): bool => $count !== null);
+
+        if ($sessionCounts->isEmpty()) {
+            return null;
+        }
+
+        return round($sessionCounts->avg(), 1);
+    }
+
+    public function averageTrainingDurationDays(string $category): ?float
+    {
+        $completedPlaces = $this->completedTrainingPlaces($category);
+
+        if ($completedPlaces->isEmpty()) {
+            return null;
+        }
+
+        $durations = $completedPlaces
+            ->filter(fn (TrainingPlace $place): bool => $place->deleted_at !== null)
+            ->map(fn (TrainingPlace $place): float => $place->created_at->diffInRealDays($place->deleted_at));
+
+        if ($durations->isEmpty()) {
+            return null;
+        }
+
+        return round($durations->avg(), 0);
+    }
+
+    public function examFirstPassRate(string $category): ?int
+    {
+        $examType = self::ATC_CATEGORY_EXAM_MAP[$category] ?? null;
+
+        if ($examType === null) {
+            return null;
+        }
+
+        $accountIds = $this->completedTrainingPlaces($category)
+            ->pluck('account_id')
+            ->unique()
+            ->values();
+
+        if ($accountIds->isEmpty()) {
+            return null;
+        }
+
+        $ctsMemberIds = Member::query()
+            ->whereIn('cid', $accountIds)
+            ->pluck('id');
+
+        if ($ctsMemberIds->isEmpty()) {
+            return null;
+        }
+
+        $firstAttempts = PracticalResult::query()
+            ->where('exam', $examType)
+            ->whereIn('student_id', $ctsMemberIds)
+            ->orderBy('date')
+            ->get()
+            ->groupBy('student_id')
+            ->map(fn (Collection $results) => $results->first());
+
+        if ($firstAttempts->isEmpty()) {
+            return null;
+        }
+
+        $passed = $firstAttempts
+            ->filter(fn (PracticalResult $result): bool => $result->result === PracticalResult::PASSED)
+            ->count();
+
+        return (int) round($passed / $firstAttempts->count() * 100);
+    }
+
+    private function callsignsForCategory(string $category): array
+    {
+        return $this->mentorPermissionService->getAllCtsCallsignsForCategory($category);
+    }
+
+    private function completedTrainingPlaces(string $category): Collection
+    {
+        return TrainingPlace::onlyTrashed()
+            ->whereHas('trainingPosition', fn ($query) => $query->where('category', $category))
+            ->with(['account', 'trainingPosition'])
+            ->get();
+    }
+}

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -97,6 +97,9 @@ class RolesAndPermissionsSeeder extends Seeder
             'training.mentoring.sessions.*',
             'training.mentoring.sessions.reallocate.*',
 
+            'training.statistics.view.*',
+            'training.statistics.view.atc',
+
             // Account Permissions
             'account.self',
             'account.view-insensitive.*',

--- a/resources/views/filament/training/pages/atc-training-statistics.blade.php
+++ b/resources/views/filament/training/pages/atc-training-statistics.blade.php
@@ -1,0 +1,7 @@
+<x-filament-panels::page>
+	@foreach ($this->getCategories() as $category)
+		<x-filament::section :heading="$category" collapsible>
+			@livewire(\App\Filament\Training\Pages\Statistics\Widgets\TrainingGroupStatisticsWidget::class, ['category' => $category], key('training-group-stats-' . str($category)->slug('_')))
+		</x-filament::section>
+	@endforeach
+</x-filament-panels::page>

--- a/tests/Feature/TrainingPanel/Statistics/AtcTrainingStatisticsTest.php
+++ b/tests/Feature/TrainingPanel/Statistics/AtcTrainingStatisticsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\Statistics;
+
+use App\Filament\Training\Pages\Statistics\AtcTrainingStatistics;
+use App\Models\Cts\Position as CtsPosition;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\MentorPermissionService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class AtcTrainingStatisticsTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_loads_when_user_has_atc_statistics_view_permission(): void
+    {
+        $this->panelUser->givePermissionTo('training.statistics.view.atc');
+
+        Livewire::actingAs($this->panelUser)
+            ->test(AtcTrainingStatistics::class)
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_is_forbidden_when_user_has_no_statistics_view_permission(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(AtcTrainingStatistics::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_displays_a_section_for_each_rating_training_atc_training_group(): void
+    {
+        $this->panelUser->givePermissionTo('training.statistics.view.atc');
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(AtcTrainingStatistics::class);
+
+        foreach (MentorPermissionService::atcRatingTrainingCategories() as $category) {
+            $component->assertSee($category);
+        }
+
+        $component->assertDontSee('Heathrow GMC')->assertDontSee('Heathrow AIR')->assertDontSee('Heathrow APC');
+    }
+
+    #[Test]
+    public function it_displays_the_four_key_statistics_for_training_groups(): void
+    {
+        $this->panelUser->givePermissionTo('training.statistics.view.atc');
+
+        $category = MentorPermissionService::atcRatingTrainingCategories()[0];
+        $trainingPosition = $this->createTrainingPosition($category, 'EGCC_GND');
+
+        TrainingPlace::factory()->create([
+            'account_id' => Account::factory()->create()->id,
+            'training_position_id' => $trainingPosition->id,
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(AtcTrainingStatistics::class)
+            ->assertSee('Active Training Places')
+            ->assertSee('Avg. Sessions to Rating')
+            ->assertSee('Avg. Training Duration')
+            ->assertSee('Exam First Pass Rate');
+    }
+
+    private function createTrainingPosition(string $category, string $callsign): TrainingPosition
+    {
+        CtsPosition::firstOrCreate(['callsign' => $callsign]);
+
+        return TrainingPosition::factory()->create([
+            'category' => $category,
+            'cts_positions' => [$callsign],
+        ]);
+    }
+}

--- a/tests/Unit/Training/Statistics/TrainingGroupStatisticsServiceTest.php
+++ b/tests/Unit/Training/Statistics/TrainingGroupStatisticsServiceTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Training\Statistics;
+
+use App\Models\Cts\Member;
+use App\Models\Cts\Position as CtsPosition;
+use App\Models\Cts\PracticalResult;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\TrainingGroupStatisticsService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TrainingGroupStatisticsServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private TrainingGroupStatisticsService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = app(TrainingGroupStatisticsService::class);
+    }
+
+    #[Test]
+    public function it_counts_active_training_places_for_a_category(): void
+    {
+        $category = 'S2 Training';
+        $trainingPosition = $this->createTrainingPosition($category, 'EGKK_TWR');
+
+        $beforeCount = $this->service->activeTrainingPlacesCount($category);
+
+        TrainingPlace::factory()->create([
+            'account_id' => Account::factory()->create()->id,
+            'training_position_id' => $trainingPosition->id,
+        ]);
+
+        TrainingPlace::factory()->create([
+            'account_id' => Account::factory()->create()->id,
+            'training_position_id' => $trainingPosition->id,
+        ]);
+
+        $otherPosition = $this->createTrainingPosition('S3 Training', 'EGLL_N_APP');
+        TrainingPlace::factory()->create([
+            'account_id' => Account::factory()->create()->id,
+            'training_position_id' => $otherPosition->id,
+        ]);
+
+        $this->assertSame($beforeCount + 2, $this->service->activeTrainingPlacesCount($category));
+    }
+
+    #[Test]
+    public function it_calculates_average_sessions_to_rating_for_completed_training_places(): void
+    {
+        $category = 'S2 Training';
+        $callsign = 'EGKK_TWR';
+        $trainingPosition = $this->createTrainingPosition($category, $callsign);
+
+        $studentOne = $this->createAccountWithMember();
+        $studentTwo = $this->createAccountWithMember();
+
+        $this->createCompletedTrainingPlace($studentOne, $trainingPosition, now()->subDays(60), now()->subDays(10));
+        $this->createCompletedTrainingPlace($studentTwo, $trainingPosition, now()->subDays(90), now()->subDays(20));
+
+        $this->createCompletedSession($studentOne->member->id, $callsign, now()->subDays(30));
+        $this->createCompletedSession($studentOne->member->id, $callsign, now()->subDays(20));
+        $this->createCompletedSession($studentOne->member->id, $callsign, now()->subDays(15));
+
+        $this->createCompletedSession($studentTwo->member->id, $callsign, now()->subDays(40));
+
+        $this->assertSame(2.0, $this->service->averageSessionsToRating($category));
+    }
+
+    #[Test]
+    public function it_calculates_average_training_duration_for_completed_training_places(): void
+    {
+        $category = 'S2 Training';
+        $trainingPosition = $this->createTrainingPosition($category, 'EGKK_TWR');
+
+        $studentOne = $this->createAccountWithMember();
+        $studentTwo = $this->createAccountWithMember();
+
+        $this->createCompletedTrainingPlace(
+            $studentOne,
+            $trainingPosition,
+            Carbon::parse('2024-01-01'),
+            Carbon::parse('2024-01-11'),
+        );
+
+        $this->createCompletedTrainingPlace(
+            $studentTwo,
+            $trainingPosition,
+            Carbon::parse('2024-01-01'),
+            Carbon::parse('2024-01-21'),
+        );
+
+        $this->assertSame(15.0, $this->service->averageTrainingDurationDays($category));
+    }
+
+    #[Test]
+    public function it_calculates_exam_first_pass_rate_for_completed_students(): void
+    {
+        $category = 'S2 Training';
+        $trainingPosition = $this->createTrainingPosition($category, 'EGKK_TWR');
+
+        $passedStudent = $this->createAccountWithMember();
+        $failedStudent = $this->createAccountWithMember();
+
+        $this->createCompletedTrainingPlace($passedStudent, $trainingPosition, now()->subDays(90), now()->subDays(10));
+        $this->createCompletedTrainingPlace($failedStudent, $trainingPosition, now()->subDays(90), now()->subDays(10));
+
+        PracticalResult::factory()->create([
+            'student_id' => $passedStudent->member->id,
+            'exam' => 'TWR',
+            'result' => PracticalResult::PASSED,
+            'date' => now()->subDays(15),
+        ]);
+
+        PracticalResult::factory()->create([
+            'student_id' => $failedStudent->member->id,
+            'exam' => 'TWR',
+            'result' => PracticalResult::FAILED,
+            'date' => now()->subDays(15),
+        ]);
+
+        PracticalResult::factory()->create([
+            'student_id' => $failedStudent->member->id,
+            'exam' => 'TWR',
+            'result' => PracticalResult::PASSED,
+            'date' => now()->subDays(5),
+        ]);
+
+        $this->assertSame(50, $this->service->examFirstPassRate($category));
+    }
+
+    #[Test]
+    public function it_returns_null_for_exam_first_pass_rate_when_category_has_no_exam_mapping(): void
+    {
+        $category = 'Heathrow GMC';
+        $trainingPosition = $this->createTrainingPosition($category, 'EGLL_GMC');
+
+        $student = $this->createAccountWithMember();
+        $this->createCompletedTrainingPlace($student, $trainingPosition, now()->subDays(90), now()->subDays(10));
+
+        $this->assertNull($this->service->examFirstPassRate($category));
+    }
+
+    #[Test]
+    public function it_returns_null_averages_when_no_completed_training_places_exist(): void
+    {
+        $category = 'S2 Training';
+        $trainingPosition = $this->createTrainingPosition($category, 'EGKK_TWR');
+
+        TrainingPlace::factory()->create([
+            'account_id' => Account::factory()->create()->id,
+            'training_position_id' => $trainingPosition->id,
+        ]);
+
+        $this->assertNull($this->service->averageSessionsToRating($category));
+        $this->assertNull($this->service->averageTrainingDurationDays($category));
+        $this->assertNull($this->service->examFirstPassRate($category));
+    }
+
+    private function createTrainingPosition(string $category, string $callsign): TrainingPosition
+    {
+        CtsPosition::firstOrCreate(['callsign' => $callsign]);
+
+        return TrainingPosition::factory()->create([
+            'category' => $category,
+            'cts_positions' => [$callsign],
+        ]);
+    }
+
+    private function createAccountWithMember(): Account
+    {
+        $account = Account::factory()->create();
+        Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+
+        return $account->fresh();
+    }
+
+    private function createCompletedTrainingPlace(
+        Account $account,
+        TrainingPosition $trainingPosition,
+        Carbon $createdAt,
+        Carbon $deletedAt,
+    ): TrainingPlace {
+        $place = TrainingPlace::factory()->create([
+            'account_id' => $account->id,
+            'training_position_id' => $trainingPosition->id,
+            'created_at' => $createdAt,
+        ]);
+
+        $place->delete();
+        $place->forceFill(['deleted_at' => $deletedAt])->save();
+
+        return $place->fresh(['account', 'trainingPosition']);
+    }
+
+    private function createCompletedSession(int $studentId, string $callsign, Carbon $takenDate): Session
+    {
+        return Session::factory()->create([
+            'student_id' => $studentId,
+            'position' => $callsign,
+            'taken_date' => $takenDate->toDateString(),
+            'taken_from' => '10:00:00',
+            'taken_to' => '11:00:00',
+            'cancelled_datetime' => null,
+            'noShow' => 0,
+            'session_done' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes TECH-660
Fixes TECH-646

# Summary of changes
Displays the following for each Rating Training Training Group
- How many training places are active for each training group
- The average number of mentoring sessions required to achieve a rating (mean average number of sessions per student per TG)
- The average length of time required to achieve a rating (mean average length of training places per student per TG)
- Average exam first pass rate per TG

2 new permissions:
`training.statistics.view.*`
`training.statistics.view.atc`

# Screenshots (if necessary)
<img width="1308" height="1131" alt="image" src="https://github.com/user-attachments/assets/906cb1d7-c887-4fb0-b7e2-7f02f50de3cd" />
<img width="304" height="364" alt="image" src="https://github.com/user-attachments/assets/5862b9f5-250f-4f0c-b421-c0fc70a30238" />
