### PR TITLE
fix: ensure only specific members exam cancellations are shown

### DIFF
--- a/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
+++ b/app/Livewire/Training/TrainingPlaceExamCancellationsTable.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Training;
 
 use App\Models\Cts\CancelReason;
+use App\Models\Cts\Member;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -51,12 +52,14 @@ class TrainingPlaceExamCancellationsTable extends Component implements HasForms,
     private function cancellationsQuery()
     {
         $position = $this->trainingPlace->trainingPosition?->exam_callsign ?? $this->trainingPlace->trainingPosition?->position?->callsign;
+        $student = Member::where('cid', $this->trainingPlace->account_id)->first();
 
         return CancelReason::query()
             ->select('cancel_reason.*')
             ->join('exam_book', 'cancel_reason.sesh_id', '=', 'exam_book.id')
             ->where('cancel_reason.sesh_type', 'EX')
             ->where('exam_book.position_1', $position)
+            ->where('exam_book.student_id', $student->id)
             ->orderBy('cancel_reason.date', 'desc');
     }
 }

--- a/app/Models/Training/TrainingPlace/TrainingPlace.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlace.php
@@ -92,10 +92,18 @@ class TrainingPlace extends Model
             return false;
         }
 
+        $member = $this->account->member;
+
+        if (! $member) {
+            return false;
+        }
+
         return CancelReason::query()
+            ->select('cancel_reason.*')
             ->join('exam_book', 'cancel_reason.sesh_id', '=', 'exam_book.id')
             ->where('cancel_reason.sesh_type', 'EX')
             ->where('exam_book.position_1', $position)
+            ->where('exam_book.student_id', $member->id)
             ->exists();
     }
 

--- a/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceExamCancellationsTableTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceExamCancellationsTableTest.php
@@ -7,6 +7,8 @@ namespace Tests\Feature\TrainingPanel\Training;
 use App\Livewire\Training\TrainingPlaceExamCancellationsTable;
 use App\Models\Cts\CancelReason;
 use App\Models\Cts\ExamBooking;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -22,12 +24,21 @@ class TrainingPlaceExamCancellationsTableTest extends BaseTrainingPanelTestCase
 
     protected string $callsign = 'EGKK_APP';
 
+    protected Member $member;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->trainingPlace = TrainingPlace::factory()
             ->for(TrainingPosition::factory()->state(['exam_callsign' => $this->callsign]), 'trainingPosition')->create();
+
+        $account = Account::findOrFail($this->trainingPlace->account_id);
+
+        $this->member = Member::factory()->create([
+            'id' => $account->generateCTSInternalID($account->id),
+            'cid' => $account->id,
+        ]);
     }
 
     #[Test]
@@ -41,21 +52,30 @@ class TrainingPlaceExamCancellationsTableTest extends BaseTrainingPanelTestCase
     #[Test]
     public function it_lists_exam_cancellations_matching_the_training_place_exam_callsign(): void
     {
-        $matchingBooking = ExamBooking::factory()->create(['position_1' => $this->callsign]);
+        $matchingBooking = ExamBooking::factory()->create([
+            'position_1' => $this->callsign,
+            'student_id' => $this->member->id,
+        ]);
         $matchingCancellation = CancelReason::factory()->create([
             'sesh_id' => $matchingBooking->id,
             'sesh_type' => 'EX',
             'reason' => 'Matching Exam Cancellation',
         ]);
 
-        $wrongPositionBooking = ExamBooking::factory()->create(['position_1' => 'EGCC_TWR']);
+        $wrongPositionBooking = ExamBooking::factory()->create([
+            'position_1' => 'EGCC_TWR',
+            'student_id' => $this->member->id,
+        ]);
         $wrongPositionCancellation = CancelReason::factory()->create([
             'sesh_id' => $wrongPositionBooking->id,
             'sesh_type' => 'EX',
             'reason' => 'Wrong Position Cancellation',
         ]);
 
-        $mentoringBooking = ExamBooking::factory()->create(['position_1' => $this->callsign]);
+        $mentoringBooking = ExamBooking::factory()->create([
+            'position_1' => $this->callsign,
+            'student_id' => $this->member->id,
+        ]);
         $mentoringCancellation = CancelReason::factory()->create([
             'sesh_id' => $mentoringBooking->id,
             'sesh_type' => 'ME',
@@ -66,5 +86,40 @@ class TrainingPlaceExamCancellationsTableTest extends BaseTrainingPanelTestCase
             ->test(TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace])
             ->assertCanSeeTableRecords([$matchingCancellation])
             ->assertCanNotSeeTableRecords([$wrongPositionCancellation, $mentoringCancellation]);
+    }
+
+    #[Test]
+    public function it_only_shows_cancellations_for_the_student(): void
+    {
+        $otherAccount = Account::factory()->create();
+        $otherMember = Member::factory()->create([
+            'id' => $otherAccount->id,
+            'cid' => $otherAccount->id,
+        ]);
+
+        $studentBooking = ExamBooking::factory()->create([
+            'position_1' => $this->callsign,
+            'student_id' => $this->member->id,
+        ]);
+        $studentCancellation = CancelReason::factory()->create([
+            'sesh_id' => $studentBooking->id,
+            'sesh_type' => 'EX',
+            'reason' => 'Student Cancellation',
+        ]);
+
+        $otherBooking = ExamBooking::factory()->create([
+            'position_1' => $this->callsign,
+            'student_id' => $otherMember->id,
+        ]);
+        $otherCancellation = CancelReason::factory()->create([
+            'sesh_id' => $otherBooking->id,
+            'sesh_type' => 'EX',
+            'reason' => 'Other Student Cancellation',
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(TrainingPlaceExamCancellationsTable::class, ['trainingPlace' => $this->trainingPlace])
+            ->assertCanSeeTableRecords([$studentCancellation])
+            ->assertCanNotSeeTableRecords([$otherCancellation]);
     }
 }


### PR DESCRIPTION
# Summary of changes
- Fixes bug where other members exam cancellations where showing on a tp

# Screenshots (if necessary)
