### PR TITLE
Fix training position grouping on training places table

### DIFF
--- a/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
@@ -51,7 +51,16 @@ class TrainingPlaceResource extends Resource
                     ? $record->trainingPosition->category
                     : '__uncategorised__'
             )
-            ->orderQueryUsing(fn (Builder $query): Builder => $query)
+            ->orderQueryUsing(fn (Builder $query, string $direction): Builder => $query
+                ->orderBy(
+                    TrainingPosition::query()
+                        ->select('category')
+                        ->whereColumn('training_positions.id', 'training_places.trainable_id')
+                        ->where('training_places.trainable_type', TrainingPosition::class),
+                    $direction,
+                )
+                ->orderByDesc('training_places.created_at')
+            )
             ->scopeQueryByKeyUsing(function (Builder $query, string $key): Builder {
                 if ($key === '__uncategorised__') {
                     return $query->where(function (Builder $query) {

--- a/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
@@ -10,6 +10,7 @@ use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
@@ -181,6 +182,54 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
+    public function it_keeps_same_category_training_places_in_a_single_contiguous_group()
+    {
+        $obsCategory = 'Duplicate Group Fix OBS '.uniqid();
+        $heathrowCategory = 'Duplicate Group Fix Heathrow '.uniqid();
+
+        $obsPosition = TrainingPosition::factory()
+            ->withCtsPositions(['EGSS_GND'])
+            ->create(['category' => $obsCategory]);
+        $heathrowPosition = TrainingPosition::factory()
+            ->withCtsPositions(['EGLL_2_GND'])
+            ->create(['category' => $heathrowCategory]);
+
+        $waitingList = WaitingList::factory()->create();
+
+        $oldestObs = $this->createTrainingPlaceForPosition($waitingList, $obsPosition, now()->subDays(30));
+        $middleHeathrow = $this->createTrainingPlaceForPosition($waitingList, $heathrowPosition, now()->subDays(15));
+        $newestObs = $this->createTrainingPlaceForPosition($waitingList, $obsPosition, now()->subDays(5));
+
+        $component = Livewire::actingAs($this->privacc)
+            ->test(ListTrainingPlaces::class)
+            ->set('tableRecordsPerPage', 100)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$oldestObs, $middleHeathrow, $newestObs]);
+
+        $orderedIds = $component->instance()->getTableRecords()->pluck('id')->values()->all();
+
+        $oldestObsIndex = array_search($oldestObs->id, $orderedIds, true);
+        $newestObsIndex = array_search($newestObs->id, $orderedIds, true);
+        $heathrowIndex = array_search($middleHeathrow->id, $orderedIds, true);
+
+        $this->assertNotFalse($oldestObsIndex);
+        $this->assertNotFalse($newestObsIndex);
+        $this->assertNotFalse($heathrowIndex);
+
+        $this->assertSame(
+            min($oldestObsIndex, $newestObsIndex) + 1,
+            max($oldestObsIndex, $newestObsIndex),
+            'Same-category places must be contiguous so Filament does not render duplicate group headers.',
+        );
+
+        $this->assertLessThan(
+            $oldestObsIndex,
+            $newestObsIndex,
+            'Within a category group, newer places should appear first.',
+        );
+    }
+
+    #[Test]
     public function it_can_search_by_student_name()
     {
         // Arrange
@@ -297,5 +346,27 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
             'trainable_type' => TrainingPosition::class,
             'trainable_id' => $trainingPosition->id,
         ]);
+    }
+
+    private function createTrainingPlaceForPosition(
+        WaitingList $waitingList,
+        TrainingPosition $trainingPosition,
+        Carbon $createdAt,
+    ): TrainingPlace {
+        $student = Account::factory()->create();
+        Member::factory()->create(['cid' => $student->id]);
+
+        $waitingListAccount = $waitingList->addToWaitingList($student, $this->privacc);
+
+        $trainingPlace = TrainingPlace::create([
+            'waiting_list_account_id' => $waitingListAccount->id,
+            'account_id' => $student->id,
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
+        ]);
+
+        $trainingPlace->forceFill(['created_at' => $createdAt])->saveQuietly();
+
+        return $trainingPlace->fresh(['trainable']);
     }
 }


### PR DESCRIPTION
### **User description**
## Summary
- Fixes duplicate category group headers on the Training Places list after the polymorphic `trainable` change (TECH-709).
- Filament groups visually as it walks sorted rows; the post-morph `orderQueryUsing` was a no-op, so `created_at` ordering interleaved categories and restarted headers (e.g. "OBS to S1 Training" appearing twice).
- Restores ordering by training position category via a correlated subquery, then `created_at` desc within each group, without a join that would make searchable columns ambiguous.

## Test plan
- [ ] Open Training Places and confirm each category appears once (no interleaved duplicate headers)
- [ ] Confirm within a category, newer places still appear above older ones
- [ ] Spot-check search / category filter still work
- [ ] `php artisan test --filter=ListTrainingPlacesTest`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed duplicate category group headers in Training Places table.

- Restored proper ordering by category (correlated subquery) then created_at desc.

- Added test to verify contiguous grouping and ordering within categories.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TP[TrainingPlaceResource] --> Grouping[Filament Group by Category]
  Grouping --> Order[orderQueryUsing: category subquery, created_at desc]
  Order --> Result[Contiguous groups, no duplicate headers]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TrainingPlaceResource.php</strong><dd><code>Fix ordering to prevent duplicate group headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php

<ul><li>Modified <code>orderQueryUsing</code> to order by training position category via <br>correlated subquery, then by <code>created_at</code> descending.<br> <li> Ensures records of the same category appear contiguously, preventing <br>duplicate group headers.</ul>


</details>


  </td>
  <td><a href="https://github.com/VATSIM-UK/core/pull/5030/files#diff-0c4095ee466195f311b2b591b99deefb22db4acc3b387442de2aef82d3e0c22a">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ListTrainingPlacesTest.php</strong><dd><code>Add test for contiguous category grouping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php

<ul><li>Added test <br><code>it_keeps_same_category_training_places_in_a_single_contiguous_group</code> to <br>verify correct ordering and contiguity.<br> <li> Added helper method <code>createTrainingPlaceForPosition</code> to create training <br>places with specific timestamps.</ul>


</details>


  </td>
  <td><a href="https://github.com/VATSIM-UK/core/pull/5030/files#diff-2fb04bf6c1c5aea14332bd15abe5400207a0e2b22f3f93994f8b67dac14107c2">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

