### PR TITLE
fix: resolve issues with heathrow progress bars

### DIFF
--- a/app/Http/Controllers/Site/ATCPagesController.php
+++ b/app/Http/Controllers/Site/ATCPagesController.php
@@ -89,7 +89,7 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
 
                 switch ($pgName) {
                     case 'Heathrow (GND)':
-                        $delGndTwr = fn () => $this->account->networkDataAtc()
+                        $delGndTwrBase = $this->account->networkDataAtc()
                             ->isUK()
                             ->withoutAfis()
                             ->withoutMilitary()
@@ -103,9 +103,9 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                         $endorsementProgress[] = [
                             'name' => 'Heathrow DEL/GND (S2+)',
                             'bars' => [
-                                ['label' => 'Total UK DEL/GND/TWR', 'hours' => $delGndTwr()->sum('minutes_online') / 60, 'required' => 40],
-                                ['label' => 'Gatwick DEL/GND/TWR', 'hours' => (clone $delGndTwr())->where('callsign', 'like', 'EGKK%')->sum('minutes_online') / 60, 'required' => 10],
-                                ['label' => 'Manchester DEL/GND/TWR', 'hours' => (clone $delGndTwr())->where('callsign', 'like', 'EGCC%')->sum('minutes_online') / 60, 'required' => 10],
+                                ['label' => 'Total UK DEL/GND/TWR', 'hours' => (clone $delGndTwrBase)->sum('minutes_online') / 60, 'required' => 40],
+                                ['label' => 'Gatwick DEL/GND/TWR', 'hours' => (clone $delGndTwrBase)->where('callsign', 'like', 'EGKK%')->sum('minutes_online') / 60, 'required' => 10],
+                                ['label' => 'Manchester DEL/GND/TWR', 'hours' => (clone $delGndTwrBase)->where('callsign', 'like', 'EGCC%')->sum('minutes_online') / 60, 'required' => 10],
                             ],
                         ];
                         break;
@@ -121,7 +121,7 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                             ->whereBetween('connected_at', [Carbon::now()->subMonths(3), Carbon::now()])
                             ->sum('minutes_online') / 60;
 
-                        $ukTwr = fn () => $this->account->networkDataAtc()
+                        $ukTwrBase = $this->account->networkDataAtc()
                             ->isUK()
                             ->withoutAfis()
                             ->withoutMilitary()
@@ -132,9 +132,9 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                             'name' => 'Heathrow TWR (S2+)',
                             'bars' => [
                                 ['label' => 'Heathrow GND/DEL (last 3 months)', 'hours' => $heathrowGndRecent, 'required' => 10],
-                                ['label' => 'Total UK TWR', 'hours' => $ukTwr()->sum('minutes_online') / 60, 'required' => 100],
-                                ['label' => 'Manchester TWR', 'hours' => (clone $ukTwr())->where('callsign', 'like', 'EGCC%')->sum('minutes_online') / 60, 'required' => 30],
-                                ['label' => 'Gatwick TWR', 'hours' => (clone $ukTwr())->where('callsign', 'like', 'EGKK%')->sum('minutes_online') / 60, 'required' => 30],
+                                ['label' => 'Total UK TWR', 'hours' => (clone $ukTwrBase)->sum('minutes_online') / 60, 'required' => 100],
+                                ['label' => 'Manchester TWR', 'hours' => (clone $ukTwrBase)->where('callsign', 'like', 'EGCC%')->sum('minutes_online') / 60, 'required' => 30],
+                                ['label' => 'Gatwick TWR', 'hours' => (clone $ukTwrBase)->where('callsign', 'like', 'EGKK%')->sum('minutes_online') / 60, 'required' => 30],
                             ],
                         ];
                         break;
@@ -147,7 +147,7 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                             ->whereBetween('connected_at', [Carbon::now()->subMonths(3), Carbon::now()])
                             ->sum('minutes_online') / 60;
 
-                        $ukApp = fn () => $this->account->networkDataAtc()
+                        $ukAppBase = $this->account->networkDataAtc()
                             ->isUK()
                             ->withoutMilitary()
                             ->atMinimumQualification(4)
@@ -157,9 +157,9 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                             'name' => 'Heathrow APP (S3+)',
                             'bars' => [
                                 ['label' => 'Heathrow TWR (last 3 months)', 'hours' => $heathrowTwrRecent, 'required' => 10],
-                                ['label' => 'Total UK APP', 'hours' => $ukApp()->sum('minutes_online') / 60, 'required' => 120],
-                                ['label' => 'Manchester APP', 'hours' => (clone $ukApp())->where('callsign', 'like', 'EGCC%')->sum('minutes_online') / 60, 'required' => 30],
-                                ['label' => 'Gatwick APP', 'hours' => (clone $ukApp())->where('callsign', 'like', 'EGKK%')->sum('minutes_online') / 60, 'required' => 30],
+                                ['label' => 'Total UK APP', 'hours' => (clone $ukAppBase)->sum('minutes_online') / 60, 'required' => 120],
+                                ['label' => 'Manchester APP', 'hours' => (clone $ukAppBase)->where('callsign', 'like', 'EGCC%')->sum('minutes_online') / 60, 'required' => 30],
+                                ['label' => 'Gatwick APP', 'hours' => (clone $ukAppBase)->where('callsign', 'like', 'EGKK%')->sum('minutes_online') / 60, 'required' => 30],
                             ],
                         ];
                         break;

--- a/app/Http/Controllers/Site/ATCPagesController.php
+++ b/app/Http/Controllers/Site/ATCPagesController.php
@@ -92,6 +92,7 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                         $delGndTwr = fn () => $this->account->networkDataAtc()
                             ->isUK()
                             ->withoutAfis()
+                            ->withoutMilitary()
                             ->atMinimumQualification(3)
                             ->where(function (Builder $b) {
                                 $b->where('facility_type', Atc::TYPE_DEL)
@@ -123,6 +124,7 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                         $ukTwr = fn () => $this->account->networkDataAtc()
                             ->isUK()
                             ->withoutAfis()
+                            ->withoutMilitary()
                             ->atMinimumQualification(3)
                             ->where('facility_type', Atc::TYPE_TWR);
 
@@ -147,6 +149,7 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
 
                         $ukApp = fn () => $this->account->networkDataAtc()
                             ->isUK()
+                            ->withoutMilitary()
                             ->atMinimumQualification(4)
                             ->where('facility_type', Atc::TYPE_APP);
 

--- a/app/Http/Controllers/Site/ATCPagesController.php
+++ b/app/Http/Controllers/Site/ATCPagesController.php
@@ -60,6 +60,14 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                 ->pluck('endorsable_id')
                 ->toArray();
 
+            $atcQualificationLevel = $this->account->qualification_atc?->vatsim ?? 0;
+
+            $gndPgId = $heathrowPositionGroups->get('Heathrow (GND)')?->id;
+            $twrPgId = $heathrowPositionGroups->get('Heathrow (TWR)')?->id;
+
+            $hasGndEndorsement = $gndPgId && in_array($gndPgId, $existingEndorsements);
+            $hasTwrEndorsement = $twrPgId && in_array($twrPgId, $existingEndorsements);
+
             $endorsementProgress = [];
             $endorsementChain = ['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)'];
 
@@ -69,10 +77,22 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                     continue;
                 }
 
+                $eligible = match ($pgName) {
+                    'Heathrow (GND)' => $atcQualificationLevel >= 3,
+                    'Heathrow (TWR)' => $atcQualificationLevel >= 3 && $hasGndEndorsement,
+                    'Heathrow (APP)' => $atcQualificationLevel >= 4 && $hasTwrEndorsement,
+                };
+
+                if (! $eligible) {
+                    continue;
+                }
+
                 switch ($pgName) {
                     case 'Heathrow (GND)':
                         $delGndTwr = fn () => $this->account->networkDataAtc()
                             ->isUK()
+                            ->withoutAfis()
+                            ->atMinimumQualification(3)
                             ->where(function (Builder $b) {
                                 $b->where('facility_type', Atc::TYPE_DEL)
                                     ->orWhere('facility_type', Atc::TYPE_GND)
@@ -96,11 +116,14 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                                 $b->where('facility_type', Atc::TYPE_GND)
                                     ->orWhere('facility_type', Atc::TYPE_DEL);
                             })
+                            ->atMinimumQualification(3)
                             ->whereBetween('connected_at', [Carbon::now()->subMonths(3), Carbon::now()])
                             ->sum('minutes_online') / 60;
 
                         $ukTwr = fn () => $this->account->networkDataAtc()
                             ->isUK()
+                            ->withoutAfis()
+                            ->atMinimumQualification(3)
                             ->where('facility_type', Atc::TYPE_TWR);
 
                         $endorsementProgress[] = [
@@ -118,11 +141,13 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
                         $heathrowTwrRecent = $this->account->networkDataAtc()
                             ->where('callsign', 'like', 'EGLL%')
                             ->where('facility_type', Atc::TYPE_TWR)
+                            ->atMinimumQualification(4)
                             ->whereBetween('connected_at', [Carbon::now()->subMonths(3), Carbon::now()])
                             ->sum('minutes_online') / 60;
 
                         $ukApp = fn () => $this->account->networkDataAtc()
                             ->isUK()
+                            ->atMinimumQualification(4)
                             ->where('facility_type', Atc::TYPE_APP);
 
                         $endorsementProgress[] = [

--- a/app/Models/NetworkData/Atc.php
+++ b/app/Models/NetworkData/Atc.php
@@ -62,6 +62,8 @@ use Watson\Rememberable\Rememberable;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\NetworkData\Atc withCallsignIn($callsigns)
  * @method static \Illuminate\Database\Query\Builder|\App\Models\NetworkData\Atc withTrashed()
  * @method static \Illuminate\Database\Query\Builder|\App\Models\NetworkData\Atc withoutTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\NetworkData\Atc withoutAfis()
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\NetworkData\Atc atMinimumQualification($vatsimLevel)
  *
  * @mixin \Eloquent
  */
@@ -233,6 +235,23 @@ class Atc extends Model
     public static function scopePositionIsWithinUK($query)
     {
         return $query->isUk();
+    }
+
+    public static function scopeWithoutAfis($query)
+    {
+        return $query->where(function ($subQuery) {
+            return $subQuery->where('callsign', 'not like', '%\_I\_TWR')
+                ->where('callsign', 'not like', '%\_I\_\_TWR')
+                ->where('callsign', 'not like', '%\_R\_TWR')
+                ->where('callsign', 'not like', '%\_R\_\_TWR');
+        });
+    }
+
+    public static function scopeAtMinimumQualification($query, $vatsimLevel)
+    {
+        return $query->whereHas('qualification', function ($q) use ($vatsimLevel) {
+            $q->where('vatsim', '>=', $vatsimLevel);
+        });
     }
 
     public function account()

--- a/app/Models/NetworkData/Atc.php
+++ b/app/Models/NetworkData/Atc.php
@@ -6,6 +6,7 @@ use App\Events\NetworkData\AtcSessionDeleted;
 use App\Events\NetworkData\AtcSessionEnded;
 use App\Events\NetworkData\AtcSessionStarted;
 use App\Events\NetworkData\AtcSessionUpdated;
+use App\Models\Atc\PositionGroup;
 use App\Models\Cts\Session as CtsSession;
 use App\Models\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -239,12 +240,12 @@ class Atc extends Model
 
     public static function scopeWithoutAfis($query)
     {
-        return $query->where(function ($subQuery) {
-            return $subQuery->where('callsign', 'not like', '%\_I\_TWR')
-                ->where('callsign', 'not like', '%\_I\_\_TWR')
-                ->where('callsign', 'not like', '%\_R\_TWR')
-                ->where('callsign', 'not like', '%\_R\_\_TWR');
-        });
+        $afisGroup = PositionGroup::where('name', 'AFISO / AGO (S1)')->first();
+        if (! $afisGroup) {
+            return $query;
+        }
+
+        return $query->whereNotIn('callsign', $afisGroup->positions()->pluck('callsign'));
     }
 
     public static function scopeAtMinimumQualification($query, $vatsimLevel)

--- a/app/Models/NetworkData/Atc.php
+++ b/app/Models/NetworkData/Atc.php
@@ -64,6 +64,7 @@ use Watson\Rememberable\Rememberable;
  * @method static \Illuminate\Database\Query\Builder|\App\Models\NetworkData\Atc withTrashed()
  * @method static \Illuminate\Database\Query\Builder|\App\Models\NetworkData\Atc withoutTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\NetworkData\Atc withoutAfis()
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\NetworkData\Atc withoutMilitary()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\NetworkData\Atc atMinimumQualification($vatsimLevel)
  *
  * @mixin \Eloquent
@@ -246,6 +247,23 @@ class Atc extends Model
         }
 
         return $query->whereNotIn('callsign', $afisGroup->positions()->pluck('callsign'));
+    }
+
+    public static function scopeWithoutMilitary($query)
+    {
+        $militaryGroupNames = ['Military (APP)', 'Military (CTR)', 'Military (TWR)'];
+        $militaryCallsigns = PositionGroup::whereIn('name', $militaryGroupNames)
+            ->get()
+            ->flatMap(fn ($g) => $g->positions()->pluck('callsign'))
+            ->unique()
+            ->values()
+            ->toArray();
+
+        if (empty($militaryCallsigns)) {
+            return $query;
+        }
+
+        return $query->whereNotIn('callsign', $militaryCallsigns);
     }
 
     public static function scopeAtMinimumQualification($query, $vatsimLevel)

--- a/tests/Feature/Site/HeathrowEndorsementProgressTest.php
+++ b/tests/Feature/Site/HeathrowEndorsementProgressTest.php
@@ -851,6 +851,75 @@ class HeathrowEndorsementProgressTest extends TestCase
     }
 
     #[Test]
+    public function test_military_twr_callsigns_are_excluded_from_twr_bars()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createMilitaryPosition('Military (TWR)', 'EGDL_TWR');
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGDL_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 100 Hrs');
+    }
+
+    #[Test]
+    public function test_military_app_callsigns_are_excluded_from_app_bars()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $this->createMilitaryPosition('Military (APP)', 'EGQL_APP');
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGQL_APP',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $s3Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 120 Hrs');
+    }
+
+    #[Test]
+    public function test_military_twr_callsigns_are_also_excluded_from_gnd_total_bars()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $this->createMilitaryPosition('Military (TWR)', 'EGVA_TWR');
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGVA_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 40 Hrs');
+    }
+
+    #[Test]
     public function test_zero_hours_shown_when_no_atc_sessions_exist()
     {
         $account = $this->createAccountWithQualification('S2');
@@ -887,6 +956,13 @@ class HeathrowEndorsementProgressTest extends TestCase
         $afisGroup = PositionGroup::firstOrCreate(['name' => 'AFISO / AGO (S1)']);
         $position = Position::factory()->create(['callsign' => $callsign]);
         $afisGroup->positions()->attach($position);
+    }
+
+    private function createMilitaryPosition(string $groupName, string $callsign): void
+    {
+        $group = PositionGroup::firstOrCreate(['name' => $groupName]);
+        $position = Position::factory()->create(['callsign' => $callsign]);
+        $group->positions()->attach($position);
     }
 
     private function createEndorsement(Account $account, PositionGroup $positionGroup): Endorsement

--- a/tests/Feature/Site/HeathrowEndorsementProgressTest.php
+++ b/tests/Feature/Site/HeathrowEndorsementProgressTest.php
@@ -28,34 +28,37 @@ class HeathrowEndorsementProgressTest extends TestCase
     }
 
     #[Test]
-    public function test_logged_in_user_without_endorsements_sees_gnd_hours()
+    public function test_obs_user_does_not_see_any_progress()
     {
-        $account = $this->createS2Account();
+        $account = $this->createAccountWithQualification('OBS');
         PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
 
-        $s1Qual = Qualification::code('S1')->firstOrFail();
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertDontSee('Your Progress');
+    }
 
-        factory(Atc::class)->create([
-            'account_id' => $account->id,
-            'callsign' => 'EGKK_GND',
-            'minutes_online' => 10 * 60,
-            'facility_type' => Atc::TYPE_GND,
-            'qualification_id' => $s1Qual->id,
-        ]);
-        factory(Atc::class)->create([
-            'account_id' => $account->id,
-            'callsign' => 'EGCC_DEL',
-            'minutes_online' => 10 * 60,
-            'facility_type' => Atc::TYPE_DEL,
-            'qualification_id' => $s1Qual->id,
-        ]);
-        factory(Atc::class)->create([
-            'account_id' => $account->id,
-            'callsign' => 'EGPH_TWR',
-            'minutes_online' => 20 * 60,
-            'facility_type' => Atc::TYPE_TWR,
-            'qualification_id' => $s1Qual->id,
-        ]);
+    #[Test]
+    public function test_s1_user_does_not_see_any_progress()
+    {
+        $account = $this->createAccountWithQualification('S1');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertDontSee('Your Progress');
+    }
+
+    #[Test]
+    public function test_s2_user_without_any_endorsements_sees_gnd_bars()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+        $this->seedGndSessions($account, $s2Qual);
 
         $this->actingAs($account)
             ->get(route(self::ROUTE))
@@ -64,54 +67,19 @@ class HeathrowEndorsementProgressTest extends TestCase
             ->assertSee('Total UK DEL/GND/TWR')
             ->assertSee('Gatwick DEL/GND/TWR')
             ->assertSee('Manchester DEL/GND/TWR')
-            ->assertSee('40 / 40 Hrs')
-            ->assertSee('10 / 10 Hrs');
+            ->assertDontSee('Total UK TWR')
+            ->assertDontSee('Total UK APP');
     }
 
     #[Test]
-    public function test_logged_in_user_with_gnd_endorsement_sees_twr_hours()
+    public function test_s2_user_with_gnd_endorsement_sees_twr_bars()
     {
-        $account = $this->createS2Account();
-        $gndPg = PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
-        PositionGroup::factory()->create(['name' => 'Heathrow (TWR)']);
-
-        Endorsement::factory()->create([
-            'account_id' => $account->id,
-            'endorsable_type' => PositionGroup::class,
-            'endorsable_id' => $gndPg->id,
-        ]);
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
 
         $s2Qual = Qualification::code('S2')->firstOrFail();
-
-        factory(Atc::class)->create([
-            'account_id' => $account->id,
-            'callsign' => 'EGLL_GND',
-            'minutes_online' => 10 * 60,
-            'facility_type' => Atc::TYPE_GND,
-            'qualification_id' => $s2Qual->id,
-            'connected_at' => Carbon::now()->subMonth(),
-        ]);
-        factory(Atc::class)->create([
-            'account_id' => $account->id,
-            'callsign' => 'EGKK_TWR',
-            'minutes_online' => 50 * 60,
-            'facility_type' => Atc::TYPE_TWR,
-            'qualification_id' => $s2Qual->id,
-        ]);
-        factory(Atc::class)->create([
-            'account_id' => $account->id,
-            'callsign' => 'EGCC_TWR',
-            'minutes_online' => 30 * 60,
-            'facility_type' => Atc::TYPE_TWR,
-            'qualification_id' => $s2Qual->id,
-        ]);
-        factory(Atc::class)->create([
-            'account_id' => $account->id,
-            'callsign' => 'EGBB_TWR',
-            'minutes_online' => 20 * 60,
-            'facility_type' => Atc::TYPE_TWR,
-            'qualification_id' => $s2Qual->id,
-        ]);
+        $this->seedTwrSessions($account, $s2Qual);
 
         $this->actingAs($account)
             ->get(route(self::ROUTE))
@@ -121,28 +89,42 @@ class HeathrowEndorsementProgressTest extends TestCase
             ->assertSee('Total UK TWR')
             ->assertSee('Manchester TWR')
             ->assertSee('Gatwick TWR')
-            ->assertSee('10 / 10 Hrs')
-            ->assertSee('100 / 100 Hrs')
-            ->assertDontSee('Total UK DEL/GND/TWR');
+            ->assertDontSee('Total UK DEL/GND/TWR')
+            ->assertDontSee('Total UK APP');
     }
 
     #[Test]
-    public function test_logged_in_user_with_all_endorsements_sees_no_progress()
+    public function test_s3_user_with_gnd_and_twr_endorsements_sees_app_bars()
     {
-        $account = $this->createS2Account();
-        $pgIds = [];
-        foreach (['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)'] as $name) {
-            $pg = PositionGroup::factory()->create(['name' => $name]);
-            $pgIds[] = $pg->id;
-        }
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
 
-        foreach ($pgIds as $pgId) {
-            Endorsement::factory()->create([
-                'account_id' => $account->id,
-                'endorsable_type' => PositionGroup::class,
-                'endorsable_id' => $pgId,
-            ]);
-        }
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+        $this->seedAppSessions($account, $s3Qual);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('Your Progress')
+            ->assertSee('Heathrow APP (S3+)')
+            ->assertSee('Heathrow TWR (last 3 months)')
+            ->assertSee('Total UK APP')
+            ->assertSee('Manchester APP')
+            ->assertSee('Gatwick APP')
+            ->assertDontSee('Total UK DEL/GND/TWR')
+            ->assertDontSee('Total UK TWR');
+    }
+
+    #[Test]
+    public function test_user_with_all_heathrow_endorsements_sees_no_progress()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (APP)']);
 
         $this->actingAs($account)
             ->get(route(self::ROUTE))
@@ -151,42 +133,847 @@ class HeathrowEndorsementProgressTest extends TestCase
     }
 
     #[Test]
-    public function test_hours_are_filtered_by_minimum_qualification()
+    public function test_s3_user_without_any_endorsements_starts_at_gnd()
     {
-        $account = $this->createS2Account();
+        $account = $this->createAccountWithQualification('S3');
         PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
 
-        $s1Qual = Qualification::code('S1')->firstOrFail();
-        $pilotQual = Qualification::factory()->pilot()->create();
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+        $this->seedGndSessions($account, $s3Qual);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('Total UK DEL/GND/TWR')
+            ->assertDontSee('Total UK TWR');
+    }
+
+    #[Test]
+    public function test_s2_user_without_gnd_endorsement_cannot_skip_to_twr()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('Total UK DEL/GND/TWR')
+            ->assertDontSee('Total UK TWR');
+    }
+
+    #[Test]
+    public function test_s3_user_with_gnd_but_not_twr_endorsement_sees_twr_not_app()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+        $this->seedTwrSessions($account, $s3Qual);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('Total UK TWR')
+            ->assertDontSee('Total UK DEL/GND/TWR')
+            ->assertDontSee('Total UK APP');
+    }
+
+    #[Test]
+    public function test_s2_user_with_all_heathrow_endorsements_sees_no_progress()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (APP)']);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertDontSee('Your Progress');
+    }
+
+    #[Test]
+    public function test_gnd_total_bar_includes_uk_del_gnd_and_twr()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_DEL',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_DEL,
+            'qualification_id' => $s2Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_GND',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_TWR',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('30 / 40 Hrs');
+    }
+
+    #[Test]
+    public function test_gnd_total_bar_excludes_app_and_ctr_facility_types()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_APP',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $s2Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_CTR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_CTR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 40 Hrs');
+    }
+
+    #[Test]
+    public function test_gnd_gatwick_bar_only_counts_egkk_callsigns()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
 
         factory(Atc::class)->create([
             'account_id' => $account->id,
             'callsign' => 'EGKK_GND',
-            'minutes_online' => 10 * 60,
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_GND',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('10 / 10 Hrs');
+    }
+
+    #[Test]
+    public function test_gnd_manchester_bar_only_counts_egcc_callsigns()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_GND',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('10 / 10 Hrs');
+    }
+
+    #[Test]
+    public function test_gnd_bars_exclude_non_uk_positions()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'LFPG_GND',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 40 Hrs')
+            ->assertSee('0 / 10 Hrs');
+    }
+
+    #[Test]
+    public function test_twr_total_bar_includes_all_uk_twr()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_TWR',
+            'minutes_online' => 6000,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('100 / 100 Hrs');
+    }
+
+    #[Test]
+    public function test_twr_total_bar_excludes_non_twr_facility_types()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 100 Hrs');
+    }
+
+    #[Test]
+    public function test_twr_gatwick_bar_only_counts_egkk_twr()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_TWR',
+            'minutes_online' => 1800,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('30 / 30 Hrs');
+    }
+
+    #[Test]
+    public function test_twr_manchester_bar_only_counts_egcc_twr()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_TWR',
+            'minutes_online' => 1800,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('30 / 30 Hrs');
+    }
+
+    #[Test]
+    public function test_twr_heathrow_gnd_del_recent_bar_only_counts_egll_gnd_del_in_last_3_months()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_GND',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+            'connected_at' => Carbon::now()->subMonth(),
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_DEL',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_DEL,
+            'qualification_id' => $s2Qual->id,
+            'connected_at' => Carbon::now()->subMonth(),
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+            'connected_at' => Carbon::now()->subMonth(),
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_GND',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s2Qual->id,
+            'connected_at' => Carbon::now()->subMonths(6),
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('20 / 10 Hrs');
+    }
+
+    #[Test]
+    public function test_twr_total_bar_excludes_non_uk_twr()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'LFPG_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 100 Hrs');
+    }
+
+    #[Test]
+    public function test_app_total_bar_includes_all_uk_app()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_APP',
+            'minutes_online' => 7200,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $s3Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('120 / 120 Hrs');
+    }
+
+    #[Test]
+    public function test_app_gatwick_bar_only_counts_egkk_app()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_APP',
+            'minutes_online' => 1800,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $s3Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('30 / 30 Hrs');
+    }
+
+    #[Test]
+    public function test_app_manchester_bar_only_counts_egcc_app()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_APP',
+            'minutes_online' => 1800,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $s3Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('30 / 30 Hrs');
+    }
+
+    #[Test]
+    public function test_app_heathrow_twr_recent_bar_only_counts_egll_twr_in_last_3_months()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_TWR',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s3Qual->id,
+            'connected_at' => Carbon::now()->subMonth(),
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_GND',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $s3Qual->id,
+            'connected_at' => Carbon::now()->subMonth(),
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s3Qual->id,
+            'connected_at' => Carbon::now()->subMonths(6),
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('10 / 10 Hrs');
+    }
+
+    #[Test]
+    public function test_app_total_bar_excludes_non_uk_app()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'LFPG_APP',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $s3Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 120 Hrs');
+    }
+
+    #[Test]
+    public function test_s1_sessions_are_excluded_from_gnd_hours()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $s1Qual = Qualification::code('S1')->firstOrFail();
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 600,
             'facility_type' => Atc::TYPE_GND,
             'qualification_id' => $s1Qual->id,
         ]);
         factory(Atc::class)->create([
             'account_id' => $account->id,
             'callsign' => 'EGCC_GND',
-            'minutes_online' => 100 * 60,
+            'minutes_online' => 2400,
             'facility_type' => Atc::TYPE_GND,
-            'qualification_id' => $pilotQual->id,
+            'qualification_id' => $s2Qual->id,
         ]);
 
         $this->actingAs($account)
             ->get(route(self::ROUTE))
             ->assertOk()
-            ->assertSee('10 / 40 Hrs')
-            ->assertSee('10 / 10 Hrs');
+            ->assertSee('40 / 40 Hrs')
+            ->assertSee('0 / 10 Hrs');
     }
 
-    private function createS2Account(): Account
+    #[Test]
+    public function test_s2_sessions_are_excluded_from_app_hours()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_APP',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 120 Hrs');
+    }
+
+    #[Test]
+    public function test_s3_sessions_are_counted_in_app_hours()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_APP',
+            'minutes_online' => 7200,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $s3Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('120 / 120 Hrs');
+    }
+
+    #[Test]
+    public function test_c1_sessions_are_counted_in_gnd_and_app_hours()
+    {
+        $account = $this->createAccountWithQualification('C1');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+        $c1Qual = Qualification::code('C1')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_APP',
+            'minutes_online' => 7200,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $c1Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('120 / 120 Hrs');
+    }
+
+    #[Test]
+    public function test_sessions_with_zero_qualification_are_excluded()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 2400,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => 0,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 40 Hrs')
+            ->assertSee('0 / 10 Hrs');
+    }
+
+    #[Test]
+    public function test_i_twr_callsigns_are_excluded_from_twr_bars()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_I_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 100 Hrs');
+    }
+
+    #[Test]
+    public function test_i_double_underscore_twr_callsigns_are_excluded()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_I__TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 100 Hrs');
+    }
+
+    #[Test]
+    public function test_r_twr_callsigns_are_excluded_from_twr_bars()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_R_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 100 Hrs');
+    }
+
+    #[Test]
+    public function test_afis_twr_callsigns_are_also_excluded_from_gnd_total_bars()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $s2Qual = Qualification::code('S2')->firstOrFail();
+
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_I_TWR',
+            'minutes_online' => 9999,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $s2Qual->id,
+        ]);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 40 Hrs');
+    }
+
+    #[Test]
+    public function test_zero_hours_shown_when_no_atc_sessions_exist()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('0 / 40 Hrs')
+            ->assertSee('0 / 10 Hrs');
+    }
+
+    private function createAccountWithQualification(string $code): Account
     {
         $account = Account::factory()->create();
-        $account->addQualification(Qualification::code('S2')->firstOrFail());
+        $account->addQualification(Qualification::code($code)->firstOrFail());
         $account->addState(State::findByCode('DIVISION')->firstOrFail(), 'EUR', 'GBR');
 
         return $account;
+    }
+
+    private function createPositionGroups(array $names): array
+    {
+        $groups = [];
+        foreach ($names as $name) {
+            $groups[$name] = PositionGroup::factory()->create(['name' => $name]);
+        }
+
+        return $groups;
+    }
+
+    private function createEndorsement(Account $account, PositionGroup $positionGroup): Endorsement
+    {
+        return Endorsement::factory()->create([
+            'account_id' => $account->id,
+            'endorsable_type' => PositionGroup::class,
+            'endorsable_id' => $positionGroup->id,
+        ]);
+    }
+
+    private function seedGndSessions(Account $account, Qualification $qualification): void
+    {
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_GND',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $qualification->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_DEL',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_DEL,
+            'qualification_id' => $qualification->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGPH_TWR',
+            'minutes_online' => 1200,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $qualification->id,
+        ]);
+    }
+
+    private function seedTwrSessions(Account $account, Qualification $qualification): void
+    {
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_GND',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_GND,
+            'qualification_id' => $qualification->id,
+            'connected_at' => Carbon::now()->subMonth(),
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_TWR',
+            'minutes_online' => 3000,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $qualification->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_TWR',
+            'minutes_online' => 1800,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $qualification->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGBB_TWR',
+            'minutes_online' => 1200,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $qualification->id,
+        ]);
+    }
+
+    private function seedAppSessions(Account $account, Qualification $qualification): void
+    {
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_TWR',
+            'minutes_online' => 600,
+            'facility_type' => Atc::TYPE_TWR,
+            'qualification_id' => $qualification->id,
+            'connected_at' => Carbon::now()->subMonth(),
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGKK_APP',
+            'minutes_online' => 3600,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $qualification->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGCC_APP',
+            'minutes_online' => 1800,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $qualification->id,
+        ]);
+        factory(Atc::class)->create([
+            'account_id' => $account->id,
+            'callsign' => 'EGBB_APP',
+            'minutes_online' => 1800,
+            'facility_type' => Atc::TYPE_APP,
+            'qualification_id' => $qualification->id,
+        ]);
     }
 }

--- a/tests/Feature/Site/HeathrowEndorsementProgressTest.php
+++ b/tests/Feature/Site/HeathrowEndorsementProgressTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Site;
 
+use App\Models\Atc\Position;
 use App\Models\Atc\PositionGroup;
 use App\Models\Mship\Account;
 use App\Models\Mship\Account\Endorsement;
@@ -764,11 +765,12 @@ class HeathrowEndorsementProgressTest extends TestCase
         $account = $this->createAccountWithQualification('S2');
         $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
         $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createAfisPosition('EGFH_I_TWR');
         $s2Qual = Qualification::code('S2')->firstOrFail();
 
         factory(Atc::class)->create([
             'account_id' => $account->id,
-            'callsign' => 'EGKK_I_TWR',
+            'callsign' => 'EGFH_I_TWR',
             'minutes_online' => 9999,
             'facility_type' => Atc::TYPE_TWR,
             'qualification_id' => $s2Qual->id,
@@ -786,11 +788,12 @@ class HeathrowEndorsementProgressTest extends TestCase
         $account = $this->createAccountWithQualification('S2');
         $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
         $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createAfisPosition('EGFH_I__TWR');
         $s2Qual = Qualification::code('S2')->firstOrFail();
 
         factory(Atc::class)->create([
             'account_id' => $account->id,
-            'callsign' => 'EGKK_I__TWR',
+            'callsign' => 'EGFH_I__TWR',
             'minutes_online' => 9999,
             'facility_type' => Atc::TYPE_TWR,
             'qualification_id' => $s2Qual->id,
@@ -808,6 +811,7 @@ class HeathrowEndorsementProgressTest extends TestCase
         $account = $this->createAccountWithQualification('S2');
         $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
         $this->createEndorsement($account, $positionGroups['Heathrow (GND)']);
+        $this->createAfisPosition('EGKK_R_TWR');
         $s2Qual = Qualification::code('S2')->firstOrFail();
 
         factory(Atc::class)->create([
@@ -829,11 +833,12 @@ class HeathrowEndorsementProgressTest extends TestCase
     {
         $account = $this->createAccountWithQualification('S2');
         PositionGroup::factory()->create(['name' => 'Heathrow (GND)']);
+        $this->createAfisPosition('EGFH_I_TWR');
         $s2Qual = Qualification::code('S2')->firstOrFail();
 
         factory(Atc::class)->create([
             'account_id' => $account->id,
-            'callsign' => 'EGKK_I_TWR',
+            'callsign' => 'EGFH_I_TWR',
             'minutes_online' => 9999,
             'facility_type' => Atc::TYPE_TWR,
             'qualification_id' => $s2Qual->id,
@@ -875,6 +880,13 @@ class HeathrowEndorsementProgressTest extends TestCase
         }
 
         return $groups;
+    }
+
+    private function createAfisPosition(string $callsign): void
+    {
+        $afisGroup = PositionGroup::firstOrCreate(['name' => 'AFISO / AGO (S1)']);
+        $position = Position::factory()->create(['callsign' => $callsign]);
+        $afisGroup->positions()->attach($position);
     }
 
     private function createEndorsement(Account $account, PositionGroup $positionGroup): Endorsement


### PR DESCRIPTION
# Summary of changes
- Only show endorsement if you have the required qualification
- Exclude AFIS and military positions
- Ensure only hours post qualification are counted

# Screenshots (if necessary)
