### PR TITLE
feat: Waiting Lists: Toggle non-home members + Toggle ATC Rating badge

### DIFF
--- a/app/Filament/Training/Resources/WaitingLists/RelationManagers/AccountsRelationManager.php
+++ b/app/Filament/Training/Resources/WaitingLists/RelationManagers/AccountsRelationManager.php
@@ -108,11 +108,12 @@ class AccountsRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
-            ->modifyQueryUsing(fn (Builder $query) => $query->with(['account', 'account.roster', 'waitingList', 'flags']))
+            ->modifyQueryUsing(fn (Builder $query) => $query->with(['account', 'account.roster', 'account.qualifications', 'waitingList', 'flags']))
             ->columns([
                 TextColumn::make('position')->getStateUsing(fn (WaitingListAccount $record) => $this->ownerRecord->positionOf($record) ?? '-')->label('Position'),
                 TextColumn::make('account_id')->label('CID')->searchable(),
                 NameColumn::make('account.name')->label('Name'),
+                TextColumn::make('atc_rating')->label('ATC')->badge()->getStateUsing(fn (WaitingListAccount $record) => $record->account->qualification_atc?->code ?? 'Missing')->toggleable(isToggledHiddenByDefault: true),
                 IconColumn::make('on_roster')->boolean()->label('On Roster')->getStateUsing(fn (WaitingListAccount $record) => $record->account->onRoster())->visible(fn () => $this->ownerRecord->feature_toggles['display_on_roster'] ?? true),
                 TextColumn::make('created_at')->label('Added On')->dateTime('d/m/Y H:i:s'),
                 IconColumn::make('cts_theory_exam')->boolean()->label('CTS Theory Exam')->getStateUsing(fn (WaitingListAccount $record) => $record->theory_exam_passed)->visible(fn () => $this->ownerRecord->feature_toggles['check_cts_theory_exam'] ?? true),

--- a/app/Filament/Training/Resources/WaitingLists/WaitingListResource.php
+++ b/app/Filament/Training/Resources/WaitingLists/WaitingListResource.php
@@ -91,7 +91,14 @@ class WaitingListResource extends Resource
 
                         Toggle::make('feature_toggles.is_vt')
                             ->label('Visiting / Transfer List')
-                            ->default(false),
+                            ->default(false)
+                            ->live()
+                            ->afterStateUpdated(fn ($state, callable $set) => $set('home_members_only', ! $state)),
+
+                        Toggle::make('home_members_only')
+                            ->label('Home Members Only')
+                            ->helperText('If enabled, only members in the division can be on this waiting list.')
+                            ->default(true),
 
                         Toggle::make('retention_checks_enabled')
                             ->label('Enable Retention Checks')

--- a/app/Models/Training/WaitingList.php
+++ b/app/Models/Training/WaitingList.php
@@ -95,7 +95,7 @@ class WaitingList extends Model
 
     public $table = 'training_waiting_list';
 
-    protected $fillable = ['name', 'slug', 'department', 'feature_toggles', 'requires_roster_membership', 'self_enrolment_enabled', 'self_enrolment_minimum_qualification_id', 'self_enrolment_maximum_qualification_id', 'self_enrolment_hours_at_qualification_id', 'self_enrolment_hours_at_qualification_minimum_hours', 'max_capacity', 'retention_checks_enabled', 'retention_checks_months', 'required_endorsement_id'];
+    protected $fillable = ['name', 'slug', 'department', 'home_members_only', 'feature_toggles', 'requires_roster_membership', 'self_enrolment_enabled', 'self_enrolment_minimum_qualification_id', 'self_enrolment_maximum_qualification_id', 'self_enrolment_hours_at_qualification_id', 'self_enrolment_hours_at_qualification_minimum_hours', 'max_capacity', 'retention_checks_enabled', 'retention_checks_months', 'required_endorsement_id'];
 
     const ATC_DEPARTMENT = 'atc';
 


### PR DESCRIPTION
- Allow setting a waiting list to allow non-home members in the frontend.
- Adds a toggle to show the members ATC Rating (Small Qol for the Visiting List)