### PR TITLE
feat: show Heathrow progress bars on main Heathrow page

### DIFF
--- a/app/Http/Controllers/Site/ATCPagesController.php
+++ b/app/Http/Controllers/Site/ATCPagesController.php
@@ -2,6 +2,11 @@
 
 namespace App\Http\Controllers\Site;
 
+use App\Models\Atc\PositionGroup;
+use App\Models\NetworkData\Atc;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+
 class ATCPagesController extends \App\Http\Controllers\BaseController
 {
     public function __construct()
@@ -39,9 +44,106 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
         $this->setTitle('Heathrow Endorsements');
         $this->addBreadcrumb('Heathrow Endorsements', route('site.atc.heathrow'));
 
-        return $this->viewMake('site.atc.heathrow')->with([
-            'account' => $this->account,
-        ]);
+        $viewData = ['account' => $this->account];
+
+        if ($this->account->exists) {
+            $heathrowPositionGroups = PositionGroup::whereIn('name', [
+                'Heathrow (GND)',
+                'Heathrow (TWR)',
+                'Heathrow (APP)',
+            ])->get()->keyBy('name');
+
+            $existingEndorsements = $this->account->endorsements()
+                ->active()
+                ->where('endorsable_type', PositionGroup::class)
+                ->whereIn('endorsable_id', $heathrowPositionGroups->pluck('id'))
+                ->pluck('endorsable_id')
+                ->toArray();
+
+            $endorsementProgress = [];
+            $endorsementChain = ['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)'];
+
+            foreach ($endorsementChain as $i => $pgName) {
+                $pg = $heathrowPositionGroups->get($pgName);
+                if (! $pg || in_array($pg->id, $existingEndorsements)) {
+                    continue;
+                }
+
+                switch ($pgName) {
+                    case 'Heathrow (GND)':
+                        $delGndTwr = fn () => $this->account->networkDataAtc()
+                            ->isUK()
+                            ->where(function (Builder $b) {
+                                $b->where('facility_type', Atc::TYPE_DEL)
+                                    ->orWhere('facility_type', Atc::TYPE_GND)
+                                    ->orWhere('facility_type', Atc::TYPE_TWR);
+                            });
+
+                        $endorsementProgress[] = [
+                            'name' => 'Heathrow DEL/GND (S2+)',
+                            'bars' => [
+                                ['label' => 'Total UK DEL/GND/TWR', 'hours' => $delGndTwr()->sum('minutes_online') / 60, 'required' => 40],
+                                ['label' => 'Gatwick DEL/GND/TWR', 'hours' => (clone $delGndTwr())->where('callsign', 'like', 'EGKK%')->sum('minutes_online') / 60, 'required' => 10],
+                                ['label' => 'Manchester DEL/GND/TWR', 'hours' => (clone $delGndTwr())->where('callsign', 'like', 'EGCC%')->sum('minutes_online') / 60, 'required' => 10],
+                            ],
+                        ];
+                        break;
+
+                    case 'Heathrow (TWR)':
+                        $heathrowGndRecent = $this->account->networkDataAtc()
+                            ->where('callsign', 'like', 'EGLL%')
+                            ->where(function (Builder $b) {
+                                $b->where('facility_type', Atc::TYPE_GND)
+                                    ->orWhere('facility_type', Atc::TYPE_DEL);
+                            })
+                            ->whereBetween('connected_at', [Carbon::now()->subMonths(3), Carbon::now()])
+                            ->sum('minutes_online') / 60;
+
+                        $ukTwr = fn () => $this->account->networkDataAtc()
+                            ->isUK()
+                            ->where('facility_type', Atc::TYPE_TWR);
+
+                        $endorsementProgress[] = [
+                            'name' => 'Heathrow TWR (S2+)',
+                            'bars' => [
+                                ['label' => 'Heathrow GND/DEL (last 3 months)', 'hours' => $heathrowGndRecent, 'required' => 10],
+                                ['label' => 'Total UK TWR', 'hours' => $ukTwr()->sum('minutes_online') / 60, 'required' => 100],
+                                ['label' => 'Manchester TWR', 'hours' => (clone $ukTwr())->where('callsign', 'like', 'EGCC%')->sum('minutes_online') / 60, 'required' => 30],
+                                ['label' => 'Gatwick TWR', 'hours' => (clone $ukTwr())->where('callsign', 'like', 'EGKK%')->sum('minutes_online') / 60, 'required' => 30],
+                            ],
+                        ];
+                        break;
+
+                    case 'Heathrow (APP)':
+                        $heathrowTwrRecent = $this->account->networkDataAtc()
+                            ->where('callsign', 'like', 'EGLL%')
+                            ->where('facility_type', Atc::TYPE_TWR)
+                            ->whereBetween('connected_at', [Carbon::now()->subMonths(3), Carbon::now()])
+                            ->sum('minutes_online') / 60;
+
+                        $ukApp = fn () => $this->account->networkDataAtc()
+                            ->isUK()
+                            ->where('facility_type', Atc::TYPE_APP);
+
+                        $endorsementProgress[] = [
+                            'name' => 'Heathrow APP (S3+)',
+                            'bars' => [
+                                ['label' => 'Heathrow TWR (last 3 months)', 'hours' => $heathrowTwrRecent, 'required' => 10],
+                                ['label' => 'Total UK APP', 'hours' => $ukApp()->sum('minutes_online') / 60, 'required' => 120],
+                                ['label' => 'Manchester APP', 'hours' => (clone $ukApp())->where('callsign', 'like', 'EGCC%')->sum('minutes_online') / 60, 'required' => 30],
+                                ['label' => 'Gatwick APP', 'hours' => (clone $ukApp())->where('callsign', 'like', 'EGKK%')->sum('minutes_online') / 60, 'required' => 30],
+                            ],
+                        ];
+                        break;
+                }
+
+                break;
+            }
+
+            $viewData['endorsementProgress'] = $endorsementProgress;
+        }
+
+        return $this->viewMake('site.atc.heathrow')->with($viewData);
     }
 
     public function viewBecomingAMentor()

--- a/app/Http/Controllers/Site/ATCPagesController.php
+++ b/app/Http/Controllers/Site/ATCPagesController.php
@@ -63,7 +63,7 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
             $endorsementProgress = [];
             $endorsementChain = ['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)'];
 
-            foreach ($endorsementChain as $i => $pgName) {
+            foreach ($endorsementChain as $pgName) {
                 $pg = $heathrowPositionGroups->get($pgName);
                 if (! $pg || in_array($pg->id, $existingEndorsements)) {
                     continue;

--- a/resources/views/site/atc/heathrow.blade.php
+++ b/resources/views/site/atc/heathrow.blade.php
@@ -47,8 +47,8 @@
 								<p><strong>{{ $bar['label'] }}</strong>
 								<div class="progress" data-toggle="tooltip" title="{{ $bar['label'] }}">
 									<div class="progress-bar {{ $met ? 'progress-bar-success' : 'progress-bar-warning' }}" role="progressbar"
-										style="width: {{ min(($bar['hours'] / $bar['required']) * 100, 100) }}%"
-										aria-valuemin="0" aria-valuemax="{{ $bar['required'] }}">
+										style="width: {{ min(($bar['hours'] / $bar['required']) * 100, 100) }}%" aria-valuemin="0"
+										aria-valuemax="{{ $bar['required'] }}">
 										{{ floor($bar['hours']) }} / {{ $bar['required'] }} Hrs
 									</div>
 								</div>

--- a/resources/views/site/atc/heathrow.blade.php
+++ b/resources/views/site/atc/heathrow.blade.php
@@ -44,10 +44,11 @@
 							<h4>{{ $ep['name'] }}</h4>
 							@foreach ($ep['bars'] as $bar)
 								@php $met = $bar['hours'] >= $bar['required']; @endphp
-								<p><strong>{{ $bar['label'] }}</strong>
+								<p><strong>{{ $bar['label'] }}</strong></p>
 								<div class="progress" data-toggle="tooltip" title="{{ $bar['label'] }}">
 									<div class="progress-bar {{ $met ? 'progress-bar-success' : 'progress-bar-warning' }}" role="progressbar"
-										style="width: {{ min(($bar['hours'] / $bar['required']) * 100, 100) }}%" aria-valuemin="0"
+										style="width: {{ min(($bar['hours'] / $bar['required']) * 100, 100) }}%"
+										aria-valuenow="{{ min($bar['hours'], $bar['required']) }}" aria-valuemin="0"
 										aria-valuemax="{{ $bar['required'] }}">
 										{{ floor($bar['hours']) }} / {{ $bar['required'] }} Hrs
 									</div>

--- a/resources/views/site/atc/heathrow.blade.php
+++ b/resources/views/site/atc/heathrow.blade.php
@@ -33,4 +33,33 @@
 			</div>
 		</div>
 	</div>
+
+	@if (!empty($endorsementProgress))
+		<div class="row">
+			<div class="col-md-9">
+				<div class="panel panel-ukblue">
+					<div class="panel-heading"><i class="fa fa-info"></i> &thinsp; Your Progress</div>
+					<div class="panel-body">
+						@foreach ($endorsementProgress as $ep)
+							<h4>{{ $ep['name'] }}</h4>
+							@foreach ($ep['bars'] as $bar)
+								@php $met = $bar['hours'] >= $bar['required']; @endphp
+								<p><strong>{{ $bar['label'] }}</strong>
+								<div class="progress" data-toggle="tooltip" title="{{ $bar['label'] }}">
+									<div class="progress-bar {{ $met ? 'progress-bar-success' : 'progress-bar-warning' }}" role="progressbar"
+										style="width: {{ min(($bar['hours'] / $bar['required']) * 100, 100) }}%"
+										aria-valuemin="0" aria-valuemax="{{ $bar['required'] }}">
+										{{ floor($bar['hours']) }} / {{ $bar['required'] }} Hrs
+									</div>
+								</div>
+							@endforeach
+							@if (!$loop->last)
+								<hr>
+							@endif
+						@endforeach
+					</div>
+				</div>
+			</div>
+		</div>
+	@endif
 @stop

--- a/tests/Feature/Site/HeathrowEndorsementProgressTest.php
+++ b/tests/Feature/Site/HeathrowEndorsementProgressTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Tests\Feature\Site;
+
+use App\Models\Atc\PositionGroup;
+use App\Models\Mship\Account;
+use App\Models\Mship\Account\Endorsement;
+use App\Models\Mship\Qualification;
+use App\Models\Mship\State;
+use App\Models\NetworkData\Atc;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class HeathrowEndorsementProgressTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private const ROUTE = 'site.atc.heathrow';
+
+    #[Test]
+    public function test_guest_does_not_see_progress_panel()
+    {
+        $this->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertDontSee('Your Progress');
+    }
+
+    #[Test]
+    public function test_logged_in_user_without_endorsements_sees_gnd_hours()
+    {
+        $account = $this->createS2Account();
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+
+        $s1Qual = Qualification::code('S1')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 10 * 60,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s1Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_DEL',
+            'minutes_online' => 10 * 60,
+            'facility_type' => Atc::TYPE_DEL,
+            'qualification_id' => $s1Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_TWR',
+            'minutes_online' => 20 * 60,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s1Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('Your Progress')
+            ->assertSee('Total UK DEL/GND/TWR')
+            ->assertSee('Gatwick DEL/GND/TWR')
+            ->assertSee('Manchester DEL/GND/TWR')
+            ->assertSee('40 / 40 Hrs')
+            ->assertSee('10 / 10 Hrs');
+    }
+
+    #[Test]
+    public function test_logged_in_user_with_gnd_endorsement_sees_twr_hours()
+    {
+        $account = $this->createS2Account();
+        $gndPg = PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        PositionGroup::factory()->create(['name' => 'Heathrow (TWR)']);
+
+        Endorsement::factory()->create([
+            'account_id' => $account->id,
+            'endorsable_type' => PositionGroup::class,
+            'endorsable_id' => $gndPg->id,
+        ]);
+
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_GND',
+            'minutes_online' => 10 * 60,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+            'connected_at' => Carbon::now()->subMonth(),
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_TWR',
+            'minutes_online' => 50 * 60,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_TWR',
+            'minutes_online' => 30 * 60,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGBB_TWR',
+            'minutes_online' => 20 * 60,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('Your Progress')
+            ->assertSee('Heathrow GND/DEL (last 3 months)')
+            ->assertSee('Total UK TWR')
+            ->assertSee('Manchester TWR')
+            ->assertSee('Gatwick TWR')
+            ->assertSee('10 / 10 Hrs')
+            ->assertSee('100 / 100 Hrs')
+            ->assertDontSee('Total UK DEL/GND/TWR');
+    }
+
+    #[Test]
+    public function test_logged_in_user_with_all_endorsements_sees_no_progress()
+    {
+        $account = $this->createS2Account();
+        $pgIds = [];
+        foreach (['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)'] as $name) {
+            $pg = PositionGroup::factory()->create(['name' => $name]);
+            $pgIds[] = $pg->id;
+        }
+
+        foreach ($pgIds as $pgId) {
+            Endorsement::factory()->create([
+                'account_id' => $account->id,
+                'endorsable_type' => PositionGroup::class,
+                'endorsable_id' => $pgId,
+            ]);
+        }
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertDontSee('Your Progress');
+    }
+
+    #[Test]
+    public function test_hours_are_filtered_by_minimum_qualification()
+    {
+        $account = $this->createS2Account();
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+
+        $s1Qual = Qualification::code('S1')->firstOrFail();
+        $pilotQual = Qualification::factory()->pilot()->create();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 10 * 60,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s1Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_GND',
+            'minutes_online' => 100 * 60,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $pilotQual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('10 / 40 Hrs')
+            ->assertSee('10 / 10 Hrs');
+    }
+
+    private function createS2Account(): Account
+    {
+        $account = Account::factory()->create();
+        $account->addQualification(Qualification::code('S2')->firstOrFail());
+        $account->addState(State::findByCode('DIVISION')->firstOrFail(), 'EUR', 'GBR');
+
+        return $account;
+    }
+}


### PR DESCRIPTION
# Summary of changes
- Adds Your Progress section which shows the next endorsement you don't hold, and your progress towards it.

# Screenshots (if necessary)
<img width="780" height="422" alt="image" src="https://github.com/user-attachments/assets/ea185ca4-7b01-4fd1-b9c7-61196dd90ca9" />

<img width="787" height="411" alt="image" src="https://github.com/user-attachments/assets/7d7dbe63-6e14-463e-a365-a24e32217317" />
