### PR TITLE
Show current time in red line on availabilit gantt chart

### DIFF
--- a/app/Livewire/Training/AvailabilityGantt.php
+++ b/app/Livewire/Training/AvailabilityGantt.php
@@ -200,10 +200,23 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
         $startTimelineHour = max(0, $minHour - 1);
         $endTimelineHour = min(23, $maxHour + 1);
 
+        $nowLinePercent = null;
+
+        if (Carbon::parse($this->date)->isToday()) {
+            $now = now();
+            $nowMinutesFromMidnight = $now->hour * 60 + $now->minute;
+            $timelineStartMinutes = $startTimelineHour * 60;
+            $totalTimelineMinutes = ($endTimelineHour - $startTimelineHour + 1) * 60;
+            $relativeNowMinutes = $nowMinutesFromMidnight - $timelineStartMinutes;
+
+            $nowLinePercent = max(0, min(100, ($relativeNowMinutes / $totalTimelineMinutes) * 100));
+        }
+
         return view('livewire.training.availability-gantt', [
             'students' => $students,
             'hours' => range($startTimelineHour, $endTimelineHour),
             'displayDate' => Carbon::parse($this->date),
+            'nowLinePercent' => $nowLinePercent,
         ]);
     }
 

--- a/resources/views/livewire/training/availability-gantt-desktop.blade.php
+++ b/resources/views/livewire/training/availability-gantt-desktop.blade.php
@@ -1,6 +1,6 @@
 <div
 	class="overflow-y-auto overflow-x-hidden max-h-[600px] relative rounded-lg border border-gray-200 dark:border-white/10 custom-scrollbar">
-	<div class="w-full">
+	<div class="w-full relative">
 		<div
 			class="flex sticky top-0 bg-gray-50 dark:bg-gray-800/95 backdrop-blur-sm z-30 shadow-sm border-b border-gray-200 dark:border-white/10">
 			<div
@@ -14,6 +14,11 @@
 						{{ str_pad($hour, 2, '0', STR_PAD_LEFT) }}
 					</div>
 				@endforeach
+
+				@if ($nowLinePercent !== null)
+					<div class="absolute inset-y-0 z-40 pointer-events-none" data-gantt-now-line
+						style="left: calc({{ $nowLinePercent }}% - 1px); width: 2px; background-color: #ef4444;"></div>
+				@endif
 			</div>
 		</div>
 
@@ -74,6 +79,11 @@
 					</div>
 
 					<div class="flex-1 relative">
+						@if ($nowLinePercent !== null)
+							<div class="absolute inset-y-0 z-30 pointer-events-none" data-gantt-now-line
+								style="left: calc({{ $nowLinePercent }}% - 1px); width: 2px; background-color: #ef4444;"></div>
+						@endif
+
 						<div class="absolute inset-0 flex pointer-events-none">
 							@foreach ($hours as $hour)
 								<div class="flex-1 border-r border-gray-100 dark:border-white/[0.02]"></div>

--- a/resources/views/livewire/training/availability-gantt-mobile.blade.php
+++ b/resources/views/livewire/training/availability-gantt-mobile.blade.php
@@ -64,6 +64,11 @@
 					@endforeach
 				</div>
 
+				@if ($nowLinePercent !== null)
+					<div class="absolute inset-x-0 z-30 pointer-events-none" data-gantt-now-line
+						style="top: calc({{ $nowLinePercent }}% - 1px); height: 2px; background-color: #ef4444;"></div>
+				@endif
+
 				@foreach ($students as $student)
 					<div
 						class="flex-1 min-w-[140px] relative bg-inherit group hover:bg-gray-50/50 dark:hover:bg-white/5 transition duration-75">

--- a/resources/views/livewire/training/availability-gantt.blade.php
+++ b/resources/views/livewire/training/availability-gantt.blade.php
@@ -32,10 +32,18 @@
 		</div>
 	@else
 		<div class="hidden lg:!block">
-			@include('livewire.training.availability-gantt-desktop', ['students' => $this->pagedStudents])
+			@include('livewire.training.availability-gantt-desktop', [
+				'students' => $this->pagedStudents,
+				'hours' => $hours,
+				'nowLinePercent' => $nowLinePercent,
+			])
 		</div>
 		<div class="block lg:!hidden">
-			@include('livewire.training.availability-gantt-mobile', ['students' => $this->pagedStudents])
+			@include('livewire.training.availability-gantt-mobile', [
+				'students' => $this->pagedStudents,
+				'hours' => $hours,
+				'nowLinePercent' => $nowLinePercent,
+			])
 		</div>
 
 		{{-- Page Arrows --}}

--- a/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
@@ -459,4 +459,63 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
         $this->assertTrue($students->first()->id === $olderStudent->id);
         $this->assertTrue($students->last()->id === $recentStudent->id);
     }
+
+    #[Test]
+    public function availability_gantt_shows_now_line_when_viewing_today(): void
+    {
+        Carbon::setTestNow(Carbon::today()->setTime(14, 30));
+
+        $student = Member::factory()->create();
+
+        Session::factory()->create([
+            'student_id' => $student->id,
+            'mentor_id' => null,
+            'position' => 'EGLL_APP',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Availability::factory()->create([
+            'student_id' => $student->id,
+            'date' => Carbon::today()->format('Y-m-d'),
+            'from' => '10:00:00',
+            'to' => '18:00:00',
+        ]);
+
+        Livewire::actingAs($this->mentor)
+            ->test(AvailabilityGantt::class)
+            ->assertSeeHtml('data-gantt-now-line');
+
+        Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function availability_gantt_does_not_show_now_line_when_viewing_a_future_date(): void
+    {
+        Carbon::setTestNow(Carbon::today()->setTime(14, 30));
+
+        $student = Member::factory()->create();
+
+        Session::factory()->create([
+            'student_id' => $student->id,
+            'mentor_id' => null,
+            'position' => 'EGLL_APP',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Availability::factory()->create([
+            'student_id' => $student->id,
+            'date' => Carbon::tomorrow()->format('Y-m-d'),
+            'from' => '10:00:00',
+            'to' => '18:00:00',
+        ]);
+
+        Livewire::actingAs($this->mentor)
+            ->test(AvailabilityGantt::class)
+            ->call('nextDay')
+            ->assertDontSeeHtml('data-gantt-now-line');
+
+        Carbon::setTestNow();
+    }
 }


### PR DESCRIPTION
# Summary of changes

Adds a current-time indicator to the mentoring availability Gantt on the Mentoring page, so mentors can see where "now" falls on the timeline when viewing today and avoid selecting availability blocks that are already in the past.

**Backend (`AvailabilityGantt`)**
- Computes `nowLinePercent` in `render()` when the selected date is today.
- Position is derived from the same timeline bounds used for availability blocks (`startTimelineHour` / `endTimelineHour`), using minute-level precision.
- The value is clamped to 0–100% so the line remains visible even when the current time is outside the displayed hour range.

**Views**
- **Desktop:** Renders a 2px red vertical line in the hour header and in each student row's timeline area, aligned with availability blocks.
- **Mobile:** Renders a 2px red horizontal line across the chart at the corresponding time position.
- Lines use `pointer-events-none` so availability blocks remain clickable.
- Explicitly passes `hour and `nowLinePercent` into the desktop/mobile partials to avoid Blade scope issues.

**Tests**
- Adds feature tests confirming the now line is present when viewing today and absent when viewing a future date.

This complements the existing accept-session modal safeguards that filter past time slots and warn when a slot has expired.

# Screenshots (if necessary)

<img width="2503" height="523" alt="image" src="https://github.com/user-attachments/assets/5cb9c591-76ca-43a8-ab51-7cfe5db64f47" />

<img width="1747" height="1126" alt="image" src="https://github.com/user-attachments/assets/8df968e5-72c3-4b7c-bade-35a962658291" />
