### PR TITLE
fix: prevent setting up an exam if an exam booking already exists

### DIFF
--- a/app/Filament/Training/Pages/Exam/ExamSetup.php
+++ b/app/Filament/Training/Pages/Exam/ExamSetup.php
@@ -71,6 +71,11 @@ class ExamSetup extends Page implements HasForms
 
         $trainingPosition = TrainingPosition::where('position_id', $validated['data']['position'])->firstOrFail();
         $ctsMember = Member::where('id', $validated['data']['student'])->first();
+        $examType = $trainingPosition->position->examLevel;
+
+        if ($this->hasPendingExam($ctsMember, $examType)) {
+            return;
+        }
 
         $service = new ExamForwardingService;
         $service->forwardForExam($ctsMember, $trainingPosition, Auth::user()->id);
@@ -91,6 +96,10 @@ class ExamSetup extends Page implements HasForms
 
         $trainingPosition = TrainingPosition::whereJsonContains('cts_positions', $position->callsign)->firstOrFail();
         $ctsMember = Member::where('id', $this->dataOBS['student_obs'])->first();
+
+        if ($this->hasPendingExam($ctsMember, 'OBS')) {
+            return;
+        }
 
         $service = new ExamForwardingService;
         $service->forwardForObsExam($ctsMember, $trainingPosition);
@@ -218,11 +227,26 @@ class ExamSetup extends Page implements HasForms
         $ctsMember = Member::where('id', $validated['dataPilot']['student_pilot'])->first();
         $examType = $validated['dataPilot']['exam_type'];
 
+        if ($this->hasPendingExam($ctsMember, $examType)) {
+            return;
+        }
+
         $service = new ExamForwardingService;
         $service->forwardForPilotExam($ctsMember, $examType, Auth::user()->id);
         $service->notifySuccess(PilotExamType::from($examType)->label());
 
         return redirect()->route('filament.training.pages.exam-setup');
+    }
+
+    private function hasPendingExam(Member $ctsMember, string $examType): bool
+    {
+        if ((new ExamResultRepository)->studentHasPendingExam($examType, $ctsMember->id)) {
+            (new ExamForwardingService)->notifyError("This student already has a pending {$examType} exam.");
+
+            return true;
+        }
+
+        return false;
     }
 
     public function formPilot(Schema $schema): Schema

--- a/app/Repositories/Cts/ExamResultRepository.php
+++ b/app/Repositories/Cts/ExamResultRepository.php
@@ -33,6 +33,14 @@ class ExamResultRepository
             ->get();
     }
 
+    public function studentHasPendingExam(string $type, int $studentId): bool
+    {
+        return ExamBooking::where('exam', $type)
+            ->where('student_id', $studentId)
+            ->where('finished', ExamBooking::NOT_FINISHED_FLAG)
+            ->exists();
+    }
+
     public function createPracticalResult(ExamBooking $examBooking, string $result, ?string $additionalComments)
     {
         $practicalResult = PracticalResult::create([

--- a/tests/Feature/TrainingPanel/Exams/ExamSetupTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamSetupTest.php
@@ -305,4 +305,127 @@ class ExamSetupTest extends BaseTrainingPanelTestCase
             ->assertSeeText('Exam Setup - TWR to CTR')
             ->assertSeeText('Exam Setup - OBS PT3');
     }
+
+    #[Test]
+    public function it_prevents_setup_exam_when_student_has_pending_twr_to_ctr_exam()
+    {
+        $this->panelUser->givePermissionTo('training.exams.setup');
+
+        $position = Position::factory()->create([
+            'callsign' => 'EGKK_TWR',
+            'type' => Position::TYPE_TOWER,
+        ]);
+        TrainingPosition::factory()->create(['position_id' => $position->id]);
+
+        $studentAccount = Account::factory()->withQualification()->create();
+        $student = Member::factory()->create([
+            'id' => $studentAccount->id,
+            'cid' => $studentAccount->id,
+        ]);
+
+        ExamBooking::factory()->create([
+            'student_id' => $student->id,
+            'exam' => $position->examLevel,
+            'finished' => ExamBooking::NOT_FINISHED_FLAG,
+        ]);
+
+        Session::factory()->create([
+            'position' => $position->callsign,
+            'student_id' => $student->id,
+            'taken_date' => now()->subDays(30),
+            'cancelled_datetime' => null,
+            'noShow' => 0,
+            'session_done' => 1,
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamSetup::class)
+            ->set('data.position', $position->id)
+            ->set('data.student', $student->id)
+            ->call('setupExam')
+            ->assertHasNoErrors()
+            ->assertNotified('Error');
+
+        $this->assertDatabaseMissing('exam_setup', [
+            'student_id' => $student->id,
+        ], 'cts');
+    }
+
+    #[Test]
+    public function it_prevents_setup_exam_for_obs_when_student_has_pending_obs_exam()
+    {
+        $this->panelUser->givePermissionTo('training.exams.setup');
+
+        $pt3Position = CtsPosition::factory()->create(['callsign' => 'OBS_SC_PT3']);
+        $pt2Position = CtsPosition::factory()->create(['callsign' => 'OBS_SC_PT2']);
+
+        $atcPosition = Position::factory()->create(['callsign' => 'SC_GND']);
+        TrainingPosition::factory()->withCtsPositions([$pt3Position->callsign])->create([
+            'position_id' => $atcPosition->id,
+            'exam_callsign' => 'OBS_SC_PT2',
+        ]);
+
+        $studentAccount = Account::factory()->withQualification()->create();
+        $student = Member::factory()->create([
+            'id' => $studentAccount->id,
+            'cid' => $studentAccount->id,
+        ]);
+
+        ExamBooking::factory()->create([
+            'student_id' => $student->id,
+            'exam' => 'OBS',
+            'finished' => ExamBooking::NOT_FINISHED_FLAG,
+        ]);
+
+        Session::factory()->create([
+            'position' => $pt2Position->callsign,
+            'student_id' => $student->id,
+            'taken_date' => now()->subDays(30),
+            'cancelled_datetime' => null,
+            'noShow' => 0,
+            'session_done' => 1,
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamSetup::class)
+            ->set('dataOBS.position_obs', $pt3Position->id)
+            ->set('dataOBS.student_obs', $student->id)
+            ->call('setupExamOBS')
+            ->assertHasNoErrors()
+            ->assertNotified('Error');
+
+        $this->assertDatabaseMissing('exam_setup', [
+            'student_id' => $student->id,
+        ], 'cts');
+    }
+
+    #[Test]
+    public function it_prevents_setup_exam_for_pilot_when_student_has_pending_pilot_exam()
+    {
+        $this->panelUser->givePermissionTo('training.exams.setup');
+
+        $studentAccount = Account::factory()->withQualification()->create();
+        $student = Member::factory()->create([
+            'id' => $studentAccount->id,
+            'cid' => $studentAccount->id,
+        ]);
+
+        ExamBooking::factory()->create([
+            'student_id' => $student->id,
+            'exam' => 'P1',
+            'finished' => ExamBooking::NOT_FINISHED_FLAG,
+        ]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ExamSetup::class)
+            ->set('dataPilot.exam_type', 'P1')
+            ->set('dataPilot.student_pilot', $student->id)
+            ->call('setupExamPilot')
+            ->assertHasNoErrors()
+            ->assertNotified('Error');
+
+        $this->assertDatabaseMissing('exam_setup', [
+            'student_id' => $student->id,
+        ], 'cts');
+    }
 }


### PR DESCRIPTION
# Summary of changes
- Stops users from setting up duplicate exams

# Screenshots (if necessary)
