### PR TITLE
Mentoring sessions that user has no permissions to see appear in all categories

### DIFF
--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -121,14 +121,18 @@ class MentoringHistory extends BaseMentoringHistoryPage
 
         $member = Member::where('cid', auth()->id())->first();
 
+        $ctsPositions = $this->getVisibleCtsPositions();
+
         $sessionsWithPermissions = $sessionRepository
-            ->getAllAcceptedSessionsForPositionsQuery($this->getVisibleCtsPositions())
+            ->getAllAcceptedSessionsForPositionsQuery($ctsPositions)
             ->where('taken_date', '<', now());
 
         $sessionsUserMentored = $sessionRepository
             ->getSessionsForMentor($member->id);
 
-        $union = $sessionsWithPermissions->union($sessionsUserMentored);
+        $sessionsUserMentoredFiltered = $sessionsUserMentored->whereIn('position', $ctsPositions);
+
+        $union = $sessionsWithPermissions->union($sessionsUserMentoredFiltered);
 
         return Session::query()
             ->fromSub($union, 'sessions')

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -128,7 +128,6 @@ class MentoringHistory extends BaseMentoringHistoryPage
 
         if (empty($ctsPositions)) {
             return $sessionsUserMentored
-                ->where('taken', 1)
                 ->where('taken_date', '<', now())
                 ->orderByDesc('taken_date')
                 ->orderByDesc('taken_from')

--- a/app/Filament/Training/Pages/Mentor/MentoringHistory.php
+++ b/app/Filament/Training/Pages/Mentor/MentoringHistory.php
@@ -123,12 +123,21 @@ class MentoringHistory extends BaseMentoringHistoryPage
 
         $ctsPositions = $this->getVisibleCtsPositions();
 
+        $sessionsUserMentored = $sessionRepository
+            ->getSessionsForMentor($member->id);
+
+        if (empty($ctsPositions)) {
+            return $sessionsUserMentored
+                ->where('taken', 1)
+                ->where('taken_date', '<', now())
+                ->orderByDesc('taken_date')
+                ->orderByDesc('taken_from')
+                ->orderByDesc('id');
+        }
+
         $sessionsWithPermissions = $sessionRepository
             ->getAllAcceptedSessionsForPositionsQuery($ctsPositions)
             ->where('taken_date', '<', now());
-
-        $sessionsUserMentored = $sessionRepository
-            ->getSessionsForMentor($member->id);
 
         $sessionsUserMentoredFiltered = $sessionsUserMentored->whereIn('position', $ctsPositions);
 

--- a/tests/Feature/TrainingPanel/Mentor/MentoringHistoryTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringHistoryTest.php
@@ -265,14 +265,17 @@ class MentoringHistoryTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
-    public function it_shows_mentor_based_sessions_alongside_permission_based_sessions(): void
+    public function it_only_shows_sessions_within_the_selected_category_even_when_user_was_the_mentor(): void
     {
-        $category = MentorPermissionService::atcCategories()[0];
-        $permittedPosition = $this->createTrainingPosition($category, 'EGLL_GND');
+        $visibleCategory = MentorPermissionService::atcCategories()[0];
+        $hiddenCategory = MentorPermissionService::atcCategories()[1];
+
+        $visiblePosition = $this->createTrainingPosition($visibleCategory, 'EGLL_GND');
+        $this->createTrainingPosition($hiddenCategory, 'EGKK_TWR');
 
         $mentorCtsMember = $this->getOrCreateCtsMember($this->panelUser);
         app(MentorPermissionService::class)->assignToMentorable(
-            $this->panelUser, $permittedPosition, $this->panelUser, $category
+            $this->panelUser, $visiblePosition, $this->panelUser, $visibleCategory
         );
 
         $student = Account::factory()->create();
@@ -281,7 +284,7 @@ class MentoringHistoryTest extends BaseTrainingPanelTestCase
         $otherMentor = Account::factory()->create();
         $otherMentorCtsMember = $this->getOrCreateCtsMember($otherMentor);
 
-        $permSessionId = $this->insertSession(
+        $visibleSessionId = $this->insertSession(
             $otherMentorCtsMember->id,
             $studentCtsMember->id,
             'EGLL_GND',
@@ -289,7 +292,7 @@ class MentoringHistoryTest extends BaseTrainingPanelTestCase
             takenDate: now()->subDay()->format('Y-m-d H:i:s'),
         );
 
-        $mentorSessionId = $this->insertSession(
+        $hiddenMentorSessionId = $this->insertSession(
             $mentorCtsMember->id,
             $studentCtsMember->id,
             'EGKK_TWR',
@@ -297,12 +300,13 @@ class MentoringHistoryTest extends BaseTrainingPanelTestCase
             takenDate: now()->subDay()->format('Y-m-d H:i:s'),
         );
 
-        $permSession = Session::on('cts')->find($permSessionId);
-        $mentorSession = Session::on('cts')->find($mentorSessionId);
+        $visibleSession = Session::on('cts')->find($visibleSessionId);
+        $hiddenMentorSession = Session::on('cts')->find($hiddenMentorSessionId);
 
         Livewire::actingAs($this->panelUser)
-            ->test(MentoringHistory::class, ['category' => $category])
-            ->assertCanSeeTableRecords([$permSession, $mentorSession]);
+            ->test(MentoringHistory::class, ['category' => $visibleCategory])
+            ->assertCanSeeTableRecords([$visibleSession])
+            ->assertCanNotSeeTableRecords([$hiddenMentorSession]);
     }
 
     private function createTrainingPosition(string $category, string $callsign): TrainingPosition


### PR DESCRIPTION
Fixes #4963 

# Summary of changes

Make sure to apply the current filter to the sessions before displaying. 

# Screenshots (if necessary)

Before:
<img width="2887" height="1795" alt="image" src="https://github.com/user-attachments/assets/7f238584-1853-48ce-babc-7365ebf63105" />

After:
<img width="2887" height="1795" alt="image" src="https://github.com/user-attachments/assets/68a0a7d9-36a2-4dbc-8024-44553dfd13c1" />

Note also when showing all sessions, it still shows correctly:
<img width="2887" height="1795" alt="image" src="https://github.com/user-attachments/assets/fca797c1-27a1-4321-a683-26c50e239633" />
