### PR TITLE
Replace waiting list position pivot with polymorphic trainable_waiting_list

### DIFF
--- a/app/Models/Mship/Qualification.php
+++ b/app/Models/Mship/Qualification.php
@@ -4,8 +4,10 @@ namespace App\Models\Mship;
 
 use App\Models\Atc\Endorseable;
 use App\Models\Model;
+use App\Models\Training\WaitingList;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 /**
  * App\Models\Mship\Qualification.
@@ -81,6 +83,17 @@ class Qualification extends Model implements Endorseable
     public function trainingPlaceOffers()
     {
         return $this->morphMany(\App\Models\Training\TrainingPlace\TrainingPlaceOffer::class, 'trainable');
+    }
+
+    public function waitingLists(): MorphToMany
+    {
+        return $this->morphToMany(
+            WaitingList::class,
+            'trainable',
+            'trainable_waiting_list',
+            'trainable_id',
+            'waiting_list_id'
+        )->withTimestamps();
     }
 
     public static function parseVatsimATCQualification($network): ?self

--- a/app/Models/Training/TrainingPosition/TrainingPosition.php
+++ b/app/Models/Training/TrainingPosition/TrainingPosition.php
@@ -9,8 +9,8 @@ use App\Models\Training\WaitingList;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Facades\Route;
 
 class TrainingPosition extends Model
@@ -24,6 +24,15 @@ class TrainingPosition extends Model
     ];
 
     protected $guarded = [];
+
+    protected static function booted(): void
+    {
+        // The trainable_waiting_list pivot is polymorphic and cannot rely on a
+        // database foreign key cascade, so detach linked waiting lists on delete.
+        static::deleting(function (TrainingPosition $trainingPosition): void {
+            $trainingPosition->waitingLists()->detach();
+        });
+    }
 
     protected const SYLLABUS_ROUTES = [
         'OBS to S1 Training' => 'site.policy.training.s1-syllabus',
@@ -48,12 +57,13 @@ class TrainingPosition extends Model
         return $this->morphMany(TrainingPlaceOffer::class, 'trainable');
     }
 
-    public function waitingLists(): BelongsToMany
+    public function waitingLists(): MorphToMany
     {
-        return $this->belongsToMany(
+        return $this->morphToMany(
             WaitingList::class,
-            'training_position_waiting_list',
-            'training_position_id',
+            'trainable',
+            'trainable_waiting_list',
+            'trainable_id',
             'waiting_list_id'
         )->withTimestamps();
     }

--- a/app/Models/Training/WaitingList.php
+++ b/app/Models/Training/WaitingList.php
@@ -9,15 +9,19 @@ use App\Models\Atc\Position;
 use App\Models\Atc\PositionGroup;
 use App\Models\Mship\Account;
 use App\Models\Mship\Note\Type;
+use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList\Removal;
 use App\Models\Training\WaitingList\WaitingListAccount;
 use App\Models\Training\WaitingList\WaitingListFlag;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Number;
 
@@ -32,18 +36,18 @@ use Illuminate\Support\Number;
  * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property string|null $cts_theory_exam_level
  * @property array|null $feature_toggles
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Account> $accounts
+ * @property-read Collection<int, Account> $accounts
  * @property-read int|null $accounts_count
- * @property-read \Illuminate\Database\Eloquent\Collection<int, WaitingListFlag> $flags
+ * @property-read Collection<int, WaitingListFlag> $flags
  * @property-read int|null $flags_count
  * @property-read object $feature_toggles_formatted
  * @property-read bool $is_vt
  * @property-read mixed $formatted_department
  * @property-read bool $should_check_atc_hours
  * @property-read bool $should_check_cts_theory_exam
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Account> $staff
+ * @property-read Collection<int, Account> $staff
  * @property-read int|null $staff_count
- * @property-read \Illuminate\Database\Eloquent\Collection<int, WaitingListAccount> $waitingListAccounts
+ * @property-read Collection<int, WaitingListAccount> $waitingListAccounts
  * @property-read int|null $waiting_list_accounts_count
  *
  * @method static \Illuminate\Database\Eloquent\Builder|WaitingList newModelQuery()
@@ -162,14 +166,41 @@ class WaitingList extends Model
     /**
      * A WaitingList can be related to many TrainingPositions.
      */
-    public function trainingPositions(): BelongsToMany
+    public function trainingPositions(): MorphToMany
     {
-        return $this->belongsToMany(
+        return $this->morphedByMany(
             TrainingPosition::class,
-            'training_position_waiting_list',
+            'trainable',
+            'trainable_waiting_list',
             'waiting_list_id',
-            'training_position_id'
+            'trainable_id'
         )->withTimestamps();
+    }
+
+    /**
+     * A WaitingList can be related to many Qualifications (pilot training).
+     */
+    public function qualifications(): MorphToMany
+    {
+        return $this->morphedByMany(
+            Qualification::class,
+            'trainable',
+            'trainable_waiting_list',
+            'waiting_list_id',
+            'trainable_id'
+        )->withTimestamps();
+    }
+
+    /**
+     * All trainables (training positions and qualifications) linked to this list.
+     *
+     * @return Attribute<Collection, never>
+     */
+    protected function trainables(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): Collection => $this->trainingPositions->concat($this->qualifications)
+        );
     }
 
     /**
@@ -333,17 +364,17 @@ class WaitingList extends Model
 
     public function minimumQualification()
     {
-        return $this->belongsTo(\App\Models\Mship\Qualification::class, 'self_enrolment_minimum_qualification_id');
+        return $this->belongsTo(Qualification::class, 'self_enrolment_minimum_qualification_id');
     }
 
     public function maximumQualification()
     {
-        return $this->belongsTo(\App\Models\Mship\Qualification::class, 'self_enrolment_maximum_qualification_id');
+        return $this->belongsTo(Qualification::class, 'self_enrolment_maximum_qualification_id');
     }
 
     public function hoursAtQualification()
     {
-        return $this->belongsTo(\App\Models\Mship\Qualification::class, 'self_enrolment_hours_at_qualification_id');
+        return $this->belongsTo(Qualification::class, 'self_enrolment_hours_at_qualification_id');
     }
 
     public function hasCapacityLimit(): bool

--- a/database/migrations/2026_07_26_000001_create_trainable_waiting_list_table.php
+++ b/database/migrations/2026_07_26_000001_create_trainable_waiting_list_table.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('trainable_waiting_list', function (Blueprint $table) {
+            $table->id();
+            $table->string('trainable_type');
+            $table->unsignedBigInteger('trainable_id');
+            $table->unsignedInteger('waiting_list_id');
+            $table->timestamps();
+
+            $table->foreign('waiting_list_id')
+                ->references('id')
+                ->on('training_waiting_list')
+                ->onDelete('cascade');
+
+            $table->unique(['trainable_type', 'trainable_id', 'waiting_list_id'], 'trainable_wl_unique');
+            $table->index('waiting_list_id', 'trainable_wl_list_index');
+        });
+
+        DB::table('training_position_waiting_list')
+            ->orderBy('id')
+            ->each(function ($pivot) {
+                DB::table('trainable_waiting_list')->insert([
+                    'trainable_type' => TrainingPosition::class,
+                    'trainable_id' => $pivot->training_position_id,
+                    'waiting_list_id' => $pivot->waiting_list_id,
+                    'created_at' => $pivot->created_at,
+                    'updated_at' => $pivot->updated_at,
+                ]);
+            });
+
+        Schema::dropIfExists('training_position_waiting_list');
+    }
+
+    public function down(): void
+    {
+        Schema::create('training_position_waiting_list', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('training_position_id');
+            $table->unsignedInteger('waiting_list_id');
+            $table->timestamps();
+
+            $table->foreign('training_position_id')
+                ->references('id')
+                ->on('training_positions')
+                ->onDelete('cascade');
+
+            $table->foreign('waiting_list_id')
+                ->references('id')
+                ->on('training_waiting_list')
+                ->onDelete('cascade');
+
+            $table->unique(['training_position_id', 'waiting_list_id'], 'tp_wl_unique');
+        });
+
+        DB::table('trainable_waiting_list')
+            ->where('trainable_type', TrainingPosition::class)
+            ->orderBy('id')
+            ->each(function ($pivot) {
+                DB::table('training_position_waiting_list')->insert([
+                    'training_position_id' => $pivot->trainable_id,
+                    'waiting_list_id' => $pivot->waiting_list_id,
+                    'created_at' => $pivot->created_at,
+                    'updated_at' => $pivot->updated_at,
+                ]);
+            });
+
+        Schema::dropIfExists('trainable_waiting_list');
+    }
+};

--- a/tests/Feature/Training/TrainableWaitingListMigrationTest.php
+++ b/tests/Feature/Training/TrainableWaitingListMigrationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Training;
+
+use App\Models\Mship\Qualification;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Models\Training\WaitingList;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TrainableWaitingListMigrationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_replaces_the_legacy_pivot_table_with_the_polymorphic_one()
+    {
+        $this->assertFalse(
+            Schema::hasTable('training_position_waiting_list'),
+            'The legacy training_position_waiting_list table should have been dropped.',
+        );
+
+        $this->assertTrue(Schema::hasTable('trainable_waiting_list'));
+        $this->assertTrue(Schema::hasColumns('trainable_waiting_list', [
+            'trainable_type',
+            'trainable_id',
+            'waiting_list_id',
+            'created_at',
+            'updated_at',
+        ]));
+    }
+
+    #[Test]
+    public function backfilled_position_rows_resolve_through_the_polymorphic_relations()
+    {
+        $waitingList = WaitingList::factory()->create();
+        $trainingPosition = TrainingPosition::factory()->create();
+
+        // Simulate a row produced by the migration backfill (raw insert, not the relation).
+        DB::table('trainable_waiting_list')->insert([
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
+            'waiting_list_id' => $waitingList->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->assertTrue($waitingList->trainingPositions()->whereKey($trainingPosition->id)->exists());
+        $this->assertTrue($trainingPosition->waitingLists()->whereKey($waitingList->id)->exists());
+        $this->assertCount(0, $waitingList->qualifications);
+    }
+
+    #[Test]
+    public function the_unique_key_covers_the_full_morph_tuple()
+    {
+        $waitingList = WaitingList::factory()->create();
+        $trainingPosition = TrainingPosition::factory()->create();
+        $qualification = Qualification::factory()->pilot()->create();
+
+        // Same id across different morph types must be allowed.
+        $waitingList->trainingPositions()->attach($trainingPosition->id);
+        $waitingList->qualifications()->attach($qualification->id);
+
+        $this->assertDatabaseHas('trainable_waiting_list', [
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
+            'waiting_list_id' => $waitingList->id,
+        ]);
+        $this->assertDatabaseHas('trainable_waiting_list', [
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+            'waiting_list_id' => $waitingList->id,
+        ]);
+    }
+}

--- a/tests/Unit/Training/WaitingList/WaitingListTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Training\WaitingList;
 
 use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
 use App\Models\Training\WaitingList\WaitingListFlag;
@@ -292,20 +293,69 @@ class WaitingListTest extends TestCase
     }
 
     #[Test]
+    public function it_stores_training_positions_polymorphically()
+    {
+        $trainingPosition = TrainingPosition::factory()->create();
+
+        $this->waitingList->trainingPositions()->attach($trainingPosition->id);
+
+        $this->assertDatabaseHas('trainable_waiting_list', [
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
+            'waiting_list_id' => $this->waitingList->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_can_have_qualifications()
+    {
+        $qualification = Qualification::factory()->pilot()->create();
+
+        $this->waitingList->qualifications()->attach($qualification->id);
+
+        $this->assertTrue($this->waitingList->fresh()->qualifications->contains($qualification));
+        $this->assertCount(1, $this->waitingList->qualifications);
+
+        $this->assertDatabaseHas('trainable_waiting_list', [
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+            'waiting_list_id' => $this->waitingList->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_merges_positions_and_qualifications_into_trainables()
+    {
+        $trainingPosition = TrainingPosition::factory()->create();
+        $qualification = Qualification::factory()->pilot()->create();
+
+        $this->waitingList->trainingPositions()->attach($trainingPosition->id);
+        $this->waitingList->qualifications()->attach($qualification->id);
+
+        $trainables = $this->waitingList->fresh()->trainables;
+
+        $this->assertCount(2, $trainables);
+        $this->assertTrue($trainables->contains(fn ($trainable) => $trainable instanceof TrainingPosition && $trainable->is($trainingPosition)));
+        $this->assertTrue($trainables->contains(fn ($trainable) => $trainable instanceof Qualification && $trainable->is($qualification)));
+    }
+
+    #[Test]
     public function it_cascades_delete_on_pivot_when_training_position_is_deleted()
     {
         $trainingPosition = TrainingPosition::factory()->create();
         $this->waitingList->trainingPositions()->attach($trainingPosition->id);
 
-        $this->assertDatabaseHas('training_position_waiting_list', [
-            'training_position_id' => $trainingPosition->id,
+        $this->assertDatabaseHas('trainable_waiting_list', [
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
             'waiting_list_id' => $this->waitingList->id,
         ]);
 
         $trainingPosition->delete();
 
-        $this->assertDatabaseMissing('training_position_waiting_list', [
-            'training_position_id' => $trainingPosition->id,
+        $this->assertDatabaseMissing('trainable_waiting_list', [
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
             'waiting_list_id' => $this->waitingList->id,
         ]);
     }
@@ -318,24 +368,27 @@ class WaitingListTest extends TestCase
 
         $waitingListId = $this->waitingList->id;
 
-        $this->assertDatabaseHas('training_position_waiting_list', [
-            'training_position_id' => $trainingPosition->id,
+        $this->assertDatabaseHas('trainable_waiting_list', [
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
             'waiting_list_id' => $waitingListId,
         ]);
 
         // Soft delete does not cascade to pivot table
         $this->waitingList->delete();
 
-        $this->assertDatabaseHas('training_position_waiting_list', [
-            'training_position_id' => $trainingPosition->id,
+        $this->assertDatabaseHas('trainable_waiting_list', [
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
             'waiting_list_id' => $waitingListId,
         ]);
 
         // Force delete should cascade
         $this->waitingList->forceDelete();
 
-        $this->assertDatabaseMissing('training_position_waiting_list', [
-            'training_position_id' => $trainingPosition->id,
+        $this->assertDatabaseMissing('trainable_waiting_list', [
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
             'waiting_list_id' => $waitingListId,
         ]);
     }


### PR DESCRIPTION
### **User description**
## Summary
- Replaces `training_position_waiting_list` with a polymorphic `trainable_waiting_list` pivot so waiting lists can link to either a `TrainingPosition` or a `Qualification`.
- Migrates existing position links via backfill, then drops the legacy table; `down()` is fully reversible.
- Converts `WaitingList::trainingPositions()` to `morphedByMany`, adds `qualifications()` + a merged `trainables` accessor, and adds inverse `waitingLists()` morph relations on both models (with an Eloquent deleting hook on `TrainingPosition` to preserve cascade behaviour that a polymorphic FK cannot express).

First of four incremental PRs for [TECH-712](https://linear.app/vatsimuk/issue/TECH-712) / [TECH-699](https://linear.app/vatsimuk/issue/TECH-699). Depends on TECH-709 (#5024), already on `main`. No ATC behaviour change; UI/permissions/notifications are out of scope (later PRs).

## Test plan
- [ ] `php artisan migrate` applies cleanly and backfills existing position↔list links into `trainable_waiting_list`
- [ ] `php artisan test tests/Unit/Training/WaitingList/WaitingListTest.php tests/Feature/Training/TrainableWaitingListMigrationTest.php`
- [ ] Confirm ATC waiting lists still show their linked training positions in Filament
- [ ] Confirm deleting a training position still removes its pivot rows
- [ ] Spot-check that soft-deleting a waiting list retains pivot rows, and force-delete cascades them


Made with [Cursor](https://cursor.com)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replaced `training_position_waiting_list` with polymorphic `trainable_waiting_list` pivot

- Migrated existing position links to new table and dropped legacy table

- Added `qualifications()` morphToMany relation on WaitingList and inverse on Qualification

- Updated tests to reflect new pivot and added coverage for qualification links


___

### Diagram Walkthrough


```mermaid
flowchart LR
    WL[WaitingList] -->|morphedByMany| TP[TrainingPosition]
    WL -->|morphedByMany| Q[Qualification]
    TP -->|morphToMany| WL
    Q -->|morphToMany| WL
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Qualification.php</strong><dd><code>Add waitingLists morph relation to Qualification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/Models/Mship/Qualification.php

<ul><li>Added <code>waitingLists()</code> MorphToMany relation to <code>Qualification</code><br> <li> Added import for <code>WaitingList</code> and <code>MorphToMany</code></ul>


</details>


  </td>
  <td><a href="https://github.com/VATSIM-UK/core/pull/5033/files#diff-d82c6a9d3be2bb7c65d1b1e2a32147bad8391283e90752d27e25bcd315762e89">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TrainingPosition.php</strong><dd><code>Convert waitingLists relation to polymorphic morphToMany</code>&nbsp; </dd></summary>
<hr>

app/Models/Training/TrainingPosition/TrainingPosition.php

<ul><li>Changed <code>waitingLists()</code> from BelongsToMany to MorphToMany<br> <li> Added booted deleting hook to detach waiting lists on delete<br> <li> Updated imports</ul>


</details>


  </td>
  <td><a href="https://github.com/VATSIM-UK/core/pull/5033/files#diff-a2c6a24c2ad9fda8a6b66ecd207498ada8c7010ab6c81881ebd698be502c078a">+15/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WaitingList.php</strong><dd><code>Add polymorphic relations and trainables accessor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/Models/Training/WaitingList.php

<ul><li>Converted <code>trainingPositions()</code> to <code>morphedByMany</code><br> <li> Added <code>qualifications()</code> morphToMany relation<br> <li> Added <code>trainables</code> accessor merging positions and qualifications<br> <li> Updated docblock and imports</ul>


</details>


  </td>
  <td><a href="https://github.com/VATSIM-UK/core/pull/5033/files#diff-81b1a0ee7b2c86a3b928021b3c82bca857b044121c92ebbcaa4e4e7bb75de0ca">+42/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>2026_07_26_000001_create_trainable_waiting_list_table.php</strong><dd><code>Create polymorphic waiting list pivot migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

database/migrations/2026_07_26_000001_create_trainable_waiting_list_table.php

<ul><li>Creates new polymorphic pivot table <code>trainable_waiting_list</code><br> <li> Backfills existing <code>training_position_waiting_list</code> data<br> <li> Drops legacy table; down() reverses the process</ul>


</details>


  </td>
  <td><a href="https://github.com/VATSIM-UK/core/pull/5033/files#diff-8fed76479225f386bb18db2ac42ea03fc477178a689e4d504895150a34e50c77">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TrainableWaitingListMigrationTest.php</strong><dd><code>Add feature test for trainable waiting list migration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/Training/TrainableWaitingListMigrationTest.php

<ul><li>Tests that migration drops legacy table and creates polymorphic one<br> <li> Verifies backfilled rows resolve through relations<br> <li> Ensures unique key covers morph tuple</ul>


</details>


  </td>
  <td><a href="https://github.com/VATSIM-UK/core/pull/5033/files#diff-5f5e85488c1d99118e6da46f2316f5cb788ca5cb3df2157e7069b9498cef8fa3">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WaitingListTest.php</strong><dd><code>Update unit tests for polymorphic waiting list pivot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/Training/WaitingList/WaitingListTest.php

<ul><li>Updated existing tests to use new <code>trainable_waiting_list</code> table<br> <li> Added tests for qualification attachment and trainables merging<br> <li> Updated cascade tests</ul>


</details>


  </td>
  <td><a href="https://github.com/VATSIM-UK/core/pull/5033/files#diff-f76125f9387455502daf8e0668cda41bc8145b6757075214d84829ee6f03e13b">+63/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

