### PR TITLE
fix: add TFP to visiting closed banner on VT page

### DIFF
--- a/resources/views/site/community/vt-dashboard.blade.php
+++ b/resources/views/site/community/vt-dashboard.blade.php
@@ -18,7 +18,7 @@
 				</p>
 
 				<div class="alert alert-danger">
-					<h3 style="margin-top: 0">TFP, P1, P2, P3, S3 and C1 Visiting Closed</h3>
+					<h3 style="margin-top: 0">The Flying Program (TFP), P1, P2, P3, S3 and C1 Visiting Closed</h3>
 					<p>We are currently <strong>not accepting applications</strong> for these due to incredibly high demand
 						leading to long wait times.</p>
 					<p><strong>Applications to transfer or to visit Shanwick are unaffected.</strong></p>

--- a/resources/views/site/community/vt-dashboard.blade.php
+++ b/resources/views/site/community/vt-dashboard.blade.php
@@ -18,11 +18,10 @@
 				</p>
 
 				<div class="alert alert-danger">
-					<h3 style="margin-top: 0">P1, P2, P3, S3 and C1 Visiting Closed</h3>
+					<h3 style="margin-top: 0">TFP, P1, P2, P3, S3 and C1 Visiting Closed</h3>
 					<p>We are currently <strong>not accepting applications</strong> for these due to incredibly high demand
 						leading to long wait times.</p>
-					<p><strong>Applications to transfer, to visit Shanwick and to visit for The Flying Program (TFP) are
-							unaffected.</strong></p>
+					<p><strong>Applications to transfer or to visit Shanwick are unaffected.</strong></p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
# Summary of changes
- Per request from WS, added TFP to VT banner

# Screenshots (if necessary)
<img width="1061" height="143" alt="image" src="https://github.com/user-attachments/assets/a9e3e0b9-5318-489c-838d-d783021c8c39" />
