### PR TITLE
fix: add handling for multiple session requests in different categories

### DIFF
--- a/app/Livewire/Training/AvailabilityGantt.php
+++ b/app/Livewire/Training/AvailabilityGantt.php
@@ -45,6 +45,8 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
 
     public int $studentsPage = 1;
 
+    public ?int $pendingSessionId = null;
+
     public function mount()
     {
         $this->date = max(request()->query('date', Carbon::today()->format('Y-m-d')), Carbon::today()->format('Y-m-d'));
@@ -157,6 +159,8 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
                     ->whereNull('mentor_id')
                     ->whereNull('filed')
                     ->whereNull('cancelled_datetime')
+                    ->whereIn('position', $allowedCallsigns)
+                    ->orderBy('id')
                     ->limit(1),
 
                 'last_session_date' => Session::selectRaw("CONCAT(taken_date, ' ', COALESCE(taken_from, '00:00:00'))")
@@ -239,13 +243,18 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
             ->form(function (array $arguments) {
                 $availability = Availability::findOrFail($arguments['availability_id']);
                 $student = Member::findOrFail($availability->student_id);
+                $allowedCallsigns = $this->getAllowedCallsigns();
 
                 $pendingSession = Session::query()
                     ->where('student_id', $student->id)
                     ->whereNull('mentor_id')
                     ->whereNull('filed')
                     ->whereNull('cancelled_datetime')
+                    ->whereIn('position', $allowedCallsigns)
+                    ->orderBy('id')
                     ->first();
+
+                $this->pendingSessionId = $pendingSession?->id;
 
                 $minTime = Carbon::parse($availability->from)->format('H:i');
                 $maxTime = Carbon::parse($availability->to)->format('H:i');
@@ -374,6 +383,16 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
                 $student = Member::findOrFail($availability->student_id);
                 $formattedDate = Carbon::parse($availability->date)->format('d/m/Y');
 
+                if (! $this->pendingSessionId) {
+                    Notification::make()
+                        ->title('Booking Failed')
+                        ->body('We could not find an active pending session request for this slot. It may have been cancelled or already claimed.')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
                 $from = Carbon::parse($data['taken_from']);
                 $to = Carbon::parse($data['taken_to']);
 
@@ -387,7 +406,8 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
                     return;
                 }
 
-                $success = $mentoringService->acceptSession($availability->id, auth()->user(), $data['taken_from'], $data['taken_to']);
+                $success = $mentoringService->acceptSession($this->pendingSessionId, $availability->id, auth()->user(), $data['taken_from'], $data['taken_to']);
+                $this->pendingSessionId = null;
 
                 if ($success) {
                     Notification::make()

--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -32,13 +32,14 @@ class MentoringSessionsService
     /**
      * Accepts a pending session by claiming a student's availability slot.
      */
-    public function acceptSession(int $availabilityId, Account $mentorAccount, string $takenFrom, string $takenTo): bool
+    public function acceptSession(int $sessionId, int $availabilityId, Account $mentorAccount, string $takenFrom, string $takenTo): bool
     {
-        return DB::transaction(function () use ($availabilityId, $mentorAccount, $takenFrom, $takenTo) {
+        return DB::transaction(function () use ($sessionId, $availabilityId, $mentorAccount, $takenFrom, $takenTo) {
             $availability = Availability::findOrFail($availabilityId);
             $mentorMember = Member::where('cid', $mentorAccount->id)->firstOrFail();
 
             $session = Session::query()
+                ->where('id', $sessionId)
                 ->where('student_id', $availability->student_id)
                 ->whereNull('mentor_id')
                 ->whereNull('filed')

--- a/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
@@ -26,9 +26,11 @@ use App\Notifications\Training\Mentoring\MentoringSessionRescheduledMentorNotifi
 use App\Notifications\Training\Mentoring\MentoringSessionRescheduledStudentNotification;
 use App\Services\Training\MentoringSessionsService;
 use Carbon\Carbon;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Notification;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -71,14 +73,14 @@ class MentoringSessionsServiceTest extends TestCase
     #[Test]
     public function accept_session_throws_exception_when_availability_does_not_exist(): void
     {
-        Session::factory()->create([
+        $session = Session::factory()->create([
             'student_id' => $this->studentMember->id,
             'mentor_id' => null,
         ]);
 
         $this->expectException(ModelNotFoundException::class);
 
-        $this->service->acceptSession(999999, $this->mentorAccount, '10:00', '12:00');
+        $this->service->acceptSession($session->id, 999999, $this->mentorAccount, '10:00', '12:00');
     }
 
     #[Test]
@@ -90,6 +92,7 @@ class MentoringSessionsServiceTest extends TestCase
         ]);
 
         $this->assertFalse($this->service->acceptSession(
+            999999,
             $availability->id,
             $this->mentorAccount,
             '10:00',
@@ -100,7 +103,7 @@ class MentoringSessionsServiceTest extends TestCase
     #[Test]
     public function accept_session_returns_false_when_pending_session_is_filed(): void
     {
-        Session::factory()->create([
+        $session = Session::factory()->create([
             'student_id' => $this->studentMember->id,
             'mentor_id' => null,
             'filed' => now(),
@@ -112,6 +115,7 @@ class MentoringSessionsServiceTest extends TestCase
         ]);
 
         $this->assertFalse($this->service->acceptSession(
+            $session->id,
             $availability->id,
             $this->mentorAccount,
             '10:00',
@@ -122,7 +126,7 @@ class MentoringSessionsServiceTest extends TestCase
     #[Test]
     public function accept_session_returns_false_when_pending_session_is_cancelled(): void
     {
-        Session::factory()->create([
+        $session = Session::factory()->create([
             'student_id' => $this->studentMember->id,
             'mentor_id' => null,
             'cancelled_datetime' => now(),
@@ -134,11 +138,42 @@ class MentoringSessionsServiceTest extends TestCase
         ]);
 
         $this->assertFalse($this->service->acceptSession(
+            $session->id,
             $availability->id,
             $this->mentorAccount,
             '10:00',
             '12:00',
         ));
+    }
+
+    #[Test]
+    public function accept_session_returns_false_when_session_id_does_not_belong_to_the_availabilitys_student(): void
+    {
+        $otherStudentAccount = Account::factory()->create();
+        $otherStudentMember = Member::factory()->create([
+            'id' => $otherStudentAccount->generateCTSInternalID($otherStudentAccount->id),
+            'cid' => $otherStudentAccount->id,
+        ]);
+
+        $mismatchedSession = Session::factory()->create([
+            'student_id' => $otherStudentMember->id,
+            'mentor_id' => null,
+        ]);
+
+        $availability = Availability::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'date' => Carbon::tomorrow(),
+        ]);
+
+        $this->assertFalse($this->service->acceptSession(
+            $mismatchedSession->id,
+            $availability->id,
+            $this->mentorAccount,
+            '10:00',
+            '12:00',
+        ));
+
+        $this->assertNull($mismatchedSession->fresh()->mentor_id);
     }
 
     #[Test]
@@ -163,6 +198,7 @@ class MentoringSessionsServiceTest extends TestCase
         ]);
 
         $this->assertTrue($this->service->acceptSession(
+            $pendingSession->id,
             $availability->id,
             $this->mentorAccount,
             '10:00',
@@ -188,7 +224,7 @@ class MentoringSessionsServiceTest extends TestCase
     }
 
     #[Test]
-    public function accept_session_assigns_first_pending_session_when_multiple_exist(): void
+    public function accept_session_only_assigns_the_specified_session_when_multiple_pending_sessions_exist(): void
     {
         Notification::fake();
 
@@ -212,6 +248,7 @@ class MentoringSessionsServiceTest extends TestCase
         ]);
 
         $this->assertTrue($this->service->acceptSession(
+            $secondPending->id,
             $availability->id,
             $this->mentorAccount,
             '10:00',
@@ -221,11 +258,139 @@ class MentoringSessionsServiceTest extends TestCase
         $firstPending->refresh();
         $secondPending->refresh();
 
-        $assignedCount = collect([$firstPending, $secondPending])
-            ->filter(fn (Session $session) => $session->mentor_id !== null)
-            ->count();
+        $this->assertNull($firstPending->mentor_id);
+        $this->assertSame($this->mentorMember->id, $secondPending->mentor_id);
+    }
 
-        $this->assertSame(1, $assignedCount);
+    #[Test]
+    public function accept_session_leaves_unspecified_pending_session_bookable_by_a_second_call(): void
+    {
+        Notification::fake();
+
+        $firstPending = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => null,
+        ]);
+
+        $secondPending = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGKK_APP',
+            'mentor_id' => null,
+        ]);
+
+        $availability = Availability::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'date' => Carbon::tomorrow(),
+            'from' => '09:00:00',
+            'to' => '13:00:00',
+        ]);
+
+        $this->assertTrue($this->service->acceptSession(
+            $secondPending->id,
+            $availability->id,
+            $this->mentorAccount,
+            '10:00',
+            '11:00',
+        ));
+
+        $this->assertTrue($this->service->acceptSession(
+            $firstPending->id,
+            $availability->id,
+            $this->mentorAccount,
+            '11:00',
+            '12:00',
+        ));
+
+        $this->assertSame($this->mentorMember->id, $firstPending->fresh()->mentor_id);
+        $this->assertSame($this->mentorMember->id, $secondPending->fresh()->mentor_id);
+    }
+
+    #[Test]
+    public function accept_session_throws_exception_when_mentor_is_not_authorized_for_the_position(): void
+    {
+        $unauthorizedMentorAccount = Account::factory()->create();
+        Member::factory()->create([
+            'id' => $unauthorizedMentorAccount->generateCTSInternalID($unauthorizedMentorAccount->id),
+            'cid' => $unauthorizedMentorAccount->id,
+        ]);
+
+        $pendingSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => null,
+        ]);
+
+        $availability = Availability::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'date' => Carbon::tomorrow(),
+            'from' => '09:00:00',
+            'to' => '13:00:00',
+        ]);
+
+        $this->expectException(AuthorizationException::class);
+
+        $this->service->acceptSession(
+            $pendingSession->id,
+            $availability->id,
+            $unauthorizedMentorAccount,
+            '10:00',
+            '12:00',
+        );
+    }
+
+    #[Test]
+    public function accept_session_throws_exception_when_requested_times_fall_outside_availability_window(): void
+    {
+        $pendingSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => null,
+        ]);
+
+        $availability = Availability::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'date' => Carbon::tomorrow(),
+            'from' => '10:00:00',
+            'to' => '12:00:00',
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->service->acceptSession(
+            $pendingSession->id,
+            $availability->id,
+            $this->mentorAccount,
+            '09:00',
+            '13:00',
+        );
+    }
+
+    #[Test]
+    public function accept_session_throws_exception_when_end_time_is_not_after_start_time(): void
+    {
+        $pendingSession = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => null,
+        ]);
+
+        $availability = Availability::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'date' => Carbon::tomorrow(),
+            'from' => '09:00:00',
+            'to' => '13:00:00',
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->service->acceptSession(
+            $pendingSession->id,
+            $availability->id,
+            $this->mentorAccount,
+            '12:00',
+            '10:00',
+        );
     }
 
     #[Test]
@@ -233,7 +398,7 @@ class MentoringSessionsServiceTest extends TestCase
     {
         Notification::fake();
 
-        Session::factory()->create([
+        $pendingSession = Session::factory()->create([
             'student_id' => $this->studentMember->id,
             'position' => 'EGLL_APP',
             'mentor_id' => null,
@@ -247,6 +412,7 @@ class MentoringSessionsServiceTest extends TestCase
         ]);
 
         $this->assertTrue($this->service->acceptSession(
+            $pendingSession->id,
             $availability->id,
             $this->mentorAccount,
             '10:00',


### PR DESCRIPTION
# Summary of changes
- Specifies which session is to be accepted
- Ensures the gantt only shows sessions in that category
 
# Screenshots (if necessary)
