### PR TITLE
fix: stop users always being able to reactivate on the roster

### DIFF
--- a/app/Livewire/Roster/Renew.php
+++ b/app/Livewire/Roster/Renew.php
@@ -49,7 +49,7 @@ class Renew extends Component
     {
         $lastLogon = AtcNetworkdataService::getLatestNetworkdataForAccount(auth()->user())?->disconnected_at;
 
-        return $lastLogon && Carbon::now()->diffInMonths($lastLogon) <= 18;
+        return $lastLogon && $lastLogon->diffInMonths(Carbon::now()) <= 18;
     }
 
     public function render(UKCP $ukcp)

--- a/tests/Feature/Roster/RenewTest.php
+++ b/tests/Feature/Roster/RenewTest.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace Tests\Feature\Roster;
+
+use App\Libraries\UKCP;
+use App\Livewire\Roster\Renew;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use App\Models\Mship\State;
+use App\Models\NetworkData\Atc;
+use App\Models\Roster;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class RenewTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function createEligibleAccount(): Account
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+        $account->addQualification(Qualification::code('S2')->first());
+
+        return $account;
+    }
+
+    private function createAtcSession(Account $account, Carbon $disconnectedAt): Atc
+    {
+        return Atc::create([
+            'account_id' => $account->id,
+            'callsign' => 'EGLL_TWR',
+            'connected_at' => $disconnectedAt->copy()->subMinutes(30),
+            'disconnected_at' => $disconnectedAt,
+            'qualification_id' => 1,
+            'facility_type' => 4,
+        ]);
+    }
+
+    public function test_redirects_when_already_on_roster()
+    {
+        $account = $this->createEligibleAccount();
+        Roster::create(['account_id' => $account->id]);
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertRedirect(route('site.roster.index'));
+    }
+
+    public function test_redirects_when_not_division_state()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('VISITING'));
+        $account->addQualification(Qualification::code('S2')->first());
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertRedirect(route('site.roster.index'));
+    }
+
+    public function test_redirects_when_no_controller_rating()
+    {
+        $account = Account::factory()->create();
+        $account->addState(State::findByCode('DIVISION'));
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertRedirect(route('site.roster.index'));
+    }
+
+    public function test_mounts_with_page_one()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertSet('page', 1);
+    }
+
+    public function test_cannot_proceed_without_recent_connection()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, Carbon::now()->subMonths(19));
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->call('nextPage')
+            ->assertForbidden();
+    }
+
+    public function test_cannot_proceed_with_no_connection_history()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->call('nextPage')
+            ->assertForbidden();
+    }
+
+    public function test_can_proceed_with_recent_connection()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, Carbon::now()->subMonths(6));
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->call('nextPage')
+            ->assertSet('page', 2);
+    }
+
+    public function test_can_proceed_when_within_18_month_window()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, Carbon::now()->subMonths(18)->addDay());
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->call('nextPage')
+            ->assertSet('page', 2);
+    }
+
+    public function test_cannot_reactivate_without_recent_connection()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->call('reactivate')
+            ->assertForbidden();
+    }
+
+    public function test_reactivate_creates_roster_record()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, Carbon::now()->subMonths(6));
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->call('nextPage')
+            ->call('reactivate')
+            ->assertRedirect(route('site.roster.index'));
+
+        $this->assertDatabaseHas('roster', ['account_id' => $account->id]);
+    }
+
+    public function test_shows_cannot_reactivate_message_when_connection_too_old()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, Carbon::now()->subMonths(19));
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertSee('cannot automatically reactivate');
+    }
+
+    public function test_shows_last_logon_on_first_page()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, Carbon::now()->subMonths(6));
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertSee('last controlling session was');
+    }
+
+    public function test_shows_notification_count()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([
+                ['id' => 1, 'title' => 'Change 1', 'body' => 'Body 1', 'link' => null],
+            ]);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertSee('You have 1 notifications to read.');
+    }
+
+    public function test_mark_notification_read_removes_notification()
+    {
+        $account = $this->createEligibleAccount();
+
+        $ukcp = $this->mock(UKCP::class);
+        $ukcp->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([
+                ['id' => 1, 'title' => 'Change 1', 'body' => 'Body 1', 'link' => null],
+            ]);
+        $ukcp->shouldReceive('markNotificationReadForUser')
+            ->with(\Mockery::type(Account::class), 1)
+            ->andReturn(true);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertSee('You have 1 notifications to read.')
+            ->call('markNotificationRead', 1, 1)
+            ->assertSee('You have 0 notifications to read.');
+    }
+
+    public function test_mark_notification_read_failure_retains_notification()
+    {
+        $account = $this->createEligibleAccount();
+
+        $ukcp = $this->mock(UKCP::class);
+        $ukcp->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([
+                ['id' => 1, 'title' => 'Change 1', 'body' => 'Body 1', 'link' => null],
+            ]);
+        $ukcp->shouldReceive('markNotificationReadForUser')
+            ->with(\Mockery::type(Account::class), 1)
+            ->andReturn(false);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertSee('You have 1 notifications to read.')
+            ->call('markNotificationRead', 1, 1)
+            ->assertSee('You have 1 notifications to read.');
+    }
+
+    public function test_shows_page_two_after_proceeding()
+    {
+        $account = $this->createEligibleAccount();
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, Carbon::now()->subMonths(6));
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->call('nextPage')
+            ->assertSee('Reactivate')
+            ->assertSee('Add to roster');
+    }
+}

--- a/tests/Feature/Roster/RenewTest.php
+++ b/tests/Feature/Roster/RenewTest.php
@@ -223,6 +223,7 @@ class RenewTest extends TestCase
     public function test_shows_notification_count()
     {
         $account = $this->createEligibleAccount();
+        $this->createAtcSession($account, Carbon::now()->subMonths(6));
 
         $this->mock(UKCP::class)
             ->shouldReceive('getUnreadNotificationsForUser')
@@ -238,6 +239,7 @@ class RenewTest extends TestCase
     public function test_mark_notification_read_removes_notification()
     {
         $account = $this->createEligibleAccount();
+        $this->createAtcSession($account, Carbon::now()->subMonths(6));
 
         $ukcp = $this->mock(UKCP::class);
         $ukcp->shouldReceive('getUnreadNotificationsForUser')
@@ -258,6 +260,7 @@ class RenewTest extends TestCase
     public function test_mark_notification_read_failure_retains_notification()
     {
         $account = $this->createEligibleAccount();
+        $this->createAtcSession($account, Carbon::now()->subMonths(6));
 
         $ukcp = $this->mock(UKCP::class);
         $ukcp->shouldReceive('getUnreadNotificationsForUser')
@@ -289,6 +292,6 @@ class RenewTest extends TestCase
             ->test(Renew::class)
             ->call('nextPage')
             ->assertSee('Reactivate')
-            ->assertSee('Add to roster');
+            ->assertSee('Add to');
     }
 }


### PR DESCRIPTION
# Summary of changes
`Carbon::now()->diffInMonths($lastLogon) <= 18` always returns true as it returns a negative number. Use `$lastLogon->diffInMonths(Carbon::now()) <= 18` instead

# Screenshots (if necessary)
