### PR TITLE
fix: improve search styling on roster page

### DIFF
--- a/resources/views/livewire/roster/search.blade.php
+++ b/resources/views/livewire/roster/search.blade.php
@@ -6,7 +6,7 @@
 				<label for="email" class="block text-sm font-medium leading-6 text-gray-900">VATSIM CID</label>
 				<div class="mt-2">
 					<input wire:model="searchTerm" id="search" name="search" type="search" autocomplete="off" required
-						class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+						class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
 				</div>
 			</div>
 


### PR DESCRIPTION
# Summary of changes
- improve search styling on roster page

# Screenshots (if necessary)
Before:
<img width="460" height="249" alt="image" src="https://github.com/user-attachments/assets/cab7331d-936d-44c9-aa42-a3cb30a40def" />


After:
<img width="458" height="222" alt="image" src="https://github.com/user-attachments/assets/e1583419-e7b9-4108-9720-4a76a876b7f2" />
