### PR TITLE
fix: standardise "Request Moodle Course" section on LL S1 page

### DIFF
--- a/resources/views/controllers/endorsements/heathrow_ground_s1.blade.php
+++ b/resources/views/controllers/endorsements/heathrow_ground_s1.blade.php
@@ -135,7 +135,9 @@
 							to request access to the Moodle Course
 						</p>
 					@else
-						<button class="btn btn-info center-block" disabled>Request Moodle Course</button>
+						<p>
+							You must meet all conditions before you can request access to the moodle course.
+						</p>
 					@endif
 				</div>
 			</div>


### PR DESCRIPTION
# Summary of changes
- Remove disabled button when conditions aren't met, as the button doesn't appear when conditions are met
# Screenshots (if necessary)
Conditions not met:
Before:
<img width="733" height="131" alt="image" src="https://github.com/user-attachments/assets/588f1ac9-9bdd-46c1-8bd0-f666ff2399ad" />

After:
<img width="699" height="133" alt="image" src="https://github.com/user-attachments/assets/4a031b3c-a454-4ec8-b8b9-8af3239e41b6" />

Conditions met:
<img width="721" height="120" alt="image" src="https://github.com/user-attachments/assets/98fec72c-39bb-4f6f-894f-1029f241df6b" />
