### PR TITLE
fix: show who cancelled a mentoring session

### DIFF
--- a/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
+++ b/app/Filament/Training/Pages/Mentor/Base/BaseMentoringHistoryPage.php
@@ -147,6 +147,23 @@ abstract class BaseMentoringHistoryPage extends Page implements HasTable
                     $record->filed !== null => 'Completed',
                     default => 'Pending',
                 })
+                ->description(function ($record) {
+                    if ($record->cancelled_datetime !== null && $record->noShow != 1) {
+                        $cancelledById = $record->cancelReason?->reason_by;
+
+                        if ($cancelledById === $record->student_id) {
+                            return 'By Student';
+                        }
+
+                        if ($cancelledById === $record->mentor_id) {
+                            return 'By Mentor';
+                        }
+
+                        return 'By Other';
+                    }
+
+                    return null;
+                })
                 ->color(fn ($state) => match ($state) {
                     'Pending' => 'primary',
                     'No Show' => 'danger',


### PR DESCRIPTION
Fixes TECH-691

# Summary of changes
- Shows under cancelled badge who cancelled a session

# Screenshots (if necessary)
<img width="656" height="121" alt="image" src="https://github.com/user-attachments/assets/42864875-3aa9-4281-8c84-d11b9be54ac7" />

If not student or mentor:
<img width="750" height="84" alt="image" src="https://github.com/user-attachments/assets/8d444b96-c5fc-4038-bf1c-196709a3e322" />
