### PR TITLE
feat: circumstantially inhibit manual roster re-activation

### DIFF
--- a/app/Livewire/Roster/Renew.php
+++ b/app/Livewire/Roster/Renew.php
@@ -70,10 +70,10 @@ class Renew extends Component
         $now = Carbon::now();
         $currentQuarterStart = $now->copy()->startOfQuarter();
 
-        $q1End = $currentQuarterStart->copy()->subDay();
+        $q1End = $currentQuarterStart->copy()->subDay()->endOfDay();
         $q1Start = $currentQuarterStart->copy()->subMonths(3);
 
-        $q2End = $q1Start->copy()->subDay();
+        $q2End = $q1Start->copy()->subDay()->endOfDay();
         $q2Start = $q1Start->copy()->subMonths(3);
 
         $q1Hours = $this->getQuarterlyHours($q1Start, $q1End);

--- a/app/Livewire/Roster/Renew.php
+++ b/app/Livewire/Roster/Renew.php
@@ -3,7 +3,9 @@
 namespace App\Livewire\Roster;
 
 use App\Libraries\UKCP;
+use App\Models\NetworkData\Atc;
 use App\Models\Roster;
+use App\Models\RosterHistory;
 use App\Services\Networkdata\AtcNetworkdataService;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -47,21 +49,60 @@ class Renew extends Component
 
     private function canReactivate(): bool
     {
-        $lastLogon = AtcNetworkdataService::getLatestNetworkdataForAccount(auth()->user())?->disconnected_at;
+        $account = auth()->user();
+        $lastLogon = AtcNetworkdataService::getLatestNetworkdataForAccount($account)?->disconnected_at;
 
-        return $lastLogon && $lastLogon->diffInMonths(Carbon::now()) <= 18;
+        // Check if the account has had a connection in the last 18 months
+        if (! $lastLogon || $lastLogon->diffInMonths(Carbon::now()) > 18) {
+            return false;
+        }
+
+        if (RosterHistory::where('account_id', $account->id)->exists()) {
+            return $this->hasMetHoursInLastTwoQuarters();
+        }
+
+        return true;
+    }
+
+    private function hasMetHoursInLastTwoQuarters(): bool
+    {
+        // The account must have met the minimum controlling hours in one of the last 2 consectutive quarters
+        $now = Carbon::now();
+        $currentQuarterStart = $now->copy()->startOfQuarter();
+
+        $q1End = $currentQuarterStart->copy()->subDay();
+        $q1Start = $currentQuarterStart->copy()->subMonths(3);
+
+        $q2End = $q1Start->copy()->subDay();
+        $q2Start = $q1Start->copy()->subMonths(3);
+
+        $q1Hours = $this->getQuarterlyHours($q1Start, $q1End);
+        $q2Hours = $this->getQuarterlyHours($q2Start, $q2End);
+
+        return $q1Hours >= 3 || $q2Hours >= 3;
+    }
+
+    private function getQuarterlyHours(Carbon $start, Carbon $end): float
+    {
+        return Atc::where('account_id', auth()->user()->id)
+            ->isUK()
+            ->whereBetween('disconnected_at', [$start, $end])
+            ->sum('minutes_online') / 60;
     }
 
     public function render(UKCP $ukcp)
     {
+        $account = auth()->user();
         $canReactivate = $this->canReactivate();
-        $lastLogon = $canReactivate ? AtcNetworkdataService::getLatestNetworkdataForAccount(auth()->user())->disconnected_at : null;
+        $lastLogon = $canReactivate ? AtcNetworkdataService::getLatestNetworkdataForAccount($account)->disconnected_at : null;
+        $lastTwoQuartersFailed = ! $this->hasMetHoursInLastTwoQuarters();
 
         return view('livewire.roster.renew', [
             'notifications' => $this->notifications,
             'canReactivate' => $canReactivate,
             'lastLogon' => $lastLogon?->diffForHumans(),
             'page' => $this->page,
+            'lastTwoQuartersFailed' => $lastTwoQuartersFailed,
         ]);
     }
 

--- a/resources/views/livewire/roster/renew.blade.php
+++ b/resources/views/livewire/roster/renew.blade.php
@@ -6,13 +6,20 @@
 				<div>
 					<span class="text-2xl font-bold">👋 Hello, {{ auth()->user()->name_first }}!</span>
 				</div>
-				@if (!$canReactivate)
+			@if (!$canReactivate)
+				@if ($lastTwoQuartersFailed)
+					<span>You have not met the minimum controlling requirements in the last two consecutive
+						quarters and cannot automatically reactivate your roster membership.
+						<br>
+						Please <a class="text-blue-500 hover:cursor-pointer" href="mailto:atc-training@vatsim.uk">contact ATC Training</a>.
+					</span>
+				@else
 					<span>As it has been 18 months since your last ATC session you cannot automatically reactivate your
 						roster membership.
 						<br>
-						Please <a class="text-blue-500 hover:cursor-pointer" href="mailto:atc-training@vatsim.uk">contact
-							ATC Training</a>.
+						Please <a class="text-blue-500 hover:cursor-pointer" href="mailto:atc-training@vatsim.uk">contact ATC Training</a>.
 					</span>
+				@endif
 				@else
 					<p>It has been a while! Our records show that your last controlling session was {{ $lastLogon }}.
 					</p>

--- a/resources/views/livewire/roster/renew.blade.php
+++ b/resources/views/livewire/roster/renew.blade.php
@@ -6,20 +6,20 @@
 				<div>
 					<span class="text-2xl font-bold">👋 Hello, {{ auth()->user()->name_first }}!</span>
 				</div>
-			@if (!$canReactivate)
-				@if ($lastTwoQuartersFailed)
-					<span>You have not met the minimum controlling requirements in the last two consecutive
-						quarters and cannot automatically reactivate your roster membership.
-						<br>
-						Please <a class="text-blue-500 hover:cursor-pointer" href="mailto:atc-training@vatsim.uk">contact ATC Training</a>.
-					</span>
-				@else
-					<span>As it has been 18 months since your last ATC session you cannot automatically reactivate your
-						roster membership.
-						<br>
-						Please <a class="text-blue-500 hover:cursor-pointer" href="mailto:atc-training@vatsim.uk">contact ATC Training</a>.
-					</span>
-				@endif
+				@if (!$canReactivate)
+					@if ($lastTwoQuartersFailed)
+						<span>You have not met the minimum controlling requirements in the last two consecutive
+							quarters and cannot automatically reactivate your roster membership.
+							<br>
+							Please <a class="text-blue-500 hover:cursor-pointer" href="mailto:atc-training@vatsim.uk">contact ATC Training</a>.
+						</span>
+					@else
+						<span>As it has been 18 months since your last ATC session you cannot automatically reactivate your
+							roster membership.
+							<br>
+							Please <a class="text-blue-500 hover:cursor-pointer" href="mailto:atc-training@vatsim.uk">contact ATC Training</a>.
+						</span>
+					@endif
 				@else
 					<p>It has been a while! Our records show that your last controlling session was {{ $lastLogon }}.
 					</p>

--- a/tests/Feature/Roster/RenewTest.php
+++ b/tests/Feature/Roster/RenewTest.php
@@ -30,15 +30,19 @@ class RenewTest extends TestCase
 
     private function createAtcSession(Account $account, Carbon $disconnectedAt, int $minutesDuration = 30): Atc
     {
-        return Atc::create([
+        $atc = Atc::create([
             'account_id' => $account->id,
             'callsign' => 'EGLL_TWR',
             'connected_at' => $disconnectedAt->copy()->subMinutes($minutesDuration),
             'disconnected_at' => $disconnectedAt,
             'qualification_id' => 1,
             'facility_type' => 4,
-            'minutes_online' => $minutesDuration,
         ]);
+
+        $atc->minutes_online = $minutesDuration;
+        $atc->save();
+
+        return $atc;
     }
 
     public function test_redirects_when_already_on_roster()

--- a/tests/Feature/Roster/RenewTest.php
+++ b/tests/Feature/Roster/RenewTest.php
@@ -207,13 +207,12 @@ class RenewTest extends TestCase
             'account_id' => $account->id,
             'original_created_at' => Carbon::now()->subMonths(12),
             'original_updated_at' => Carbon::now()->subMonths(12),
-            'created_at' => Carbon::now()->subMonths(9),
         ]);
 
         $currentQuarterStart = Carbon::now()->copy()->startOfQuarter();
         $lastQuarterStart = $currentQuarterStart->copy()->subMonths(3);
 
-        $sessionTime = $lastQuarterStart->copy()->addDays(15);
+        $sessionTime = $lastQuarterStart->copy()->addWeeks(4)->addHours(12);
 
         $this->mock(UKCP::class)
             ->shouldReceive('getUnreadNotificationsForUser')
@@ -235,13 +234,11 @@ class RenewTest extends TestCase
             'account_id' => $account->id,
             'original_created_at' => Carbon::now()->subMonths(12),
             'original_updated_at' => Carbon::now()->subMonths(12),
-            'created_at' => Carbon::now()->subMonths(9),
         ]);
 
         $currentQuarterStart = Carbon::now()->copy()->startOfQuarter();
-        $q2Start = $currentQuarterStart->copy()->subMonths(6);
 
-        $sessionTime = $q2Start->copy()->addDays(15);
+        $sessionTime = $currentQuarterStart->copy()->subMonths(5)->addWeeks(2)->addHours(12);
 
         $this->mock(UKCP::class)
             ->shouldReceive('getUnreadNotificationsForUser')

--- a/tests/Feature/Roster/RenewTest.php
+++ b/tests/Feature/Roster/RenewTest.php
@@ -9,6 +9,7 @@ use App\Models\Mship\Qualification;
 use App\Models\Mship\State;
 use App\Models\NetworkData\Atc;
 use App\Models\Roster;
+use App\Models\RosterHistory;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Livewire\Livewire;
@@ -27,15 +28,16 @@ class RenewTest extends TestCase
         return $account;
     }
 
-    private function createAtcSession(Account $account, Carbon $disconnectedAt): Atc
+    private function createAtcSession(Account $account, Carbon $disconnectedAt, int $minutesDuration = 30): Atc
     {
         return Atc::create([
             'account_id' => $account->id,
             'callsign' => 'EGLL_TWR',
-            'connected_at' => $disconnectedAt->copy()->subMinutes(30),
+            'connected_at' => $disconnectedAt->copy()->subMinutes($minutesDuration),
             'disconnected_at' => $disconnectedAt,
             'qualification_id' => 1,
             'facility_type' => 4,
+            'minutes_online' => $minutesDuration,
         ]);
     }
 
@@ -95,22 +97,6 @@ class RenewTest extends TestCase
             ->assertSet('page', 1);
     }
 
-    public function test_cannot_proceed_without_recent_connection()
-    {
-        $account = $this->createEligibleAccount();
-
-        $this->mock(UKCP::class)
-            ->shouldReceive('getUnreadNotificationsForUser')
-            ->andReturn([]);
-
-        $this->createAtcSession($account, Carbon::now()->subMonths(19));
-
-        Livewire::actingAs($account)
-            ->test(Renew::class)
-            ->call('nextPage')
-            ->assertForbidden();
-    }
-
     public function test_cannot_proceed_with_no_connection_history()
     {
         $account = $this->createEligibleAccount();
@@ -122,52 +108,6 @@ class RenewTest extends TestCase
         Livewire::actingAs($account)
             ->test(Renew::class)
             ->call('nextPage')
-            ->assertForbidden();
-    }
-
-    public function test_can_proceed_with_recent_connection()
-    {
-        $account = $this->createEligibleAccount();
-
-        $this->mock(UKCP::class)
-            ->shouldReceive('getUnreadNotificationsForUser')
-            ->andReturn([]);
-
-        $this->createAtcSession($account, Carbon::now()->subMonths(6));
-
-        Livewire::actingAs($account)
-            ->test(Renew::class)
-            ->call('nextPage')
-            ->assertSet('page', 2);
-    }
-
-    public function test_can_proceed_when_within_18_month_window()
-    {
-        $account = $this->createEligibleAccount();
-
-        $this->mock(UKCP::class)
-            ->shouldReceive('getUnreadNotificationsForUser')
-            ->andReturn([]);
-
-        $this->createAtcSession($account, Carbon::now()->subMonths(18)->addDay());
-
-        Livewire::actingAs($account)
-            ->test(Renew::class)
-            ->call('nextPage')
-            ->assertSet('page', 2);
-    }
-
-    public function test_cannot_reactivate_without_recent_connection()
-    {
-        $account = $this->createEligibleAccount();
-
-        $this->mock(UKCP::class)
-            ->shouldReceive('getUnreadNotificationsForUser')
-            ->andReturn([]);
-
-        Livewire::actingAs($account)
-            ->test(Renew::class)
-            ->call('reactivate')
             ->assertForbidden();
     }
 
@@ -236,49 +176,108 @@ class RenewTest extends TestCase
             ->assertSee('You have 1 notifications to read.');
     }
 
-    public function test_mark_notification_read_removes_notification()
+    public function test_cannot_proceed_when_previous_removal_and_no_hours_in_last_two_quarters()
     {
         $account = $this->createEligibleAccount();
-        $this->createAtcSession($account, Carbon::now()->subMonths(6));
 
-        $ukcp = $this->mock(UKCP::class);
-        $ukcp->shouldReceive('getUnreadNotificationsForUser')
-            ->andReturn([
-                ['id' => 1, 'title' => 'Change 1', 'body' => 'Body 1', 'link' => null],
-            ]);
-        $ukcp->shouldReceive('markNotificationReadForUser')
-            ->with(\Mockery::type(Account::class), 1)
-            ->andReturn(true);
+        RosterHistory::create([
+            'account_id' => $account->id,
+            'original_created_at' => Carbon::now()->subMonths(12),
+            'original_updated_at' => Carbon::now()->subMonths(12),
+            'created_at' => Carbon::now()->subMonths(9),
+        ]);
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, Carbon::now()->subMonths(15));
 
         Livewire::actingAs($account)
             ->test(Renew::class)
-            ->assertSee('You have 1 notifications to read.')
-            ->call('markNotificationRead', 1, 1)
-            ->assertSee('You have 0 notifications to read.');
+            ->call('nextPage')
+            ->assertForbidden();
     }
 
-    public function test_mark_notification_read_failure_retains_notification()
+    public function test_can_proceed_when_previous_removal_and_met_hours_in_last_quarter()
     {
         $account = $this->createEligibleAccount();
-        $this->createAtcSession($account, Carbon::now()->subMonths(6));
 
-        $ukcp = $this->mock(UKCP::class);
-        $ukcp->shouldReceive('getUnreadNotificationsForUser')
-            ->andReturn([
-                ['id' => 1, 'title' => 'Change 1', 'body' => 'Body 1', 'link' => null],
-            ]);
-        $ukcp->shouldReceive('markNotificationReadForUser')
-            ->with(\Mockery::type(Account::class), 1)
-            ->andReturn(false);
+        RosterHistory::create([
+            'account_id' => $account->id,
+            'original_created_at' => Carbon::now()->subMonths(12),
+            'original_updated_at' => Carbon::now()->subMonths(12),
+            'created_at' => Carbon::now()->subMonths(9),
+        ]);
+
+        $currentQuarterStart = Carbon::now()->copy()->startOfQuarter();
+        $lastQuarterStart = $currentQuarterStart->copy()->subMonths(3);
+
+        $sessionTime = $lastQuarterStart->copy()->addDays(15);
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, $sessionTime, 180);
 
         Livewire::actingAs($account)
             ->test(Renew::class)
-            ->assertSee('You have 1 notifications to read.')
-            ->call('markNotificationRead', 1, 1)
-            ->assertSee('You have 1 notifications to read.');
+            ->call('nextPage')
+            ->assertSet('page', 2);
     }
 
-    public function test_shows_page_two_after_proceeding()
+    public function test_can_proceed_when_previous_removal_and_met_hours_in_prior_quarter_only()
+    {
+        $account = $this->createEligibleAccount();
+
+        RosterHistory::create([
+            'account_id' => $account->id,
+            'original_created_at' => Carbon::now()->subMonths(12),
+            'original_updated_at' => Carbon::now()->subMonths(12),
+            'created_at' => Carbon::now()->subMonths(9),
+        ]);
+
+        $currentQuarterStart = Carbon::now()->copy()->startOfQuarter();
+        $q2Start = $currentQuarterStart->copy()->subMonths(6);
+
+        $sessionTime = $q2Start->copy()->addDays(15);
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, $sessionTime, 180);
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->call('nextPage')
+            ->assertSet('page', 2);
+    }
+
+    public function test_shows_quarter_failure_message_when_no_hours_in_last_two_quarters()
+    {
+        $account = $this->createEligibleAccount();
+
+        RosterHistory::create([
+            'account_id' => $account->id,
+            'original_created_at' => Carbon::now()->subMonths(12),
+            'original_updated_at' => Carbon::now()->subMonths(12),
+            'created_at' => Carbon::now()->subMonths(9),
+        ]);
+
+        $this->mock(UKCP::class)
+            ->shouldReceive('getUnreadNotificationsForUser')
+            ->andReturn([]);
+
+        $this->createAtcSession($account, Carbon::now()->subMonths(15));
+
+        Livewire::actingAs($account)
+            ->test(Renew::class)
+            ->assertSee('minimum controlling requirements');
+    }
+
+    public function test_first_time_joiner_not_blocked_by_quarter_check()
     {
         $account = $this->createEligibleAccount();
 
@@ -291,7 +290,6 @@ class RenewTest extends TestCase
         Livewire::actingAs($account)
             ->test(Renew::class)
             ->call('nextPage')
-            ->assertSee('Reactivate')
-            ->assertSee('Add to');
+            ->assertSet('page', 2);
     }
 }


### PR DESCRIPTION
# Summary of changes
- To reactivate on the roster you must now:
  - Have controlled within the last 18 months
  - Have met the 3 hours controlling requirements in one of the previous two quarters

# Screenshots (if necessary)
<img width="746" height="410" alt="image" src="https://github.com/user-attachments/assets/e704513b-86bd-4fda-898f-b52efb0e4d2f" />
