### PR TITLE
fix: allow tables to be shown on mentoring reports

### DIFF
--- a/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
+++ b/app/Filament/Training/Concerns/InteractsWithCtsRichEditorNotes.php
@@ -154,7 +154,7 @@ trait InteractsWithCtsRichEditorNotes
 
     protected function ctsAllowedNotesHtmlTags(): string
     {
-        return '<p><br><h1><h2><h3><h4><h5><h6><strong><b><em><i><u><s><ul><ol><li><a><span><pre><code>';
+        return '<p><br><h1><h2><h3><h4><h5><h6><strong><b><em><i><u><s><sub><sup><ul><ol><li><a><span><pre><code><table><thead><tbody><tfoot><tr><td><th><caption><colgroup><col>';
     }
 
     protected function ctsSanitizeNotesHtml(string $html): string

--- a/resources/css/filament/training/notes.css
+++ b/resources/css/filament/training/notes.css
@@ -16,16 +16,38 @@
         @apply text-xl;
     }
 
-    .cts-notes-content h3 {
-        @apply text-lg;
+    .cts-notes-content table {
+        @apply w-full border-collapse mb-4;
+        table-layout: fixed;
+        box-sizing: border-box;
+        width: 100% !important;
     }
 
-    .cts-notes-content h4 {
-        @apply text-base;
+    .cts-notes-content table col {
+        width: auto !important;
     }
 
-    .cts-notes-content h5,
-    .cts-notes-content h6 {
-        @apply text-sm;
+    .cts-notes-content th,
+    .cts-notes-content td {
+        @apply border border-gray-300 align-top text-left;
+        padding: 0.5rem 0.75rem !important;
+        box-sizing: border-box;
+        overflow-wrap: break-word;
+        word-break: normal;
+        white-space: normal;
+        min-width: 60px;
+    }
+
+    .cts-notes-content th {
+        @apply bg-gray-50 font-semibold;
+    }
+
+    .dark .cts-notes-content th,
+    .dark .cts-notes-content td {
+        @apply border-gray-600;
+    }
+
+    .dark .cts-notes-content th {
+        @apply bg-gray-800;
     }
 }

--- a/resources/css/filament/training/notes.css
+++ b/resources/css/filament/training/notes.css
@@ -50,4 +50,5 @@
     .dark .cts-notes-content th {
         @apply bg-gray-800;
     }
+
 }


### PR DESCRIPTION
# Summary of changes
- Allows tables to be shown

# Screenshots (if necessary)
<img width="976" height="988" alt="image" src="https://github.com/user-attachments/assets/7a91a08e-970d-4319-ad82-4f670b527f79" />
