### PR TITLE
feat: Allow staff to edit an applications facility

### DIFF
--- a/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ViewVisitTransferApplication.php
+++ b/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ViewVisitTransferApplication.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources\VisitTransfer\VisitTransferApplications\P
 
 use App\Enums\VTCheckStatus;
 use App\Filament\Admin\Resources\VisitTransfer\VisitTransferApplications\VisitTransferApplicationResource;
+use App\Models\Mship\Note\Type;
 use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Checkbox;
@@ -147,7 +148,44 @@ class ViewVisitTransferApplication extends ViewRecord
                                     TextEntry::make('atc_rating')->label('ATC Rating')->getStateUsing(fn ($record) => ($record->account?->qualification_atc?->name_long ?? 'Unknown ATC')),
                                     TextEntry::make('pilot_rating')->label('Pilot Rating')->getStateUsing(fn ($record) => ($record->account?->qualification_pilot?->name_long ?? 'Unknown Pilot')),
                                     TextEntry::make('type_string')->label('Facility Type'),
-                                    TextEntry::make('facility.name')->label('Facility Name'),
+                                    TextEntry::make('facility.name')->label('Facility Name')->hintAction(Action::make('change_facility')
+                                        ->label('Edit')
+                                        ->icon('heroicon-m-pencil-square')
+                                        ->color('warning')
+                                        ->modalHeading(fn ($record) => "Change Facility for Application #{$record->public_id}")
+                                        ->modalDescription('This will change the facility for the application. It bypasses facility restrictions including rating requirements.')
+                                        ->schema([
+                                            Select::make('facility_id')
+                                                ->label('New Facility')
+                                                ->options(fn () => \App\Models\VisitTransfer\Facility::query()
+                                                    ->where('id', '!=', $application->facility_id)
+                                                    ->orderBy('name')
+                                                    ->pluck('name', 'id'))
+                                                ->searchable()
+                                                ->required(),
+                                            Textarea::make('staff_note')
+                                                ->label('Staff Note')
+                                                ->required(),
+                                        ])
+                                        ->action(function ($record, array $data) {
+                                            $newFacility = \App\Models\VisitTransfer\Facility::find($data['facility_id']);
+                                            if (! $newFacility) {
+                                                throw new \Exception('Selected facility not found.');
+                                            }
+
+                                            if ($newFacility->can_visit && ! $newFacility->can_transfer) {
+                                                $record->type = \App\Models\VisitTransfer\Application::TYPE_VISIT;
+                                            } elseif ($newFacility->can_transfer && ! $newFacility->can_visit) {
+                                                $record->type = \App\Models\VisitTransfer\Application::TYPE_TRANSFER;
+                                            }
+
+                                            $record->training_team = $newFacility->training_team;
+
+                                            $record->setFacility($newFacility, true);
+                                            $noteContent = "Application {$record->id} Facility changed to {$newFacility->name} by ".auth()->user()->id.'. Staff Note: '.$data['staff_note'];
+                                            $this->record->account->addNote(Type::isShortCode('visittransfer')->first(), $noteContent, auth()->user(), $this->record);
+                                        })
+                                        ->authorize(fn ($record) => auth()->user()->can('changeFacility', $record)), ),
                                     TextEntry::make('created_at')->label('Created At')->dateTime(),
                                     TextEntry::make('statement')->label('Statement')->columnSpan(2)->getStateUsing(fn ($record) => $record->statement ?? 'No statement provided'),
                                 ]),

--- a/app/Models/VisitTransfer/Application.php
+++ b/app/Models/VisitTransfer/Application.php
@@ -547,14 +547,16 @@ class Application extends Model
     }
 
     /** Business logic. */
-    public function setFacility(Facility $facility)
+    public function setFacility(Facility $facility, bool $overrideRestrictions = false)
     {
-        $this->guardAgainstTransferringToANonTrainingFacility($facility);
+        if (! $overrideRestrictions) {
+            $this->guardAgainstTransferringToANonTrainingFacility($facility);
 
-        $this->guardAgainstApplyingToAFacilityWithNoCapacity($facility);
+            $this->guardAgainstApplyingToAFacilityWithNoCapacity($facility);
 
-        if (! $this->meetsRatingRequirements($facility)) {
-            throw new RatingRequirementNotMetException($facility);
+            if (! $this->meetsRatingRequirements($facility)) {
+                throw new RatingRequirementNotMetException($facility);
+            }
         }
 
         $this->training_required = $facility->training_required;

--- a/app/Policies/VisitTransfer/ApplicationPolicy.php
+++ b/app/Policies/VisitTransfer/ApplicationPolicy.php
@@ -60,6 +60,11 @@ class ApplicationPolicy
         && (! $this->checkIsSatisfied($application->check_outcome_90_day) || ! $this->checkIsSatisfied($application->check_outcome_50_hours));
     }
 
+    public function changeFacility(Account $user, Application $application)
+    {
+        return $user->can('vt.application.modify.*') && ($application->can_accept || $application->can_reject || $application->can_complete || $application->can_cancel);
+    }
+
     public function create(Account $user, Application $application)
     {
         if ($user->hasState('DIVISION')) {

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -140,7 +140,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'vt.application.cancel.*',
             'vt.status.revoke',
             'vt.status.grant.manual',
-            // 'vt.application.check.modify.*',
+            'vt.application.modify.*',
 
             // Waiting List System Permissions,
             'waiting-lists.access',

--- a/tests/Feature/VisitTransfer/Application/ViewApplicationPageTest.php
+++ b/tests/Feature/VisitTransfer/Application/ViewApplicationPageTest.php
@@ -7,6 +7,7 @@ use App\Filament\Admin\Resources\VisitTransfer\VisitTransferApplications\Pages\V
 use App\Models\Mship\Account;
 use App\Models\VisitTransfer\Application;
 use App\Models\VisitTransfer\Facility;
+use Filament\Actions\Testing\TestAction;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Admin\BaseAdminTestCase;
@@ -345,5 +346,88 @@ class ViewApplicationPageTest extends BaseAdminTestCase
         $this->assertFalse($waitingList->includesAccount($application->account));
 
         $this->assertTrue($application->fresh()->is_cancelled);
+    }
+
+    #[Test]
+    public function it_can_change_facility_with_permission()
+    {
+        $this->adminUser->givePermissionTo('vt.application.modify.*');
+
+        $oldFacility = Facility::factory()->transfer('atc')->create();
+        $newFacility = Facility::factory()->transfer('atc')->create();
+
+        $this->application->update([
+            'facility_id' => $oldFacility->id,
+            'status' => Application::STATUS_UNDER_REVIEW,
+        ]);
+
+        $action = TestAction::make('change_facility')
+            ->schemaComponent('facility.name');
+
+        Livewire::actingAs($this->adminUser)
+            ->test(ViewVisitTransferApplication::class, [
+                'record' => $this->application->id,
+            ])
+            ->assertActionVisible($action)
+            ->callAction($action, data: [
+                'facility_id' => $newFacility->id,
+                'staff_note' => 'Changed facility during testing.',
+            ])
+            ->assertHasNoFormErrors();
+
+        $this->application->refresh();
+
+        $this->assertSame(
+            $newFacility->id,
+            $this->application->facility_id,
+        );
+
+        $this->assertSame(
+            $newFacility->training_team,
+            $this->application->getRawOriginal('training_team'),
+        );
+
+        $this->assertSame(
+            Application::TYPE_TRANSFER,
+            $this->application->type,
+        );
+    }
+
+    #[Test]
+    public function it_cannot_change_facility_without_permission()
+    {
+        $oldFacility = Facility::factory()
+            ->transfer('atc')
+            ->create();
+
+        $newFacility = Facility::factory()
+            ->transfer('atc')
+            ->create();
+
+        $this->application->update([
+            'facility_id' => $oldFacility->id,
+            'status' => Application::STATUS_UNDER_REVIEW,
+        ]);
+
+        $action = TestAction::make('change_facility')
+            ->schemaComponent('facility.name');
+
+        Livewire::actingAs($this->adminUser)
+            ->test(ViewVisitTransferApplication::class, [
+                'record' => $this->application->id,
+            ])
+            ->assertActionDoesNotExist($action);
+
+        $this->application->refresh();
+
+        $this->assertSame(
+            $oldFacility->id,
+            $this->application->facility_id,
+        );
+
+        $this->assertNotSame(
+            $newFacility->id,
+            $this->application->facility_id,
+        );
     }
 }


### PR DESCRIPTION
Per title, allows an authorised member to change a vt applications facility from, for example C1 Visit to C1 Transfer without the member needing to open a new application

<img width="604" height="453" alt="image" src="https://github.com/user-attachments/assets/cbe7e04a-cab7-4ad7-9457-2569e9cfbaca" />

<img width="901" height="468" alt="image" src="https://github.com/user-attachments/assets/d8a668ef-93b0-4d62-a73e-9e6aaa42e973" />

Will need the 'vt.application.modify.*' permission awarded once in prod