### PR TITLE
fix: cancelled sessions should be marked as done

### DIFF
--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -123,6 +123,7 @@ class MentoringSessionsService
 
             $session->update([
                 'cancelled_datetime' => now(),
+                'session_done' => 1,
             ]);
 
             CancelReason::create([


### PR DESCRIPTION
# Summary of changes
- To stop sessions still appearing in the CTS accepted mentoring sessions table they must be marked as done

# Screenshots (if necessary)
