### PR TITLE
fix: ensure last session takes into account the time of the session

### DIFF
--- a/app/Livewire/Training/AvailabilityGantt.php
+++ b/app/Livewire/Training/AvailabilityGantt.php
@@ -159,15 +159,15 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
                     ->whereNull('cancelled_datetime')
                     ->limit(1),
 
-                'last_session_date' => Session::select('taken_date')
+                'last_session_date' => Session::selectRaw("CONCAT(taken_date, ' ', COALESCE(taken_from, '00:00:00'))")
                     ->whereColumn('student_id', 'members.id')
                     ->whereNotNull('taken_date')
-                    ->where('taken_date', '<=', now())
                     ->whereNull('cancelled_datetime')
-                    ->latest('taken_date')
+                    ->orderBy('taken_date', 'desc')
+                    ->orderBy('taken_from', 'desc')
                     ->limit(1),
             ])
-            ->orderByRaw("COALESCE(last_session_date, '1970-01-01') ASC")
+            ->orderByRaw("COALESCE(last_session_date, '1970-01-01 00:00:00') ASC")
             ->get();
     }
 

--- a/resources/views/livewire/training/availability-gantt-desktop.blade.php
+++ b/resources/views/livewire/training/availability-gantt-desktop.blade.php
@@ -73,8 +73,18 @@
 						</div>
 
 						<div class="text-xs text-gray-300 dark:text-gray-400 mt-0.5">
-							Last Session:
-							{{ $student->last_session_date ? \Carbon\Carbon::parse($student->last_session_date)->diffForHumans(null, true) . ' ago' : 'Never' }}
+							@php
+								$sessionDate = $student->last_session_date ? \Carbon\Carbon::parse($student->last_session_date) : null;
+							@endphp
+							@if ($sessionDate)
+								@if ($sessionDate->isFuture())
+									Next Session: Starts in {{ $sessionDate->diffForHumans(null, true) }}
+								@else
+									Last Session: {{ $sessionDate->diffForHumans(null, true) }} ago
+								@endif
+							@else
+								Never
+							@endif
 						</div>
 					</div>
 

--- a/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
@@ -440,6 +440,7 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
             'mentor_id' => $this->mentorMember->id,
             'position' => 'EGLL_APP',
             'taken_date' => Carbon::yesterday()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
             'filed' => now(),
         ]);
 
@@ -448,6 +449,7 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
             'mentor_id' => $this->mentorMember->id,
             'position' => 'EGLL_APP',
             'taken_date' => Carbon::now()->subMonths(3)->format('Y-m-d'),
+            'taken_from' => '10:00:00',
             'filed' => now(),
         ]);
 
@@ -458,6 +460,107 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
 
         $this->assertTrue($students->first()->id === $olderStudent->id);
         $this->assertTrue($students->last()->id === $recentStudent->id);
+    }
+
+    #[Test]
+    public function last_session_date_shows_next_session_for_future_session(): void
+    {
+        Carbon::setTestNow(Carbon::today()->setTime(10, 0));
+
+        $student = Member::factory()->create();
+
+        Session::factory()->create([
+            'student_id' => $student->id,
+            'mentor_id' => null,
+            'position' => 'EGLL_APP',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Availability::factory()->create([
+            'student_id' => $student->id,
+            'date' => Carbon::today()->format('Y-m-d'),
+            'from' => '08:00:00',
+            'to' => '18:00:00',
+        ]);
+
+        Session::factory()->create([
+            'student_id' => $student->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken_date' => Carbon::today()->format('Y-m-d'),
+            'taken_from' => '14:00:00',
+            'filed' => now(),
+        ]);
+
+        Livewire::actingAs($this->mentor)
+            ->test(AvailabilityGantt::class)
+            ->assertSee('Next Session');
+
+        Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function last_session_date_shows_last_session_for_past_session(): void
+    {
+        Carbon::setTestNow(Carbon::today()->setTime(10, 0));
+
+        $student = Member::factory()->create();
+
+        Session::factory()->create([
+            'student_id' => $student->id,
+            'mentor_id' => null,
+            'position' => 'EGLL_APP',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Availability::factory()->create([
+            'student_id' => $student->id,
+            'date' => Carbon::today()->format('Y-m-d'),
+            'from' => '08:00:00',
+            'to' => '18:00:00',
+        ]);
+
+        Session::factory()->create([
+            'student_id' => $student->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken_date' => Carbon::today()->format('Y-m-d'),
+            'taken_from' => '08:00:00',
+            'filed' => now(),
+        ]);
+
+        Livewire::actingAs($this->mentor)
+            ->test(AvailabilityGantt::class)
+            ->assertSee('Last Session');
+
+        Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function last_session_date_shows_never_when_no_session_exists(): void
+    {
+        $student = Member::factory()->create();
+
+        Session::factory()->create([
+            'student_id' => $student->id,
+            'mentor_id' => null,
+            'position' => 'EGLL_APP',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Availability::factory()->create([
+            'student_id' => $student->id,
+            'date' => Carbon::today()->format('Y-m-d'),
+            'from' => '08:00:00',
+            'to' => '18:00:00',
+        ]);
+
+        Livewire::actingAs($this->mentor)
+            ->test(AvailabilityGantt::class)
+            ->assertSee('Never');
     }
 
     #[Test]


### PR DESCRIPTION
# Summary of changes
- Use time aswell to get an accurate time to last session
- Add handling for session booked in the future

# Screenshots (if necessary)
<img width="285" height="158" alt="image" src="https://github.com/user-attachments/assets/b5c935f4-daf8-4eef-849f-ca084f646777" />
<img width="307" height="160" alt="image" src="https://github.com/user-attachments/assets/6915f725-d270-4c57-bd15-c41d09e148aa" />
