### PR TITLE
feat: add a roster history table to the accounts page

### DIFF
--- a/app/Filament/Admin/Resources/Accounts/AccountResource.php
+++ b/app/Filament/Admin/Resources/Accounts/AccountResource.php
@@ -14,6 +14,7 @@ use App\Filament\Admin\Resources\Accounts\RelationManagers\NotesRelationManager;
 use App\Filament\Admin\Resources\Accounts\RelationManagers\QualificationsRelationManager;
 use App\Filament\Admin\Resources\Accounts\RelationManagers\RetentionChecksRelationManager;
 use App\Filament\Admin\Resources\Accounts\RelationManagers\RolesRelationManager;
+use App\Filament\Admin\Resources\Accounts\RelationManagers\RosterHistoryRelationManager;
 use App\Filament\Admin\Resources\Accounts\RelationManagers\StatesRelationManager;
 use App\Filament\Admin\Resources\Accounts\RelationManagers\VisitTransferRelationManager;
 use App\Filament\Support\NameColumn;
@@ -202,6 +203,7 @@ class AccountResource extends Resource implements DefinesGatedAttributes
             EndorsementsRelationManager::class,
             WaitingListsRelationManager::class,
             RetentionChecksRelationManager::class,
+            RosterHistoryRelationManager::class,
             VisitTransferRelationManager::class,
         ];
     }

--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/RosterHistoryRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/RosterHistoryRelationManager.php
@@ -51,7 +51,7 @@ class RosterHistoryRelationManager extends RelationManager
                     })
                     ->placeholder('N/A'),
                 TextColumn::make('controlling_hours')
-                    ->label('Controlling Hours During')
+                    ->label('Hours Controlled')
                     ->getStateUsing(function ($record) {
                         $minutes = Atc::where('account_id', $record->account_id)
                             ->isUk()

--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/RosterHistoryRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/RosterHistoryRelationManager.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Accounts\RelationManagers;
+
+use App\Models\NetworkData\Atc;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class RosterHistoryRelationManager extends RelationManager
+{
+    protected static string $relationship = 'rosterHistory';
+
+    protected static ?string $recordTitleAttribute = 'id';
+
+    protected static ?string $title = 'Roster History';
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(function ($query) {
+                return $query->with(['removedBy', 'rosterUpdate']);
+            })
+            ->columns([
+                TextColumn::make('original_created_at')
+                    ->label('Joined')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->label('Removed')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('removedBy.name')
+                    ->label('Removed By')
+                    ->placeholder('N/A')
+                    ->description(fn ($record) => $record->removedBy?->id ?? null)
+                    ->sortable(),
+                TextColumn::make('rosterUpdate.period_start')
+                    ->label('Roster Update')
+                    ->getStateUsing(function ($record) {
+                        if ($record->rosterUpdate) {
+                            return $record->rosterUpdate->period_start->format('d M Y').' - '.$record->rosterUpdate->period_end->format('d M Y');
+                        }
+
+                        return null;
+                    })
+                    ->placeholder('N/A'),
+                TextColumn::make('controlling_hours')
+                    ->label('Controlling Hours During')
+                    ->getStateUsing(function ($record) {
+                        $minutes = Atc::where('account_id', $record->account_id)
+                            ->isUk()
+                            ->whereBetween('connected_at', [$record->original_created_at, $record->created_at])
+                            ->sum('minutes_online');
+
+                        if (! $minutes) {
+                            return null;
+                        }
+
+                        $hours = intdiv($minutes, 60);
+                        $remainingMinutes = $minutes % 60;
+
+                        if ($hours > 0) {
+                            return $hours.'h '.$remainingMinutes.'m';
+                        }
+
+                        return $remainingMinutes.'m';
+                    }),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+}

--- a/app/Models/Mship/Account.php
+++ b/app/Models/Mship/Account.php
@@ -29,6 +29,7 @@ use App\Models\Mship\Concerns\HasVisitTransferApplications;
 use App\Models\Mship\Concerns\HasWaitingLists;
 use App\Models\Mship\Note\Type;
 use App\Models\Roster;
+use App\Models\RosterHistory;
 use App\Models\Training\WaitingList\WaitingListAccount;
 use App\Models\Training\WaitingList\WaitingListRetentionCheck;
 use Illuminate\Auth\Authenticatable;
@@ -38,6 +39,7 @@ use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes as SoftDeletingTrait;
@@ -428,6 +430,11 @@ class Account extends Model implements AuthenticatableContract, AuthorizableCont
     public function roster(): HasOne
     {
         return $this->hasOne(Roster::class, 'account_id', 'id');
+    }
+
+    public function rosterHistory(): HasMany
+    {
+        return $this->hasMany(RosterHistory::class, 'account_id');
     }
 
     public function onRoster(): bool

--- a/app/Models/RosterHistory.php
+++ b/app/Models/RosterHistory.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use App\Models\Mship\Account;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class RosterHistory extends Model
 {
@@ -12,4 +14,28 @@ class RosterHistory extends Model
     protected $table = 'roster_history';
 
     protected $fillable = ['account_id', 'original_created_at', 'original_updated_at', 'removed_by', 'roster_update_id'];
+
+    protected function casts(): array
+    {
+        return [
+            'original_created_at' => 'datetime',
+            'original_updated_at' => 'datetime',
+            'roster_update_id' => 'integer',
+        ];
+    }
+
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'account_id');
+    }
+
+    public function removedBy(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'removed_by');
+    }
+
+    public function rosterUpdate(): BelongsTo
+    {
+        return $this->belongsTo(RosterUpdate::class, 'roster_update_id');
+    }
 }

--- a/app/Models/RosterUpdate.php
+++ b/app/Models/RosterUpdate.php
@@ -11,6 +11,8 @@ class RosterUpdate extends Model
     protected $fillable = ['period_start', 'period_end', 'data'];
 
     protected $casts = [
+        'period_start' => 'datetime',
+        'period_end' => 'datetime',
         'data' => 'json',
     ];
 }

--- a/tests/Feature/Admin/Account/RelationManagers/RosterHistoryRelationManagerTest.php
+++ b/tests/Feature/Admin/Account/RelationManagers/RosterHistoryRelationManagerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature\Admin\Account\RelationManagers;
+
+use App\Filament\Admin\Resources\Accounts\RelationManagers\RosterHistoryRelationManager;
+use App\Models\Mship\Account;
+use App\Models\NetworkData\Atc;
+use App\Models\RosterHistory;
+use App\Models\RosterUpdate;
+use Carbon\Carbon;
+use Filament\Resources\Pages\ViewRecord;
+use Livewire\Livewire;
+use Tests\Feature\Admin\BaseAdminTestCase;
+
+class RosterHistoryRelationManagerTest extends BaseAdminTestCase
+{
+    private Account $account;
+
+    private Account $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->account = Account::factory()->create();
+        $this->admin = Account::factory()->create();
+    }
+
+    public function test_it_renders()
+    {
+        $this->actingAsSuperUser();
+
+        Livewire::test(RosterHistoryRelationManager::class, [
+            'ownerRecord' => $this->account,
+            'pageClass' => ViewRecord::class,
+        ])
+            ->assertSuccessful();
+    }
+
+    public function test_it_displays_roster_history_records()
+    {
+        $this->actingAsSuperUser();
+
+        $history = RosterHistory::create([
+            'account_id' => $this->account->id,
+            'original_created_at' => Carbon::parse('2024-01-15 10:00:00'),
+            'original_updated_at' => Carbon::parse('2024-06-01 12:00:00'),
+            'removed_by' => $this->admin->id,
+            'created_at' => Carbon::parse('2024-12-20 14:00:00'),
+        ]);
+
+        Livewire::test(RosterHistoryRelationManager::class, [
+            'ownerRecord' => $this->account,
+            'pageClass' => ViewRecord::class,
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$history]);
+    }
+
+    public function test_it_displays_controlling_hours()
+    {
+        $this->actingAsSuperUser();
+
+        $history = RosterHistory::create([
+            'account_id' => $this->account->id,
+            'original_created_at' => Carbon::parse('2024-01-01 00:00:00'),
+            'original_updated_at' => Carbon::parse('2024-01-01 00:00:00'),
+            'removed_by' => null,
+            'created_at' => Carbon::parse('2024-12-31 23:59:59'),
+        ]);
+
+        Atc::create([
+            'account_id' => $this->account->id,
+            'callsign' => 'EGLL_N_APP',
+            'connected_at' => Carbon::parse('2024-06-01 10:00:00'),
+            'disconnected_at' => Carbon::parse('2024-06-01 12:30:00'),
+            'minutes_online' => 150,
+            'qualification_id' => 1,
+        ]);
+
+        Livewire::test(RosterHistoryRelationManager::class, [
+            'ownerRecord' => $this->account,
+            'pageClass' => ViewRecord::class,
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$history]);
+    }
+
+    public function test_it_excludes_sessions_outside_roster_period()
+    {
+        $this->actingAsSuperUser();
+
+        $history = RosterHistory::create([
+            'account_id' => $this->account->id,
+            'original_created_at' => Carbon::parse('2024-06-01 00:00:00'),
+            'original_updated_at' => Carbon::parse('2024-06-01 00:00:00'),
+            'removed_by' => null,
+            'created_at' => Carbon::parse('2024-08-01 00:00:00'),
+        ]);
+
+        Atc::create([
+            'account_id' => $this->account->id,
+            'callsign' => 'EGLL_N_APP',
+            'connected_at' => Carbon::parse('2024-09-01 10:00:00'),
+            'disconnected_at' => Carbon::parse('2024-09-01 11:00:00'),
+            'minutes_online' => 60,
+            'qualification_id' => 1,
+        ]);
+
+        Livewire::test(RosterHistoryRelationManager::class, [
+            'ownerRecord' => $this->account,
+            'pageClass' => ViewRecord::class,
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$history]);
+    }
+
+    public function test_it_displays_roster_update_period()
+    {
+        $this->actingAsSuperUser();
+
+        $rosterUpdate = RosterUpdate::create([
+            'period_start' => Carbon::parse('2024-12-15'),
+            'period_end' => Carbon::parse('2024-12-22'),
+            'data' => ['test' => true],
+        ]);
+
+        $history = RosterHistory::create([
+            'account_id' => $this->account->id,
+            'original_created_at' => Carbon::parse('2024-01-15 10:00:00'),
+            'original_updated_at' => Carbon::parse('2024-06-01 12:00:00'),
+            'removed_by' => $this->admin->id,
+            'roster_update_id' => $rosterUpdate->id,
+            'created_at' => Carbon::parse('2024-12-20 14:00:00'),
+        ]);
+
+        Livewire::test(RosterHistoryRelationManager::class, [
+            'ownerRecord' => $this->account,
+            'pageClass' => ViewRecord::class,
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$history]);
+    }
+}


### PR DESCRIPTION
# Summary of changes
- Stops me having to go into the DB to check peoples history on the roster

# Screenshots (if necessary)
<img width="1416" height="654" alt="image" src="https://github.com/user-attachments/assets/bb929ced-e5fb-425f-a463-f99b16cc4f53" />
