### PR TITLE
Stop CTS CID cheating on tests

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,44 +1,38 @@
-name: PR Agent
+name: Open Code Review
 
 on:
-  pull_request_target:
-    types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
 
 jobs:
-  pr_agent_job:
+  ocr_job:
     if: >-
-      github.event.sender.type != 'Bot' && (
-        (github.event_name == 'pull_request_target' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
-        (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
-      )
+      github.event.issue.pull_request != null &&
+      github.event.sender.type != 'Bot' &&
+      (startsWith(github.event.comment.body, '/ocr') || startsWith(github.event.comment.body, '/review')) &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
-      contents: write
+      contents: read
 
     steps:
-      - name: PR Agent action step
-        uses: the-pr-agent/pr-agent@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0
 
-          OPENAI__API_BASE: "https://opencode.ai/zen/go/v1"
-          OPENAI__KEY: ${{ secrets.OPENCODE_API_KEY }}
-          CONFIG__MODEL: "openai/deepseek-v4-flash"
+      - name: Open Code Review Action
+        uses: alibaba/open-code-review@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-          CONFIG__IGNORE__GLOB: "['*.lock', 'composer.lock', 'package-lock.json', 'public/build/*', 'storage/*', 'bootstrap/cache/*', 'vendor/*', 'node_modules/*', 'junit.xml']"
+          llm_url: "https://opencode.ai/zen/go/v1"
+          llm_auth_token: ${{ secrets.OPENCODE_API_KEY }}
+          llm_model: "openai/deepseek-v4-flash"
+          llm_use_anthropic: "false"
 
-          PR_REVIEWER__INLINE_CODE_COMMENTS: "true"
-
-          PR_CODE_SUGGESTIONS__COMMITABLE_CODE_SUGGESTIONS: "true"
-          PR_CODE_SUGGESTIONS__SUGGESTIONS_SCORE_THRESHOLD: "7"
-
-          CONFIG__CUSTOM_MODEL_MAX_TOKENS: "128000"
-          PR_CODE_SUGGESTIONS__MAX_CONTEXT_TOKENS: "24000"
-
-          PR_CODE_SUGGESTIONS__EXTRA_INSTRUCTIONS: >-
-            Ignore all code-style, formatting, or indentation issues (Laravel Pint will catch these).
+          background: "Ignore all code-style, formatting, or indentation issues (Laravel Pint will catch these)."

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,38 +1,44 @@
-name: Open Code Review
+name: PR Agent
 
 on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
 
 jobs:
-  ocr_job:
+  pr_agent_job:
     if: >-
-      github.event.issue.pull_request != null &&
-      github.event.sender.type != 'Bot' &&
-      (startsWith(github.event.comment.body, '/ocr') || startsWith(github.event.comment.body, '/review')) &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'pull_request_target' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+        (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+      )
 
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
-      contents: read
+      contents: write
 
     steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
-          fetch-depth: 0
+      - name: PR Agent action step
+        uses: the-pr-agent/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Open Code Review Action
-        uses: alibaba/open-code-review@main
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI__API_BASE: "https://opencode.ai/zen/go/v1"
+          OPENAI__KEY: ${{ secrets.OPENCODE_API_KEY }}
+          CONFIG__MODEL: "openai/deepseek-v4-flash"
 
-          llm_url: "https://opencode.ai/zen/go/v1"
-          llm_auth_token: ${{ secrets.OPENCODE_API_KEY }}
-          llm_model: "openai/deepseek-v4-flash"
-          llm_use_anthropic: "false"
+          CONFIG__IGNORE__GLOB: "['*.lock', 'composer.lock', 'package-lock.json', 'public/build/*', 'storage/*', 'bootstrap/cache/*', 'vendor/*', 'node_modules/*', 'junit.xml']"
 
-          background: "Ignore all code-style, formatting, or indentation issues (Laravel Pint will catch these)."
+          PR_REVIEWER__INLINE_CODE_COMMENTS: "true"
+
+          PR_CODE_SUGGESTIONS__COMMITABLE_CODE_SUGGESTIONS: "true"
+          PR_CODE_SUGGESTIONS__SUGGESTIONS_SCORE_THRESHOLD: "7"
+
+          CONFIG__CUSTOM_MODEL_MAX_TOKENS: "128000"
+          PR_CODE_SUGGESTIONS__MAX_CONTEXT_TOKENS: "24000"
+
+          PR_CODE_SUGGESTIONS__EXTRA_INSTRUCTIONS: >-
+            Ignore all code-style, formatting, or indentation issues (Laravel Pint will catch these).

--- a/app/Listeners/Training/Exams/CreateCtsBookingEntry.php
+++ b/app/Listeners/Training/Exams/CreateCtsBookingEntry.php
@@ -20,7 +20,7 @@ class CreateCtsBookingEntry
 
         app(BookingService::class)->create([
             'position_id' => $position?->id,
-            'member_id' => $examBooking->student_id,
+            'member_id' => $examBooking->student?->cid,
             'type' => Booking::TYPE_EXAM,
             'starts_at' => Carbon::parse($examBooking->taken_date)->format('Y-m-d').' '.$examBooking->taken_from,
             'ends_at' => Carbon::parse($examBooking->taken_date)->format('Y-m-d').' '.$examBooking->taken_to,

--- a/app/Services/Training/CancelPendingExamService.php
+++ b/app/Services/Training/CancelPendingExamService.php
@@ -74,7 +74,7 @@ class CancelPendingExamService
                 'sesh_type' => 'EX',
                 'reason' => $reason,
                 'used' => 0,
-                'reason_by' => $cancelledBy->id,
+                'reason_by' => $cancelledBy->member?->id,
                 'date' => now(),
             ]);
 

--- a/database/factories/Cts/ExamBookingFactory.php
+++ b/database/factories/Cts/ExamBookingFactory.php
@@ -23,9 +23,7 @@ class ExamBookingFactory extends Factory
     public function definition(): array
     {
         $account = Account::factory()->create();
-        $studentMember = Member::factory()->create(
-            ['id' => $account->id, 'cid' => $account->id]
-        );
+        $studentMember = Member::factory()->forAccount($account)->create();
 
         return [
             'position_1' => 'EGKK_TWR',

--- a/database/factories/Cts/MemberFactory.php
+++ b/database/factories/Cts/MemberFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories\Cts;
 
 use App\Models\Cts\Member;
+use App\Models\Mship\Account;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -10,17 +11,33 @@ class MemberFactory extends Factory
 {
     protected $model = Member::class;
 
+    /**
+     * CTS assigns member `id` independently of `cid` (see HasCTSAccount::generateCTSInternalID) -
+     * they must never be assumed equal, so the default state deliberately draws them from
+     * non-overlapping ranges.
+     */
     public function definition(): array
     {
         $joined = Carbon::now();
-        $cid = $this->faker->unique()->numberBetween(810000, 1400000);
 
         return [
-            'id' => $cid,
-            'cid' => $cid,
+            'id' => $this->faker->unique()->numberBetween(2000000, 2999999),
+            'cid' => $this->faker->unique()->numberBetween(810000, 1400000),
             'name' => $this->faker->name,
             'joined' => $joined,
             'joined_div' => $joined->addDays(rand(-240, 0)),
         ];
+    }
+
+    /**
+     * Link this member to a real account via `cid`, while keeping `id` deliberately
+     * different so tests exercise the `cid` translation instead of assuming id === cid.
+     */
+    public function forAccount(Account $account): static
+    {
+        return $this->state(fn () => [
+            'cid' => $account->id,
+            'id' => $account->id + 5000000,
+        ]);
     }
 }

--- a/tests/Feature/Training/Exams/ExamAcceptedEventIntegrationTest.php
+++ b/tests/Feature/Training/Exams/ExamAcceptedEventIntegrationTest.php
@@ -33,14 +33,8 @@ class ExamAcceptedEventIntegrationTest extends TestCase
         $examinerAccount = Account::factory()->create(['email' => 'examiner@test.com']);
         $position = Position::factory()->create(['callsign' => 'EGKK_TWR']);
 
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
-        $examiner = Member::factory()->create([
-            'id' => $examinerAccount->id,
-            'cid' => $examinerAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
+        $examiner = Member::factory()->forAccount($examinerAccount)->create();
 
         $examDate = Carbon::tomorrow();
         $examBooking = ExamBooking::factory()->create([
@@ -106,18 +100,9 @@ class ExamAcceptedEventIntegrationTest extends TestCase
         $secondaryExaminerAccount = Account::factory()->create(['email' => 'secondary@test.com']);
         $position = Position::factory()->create(['callsign' => 'EGLL_APP']);
 
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
-        $primaryExaminer = Member::factory()->create([
-            'id' => $primaryExaminerAccount->id,
-            'cid' => $primaryExaminerAccount->id,
-        ]);
-        $secondaryExaminer = Member::factory()->create([
-            'id' => $secondaryExaminerAccount->id,
-            'cid' => $secondaryExaminerAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
+        $primaryExaminer = Member::factory()->forAccount($primaryExaminerAccount)->create();
+        $secondaryExaminer = Member::factory()->forAccount($secondaryExaminerAccount)->create();
 
         $examDate = Carbon::tomorrow();
         $examBooking = ExamBooking::factory()->create([
@@ -160,10 +145,7 @@ class ExamAcceptedEventIntegrationTest extends TestCase
         Event::fake([ExamAccepted::class]);
 
         $studentAccount = Account::factory()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         $examBooking = ExamBooking::factory()->create([
             'student_id' => $student->id,

--- a/tests/Feature/Training/Exams/ExamRequestsTableSecondaryExaminerScopingTest.php
+++ b/tests/Feature/Training/Exams/ExamRequestsTableSecondaryExaminerScopingTest.php
@@ -90,11 +90,7 @@ class ExamRequestsTableSecondaryExaminerScopingTest extends TestCase
     private function createExaminerWithSettings(array $settings): Member
     {
         $examinerAccount = Account::factory()->create();
-        $examinerMember = Member::factory()->create([
-            'id' => $examinerAccount->id,
-            'cid' => $examinerAccount->id,
-            'examiner' => true,
-        ]);
+        $examinerMember = Member::factory()->forAccount($examinerAccount)->create(['examiner' => true]);
 
         ExaminerSettings::create(array_merge([
             'memberID' => $examinerMember->id,

--- a/tests/Feature/TrainingPanel/BaseTrainingPanelTestCase.php
+++ b/tests/Feature/TrainingPanel/BaseTrainingPanelTestCase.php
@@ -21,7 +21,7 @@ abstract class BaseTrainingPanelTestCase extends TestCase
 
         $this->panelUser = Account::factory()->create();
 
-        Member::factory()->create(['id' => $this->panelUser->id, 'cid' => $this->panelUser->id]);
+        Member::factory()->forAccount($this->panelUser)->create();
 
         $this->panelUser->givePermissionTo('training.access');
     }

--- a/tests/Feature/TrainingPanel/Exams/ConductExamPilotTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ConductExamPilotTest.php
@@ -25,7 +25,7 @@ class ConductExamPilotTest extends BaseTrainingPanelTestCase
     private function createPilotExamBooking(string $examType = 'P1'): array
     {
         $account = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
 
         $exam = ExamBooking::factory()->create([
             'taken' => 1,
@@ -37,7 +37,7 @@ class ConductExamPilotTest extends BaseTrainingPanelTestCase
 
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         return [$account, $student, $exam];
@@ -93,7 +93,7 @@ class ConductExamPilotTest extends BaseTrainingPanelTestCase
     public function it_does_not_show_partial_pass_for_atc_exams()
     {
         $account = Account::factory()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
         $exam = ExamBooking::factory()->create([
             'taken' => 1,
             'finished' => ExamBooking::NOT_FINISHED_FLAG,
@@ -101,7 +101,7 @@ class ConductExamPilotTest extends BaseTrainingPanelTestCase
             'student_id' => $student->id,
             'student_rating' => Qualification::code('S1')->first()->vatsim,
         ]);
-        $exam->examiners()->create(['examid' => $exam->id, 'senior' => $this->panelUser->id]);
+        $exam->examiners()->create(['examid' => $exam->id, 'senior' => $this->panelUser->member->id]);
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
 
         $component = Livewire::actingAs($this->panelUser)

--- a/tests/Feature/TrainingPanel/Exams/ConductExamTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ConductExamTest.php
@@ -33,7 +33,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
     public function it_loads_if_authorised()
     {
         $account = Account::factory()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
         $exam = ExamBooking::factory()->create([
             'taken' => 1,
             'finished' => ExamBooking::NOT_FINISHED_FLAG,
@@ -43,7 +43,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         ]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
@@ -59,7 +59,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'exam' => 'TWR']);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         Livewire::actingAs($this->panelUser)
@@ -84,7 +84,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         $exam = ExamBooking::factory()->create(['taken' => 0, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'exam' => 'TWR']);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
@@ -100,7 +100,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::FINISHED_FLAG, 'exam' => 'TWR']);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
@@ -116,7 +116,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'exam' => 'APP']);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
@@ -130,7 +130,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
     public function test_can_fill_out_comments_one_of_criteria()
     {
         $account = Account::factory()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
         $exam = ExamBooking::factory()->create([
             'taken' => 1,
             'finished' => ExamBooking::NOT_FINISHED_FLAG,
@@ -140,7 +140,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         ]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
@@ -170,7 +170,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
     public function test_can_change_grade_on_one_of_criteria()
     {
         $account = Account::factory()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
         $exam = ExamBooking::factory()->create([
             'taken' => 1,
             'finished' => ExamBooking::NOT_FINISHED_FLAG,
@@ -180,7 +180,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         ]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
@@ -210,7 +210,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
     public function test_full_end_to_end_completion_of_form_pass()
     {
         $account = Account::factory()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
         $exam = ExamBooking::factory()->create([
             'taken' => 1,
             'finished' => ExamBooking::NOT_FINISHED_FLAG,
@@ -220,7 +220,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         ]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
@@ -267,7 +267,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
     {
         // Create user and login
         $account = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
 
         $position = Position::factory()->create(['callsign' => 'EGKK_TWR']);
         TrainingPosition::factory()->create(['position_id' => $position->id]);
@@ -283,7 +283,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         ]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
@@ -332,7 +332,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
     {
         // Create user with ATC qualification and login
         $account = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
 
         // Create OBS position
         $position = Position::factory()->create(['callsign' => 'OBS_PH_PT3']);
@@ -350,7 +350,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
         ]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.obs');
@@ -398,7 +398,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
     public function it_removes_training_place_when_exam_is_passed()
     {
         $account = Account::factory()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
 
         $position = Position::factory()->create(['callsign' => 'EGKK_TWR']);
         $trainingPosition = TrainingPosition::factory()->create(['position_id' => $position->id]);
@@ -414,7 +414,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
 
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');
@@ -460,7 +460,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
     public function it_only_removes_the_training_place_associated_with_the_passed_exam_position()
     {
         $account = Account::factory()->create();
-        $student = Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        $student = Member::factory()->forAccount($account)->create();
 
         $examPosition = Position::factory()->create(['callsign' => 'EGKK_TWR']);
         $examTrainingPosition = TrainingPosition::factory()->create(['position_id' => $examPosition->id]);
@@ -495,7 +495,7 @@ class ConductExamTest extends BaseTrainingPanelTestCase
 
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->panelUser->givePermissionTo('training.exams.conduct.twr');

--- a/tests/Feature/TrainingPanel/Exams/ExamHistoryTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamHistoryTest.php
@@ -36,10 +36,7 @@ class ExamHistoryTest extends BaseTrainingPanelTestCase
         foreach ($examLevels as $level) {
             // Create a student account and member
             $student = Account::factory()->create();
-            $studentMember = Member::factory()->create([
-                'id' => $student->id,
-                'cid' => $student->id,
-            ]);
+            $studentMember = Member::factory()->forAccount($student)->create();
 
             // Create an exam booking
             $examBooking = ExamBooking::factory()->create([
@@ -54,7 +51,7 @@ class ExamHistoryTest extends BaseTrainingPanelTestCase
             // Create examiners
             $examBooking->examiners()->create([
                 'examid' => $examBooking->id,
-                'senior' => $this->panelUser->id,
+                'senior' => $this->panelUser->member->id,
             ]);
 
             // Create a practical result
@@ -308,10 +305,7 @@ class ExamHistoryTest extends BaseTrainingPanelTestCase
     {
         // Create a practical result without an exam booking
         $orphanStudent = Account::factory()->create();
-        $orphanStudentMember = Member::factory()->create([
-            'id' => $orphanStudent->id,
-            'cid' => $orphanStudent->id,
-        ]);
+        $orphanStudentMember = Member::factory()->forAccount($orphanStudent)->create();
 
         // Use a smaller examid that fits in the database column
         PracticalResult::factory()->create([

--- a/tests/Feature/TrainingPanel/Exams/ExamRequestsTableTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamRequestsTableTest.php
@@ -38,10 +38,7 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
 
         // Create a student account and member
         $this->studentAccount = Account::factory()->create();
-        $this->studentMember = Member::factory()->create([
-            'id' => $this->studentAccount->id,
-            'cid' => $this->studentAccount->id,
-        ]);
+        $this->studentMember = Member::factory()->forAccount($this->studentAccount)->create();
 
         // Attach an ATC qualification to the panel user (as examiner)
         $atcQualification = Qualification::factory()->atc()->create(['vatsim' => 3]);
@@ -71,11 +68,7 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
     protected function createExaminerMemberForScope(string $scopeColumn): Member
     {
         $examinerAccount = Account::factory()->create();
-        $examinerMember = Member::factory()->create([
-            'id' => $examinerAccount->id,
-            'cid' => $examinerAccount->id,
-            'examiner' => true,
-        ]);
+        $examinerMember = Member::factory()->forAccount($examinerAccount)->create(['examiner' => true]);
 
         ExaminerSettings::create([
             'memberID' => $examinerMember->id,
@@ -109,7 +102,7 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
         // The ExamRequestsTable component itself doesn't enforce authorization
         // Authorization is handled at the page level where it's embedded
         $userWithoutExamPermissions = Account::factory()->create();
-        Member::factory()->create(['id' => $userWithoutExamPermissions->id, 'cid' => $userWithoutExamPermissions->id]);
+        Member::factory()->forAccount($userWithoutExamPermissions)->create();
         $userWithoutExamPermissions->givePermissionTo('training.access');
 
         Livewire::actingAs($userWithoutExamPermissions)
@@ -141,7 +134,7 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
         // Create examiner record for the accepted exam
         PracticalExaminers::create([
             'examid' => $acceptedExam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         Livewire::actingAs($this->panelUser)
@@ -306,10 +299,7 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
     {
         // Create availability for a different student
         $otherStudentAccount = Account::factory()->create();
-        $otherStudentMember = Member::factory()->create([
-            'id' => $otherStudentAccount->id,
-            'cid' => $otherStudentAccount->id,
-        ]);
+        $otherStudentMember = Member::factory()->forAccount($otherStudentAccount)->create();
 
         $otherAvailability = Availability::factory()
             ->forStudent($otherStudentMember->id)
@@ -406,7 +396,7 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
     {
         // Create a user with only TWR exam permissions
         $twrOnlyUser = Account::factory()->create();
-        $twrMember = Member::factory()->create(['id' => $twrOnlyUser->id, 'cid' => $twrOnlyUser->id]);
+        $twrMember = Member::factory()->forAccount($twrOnlyUser)->create();
         $twrOnlyUser->givePermissionTo('training.access');
         $twrOnlyUser->givePermissionTo('training.exams.conduct.twr');
 
@@ -444,7 +434,7 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
     {
         // Create a user with no exam conduct permissions
         $noPermissionsUser = Account::factory()->create();
-        $noPermissionsMember = Member::factory()->create(['id' => $noPermissionsUser->id, 'cid' => $noPermissionsUser->id]);
+        $noPermissionsMember = Member::factory()->forAccount($noPermissionsUser)->create();
         $noPermissionsUser->givePermissionTo('training.access');
 
         Livewire::actingAs($noPermissionsUser)
@@ -459,7 +449,7 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
     {
         // Create a user with only APP permissions
         $appOnlyUser = Account::factory()->create();
-        $appMember = Member::factory()->create(['id' => $appOnlyUser->id, 'cid' => $appOnlyUser->id]);
+        $appMember = Member::factory()->forAccount($appOnlyUser)->create();
         $appOnlyUser->givePermissionTo('training.access');
         $appOnlyUser->givePermissionTo('training.exams.conduct.app');
 
@@ -540,7 +530,7 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
     {
         // Create a user with only TWR permissions
         $twrOnlyUser = Account::factory()->create();
-        $twrMember = Member::factory()->create(['id' => $twrOnlyUser->id, 'cid' => $twrOnlyUser->id]);
+        $twrMember = Member::factory()->forAccount($twrOnlyUser)->create();
         $twrOnlyUser->givePermissionTo('training.access');
         $twrOnlyUser->givePermissionTo('training.exams.conduct.twr');
 

--- a/tests/Feature/TrainingPanel/Exams/ExamSetupTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamSetupTest.php
@@ -55,10 +55,7 @@ class ExamSetupTest extends BaseTrainingPanelTestCase
 
         // Create a student account and member
         $studentAccount = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         // Create a recent completed session for the student
         Session::factory()->create([
@@ -101,10 +98,7 @@ class ExamSetupTest extends BaseTrainingPanelTestCase
         ]);
 
         $studentAccount = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         // Create a recent completed session for the student on PT2 position
         Session::factory()->create([
@@ -196,10 +190,7 @@ class ExamSetupTest extends BaseTrainingPanelTestCase
         $position = Position::factory()->create(['callsign' => 'EGKK_TWR']);
         TrainingPosition::factory()->create(['position_id' => $position->id]);
 
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         ExamBooking::factory()->create([
             'student_id' => $student->id,
@@ -228,10 +219,7 @@ class ExamSetupTest extends BaseTrainingPanelTestCase
         $this->panelUser->givePermissionTo('training.exams.setup');
 
         $studentAccount = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         PracticalResult::factory()->create([
             'student_id' => $student->id,
@@ -264,10 +252,7 @@ class ExamSetupTest extends BaseTrainingPanelTestCase
         $this->panelUser->givePermissionTo('training.exams.setup');
 
         $studentAccount = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         PracticalResult::factory()->create([
             'student_id' => $student->id,
@@ -318,10 +303,7 @@ class ExamSetupTest extends BaseTrainingPanelTestCase
         TrainingPosition::factory()->create(['position_id' => $position->id]);
 
         $studentAccount = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         ExamBooking::factory()->create([
             'student_id' => $student->id,
@@ -366,10 +348,7 @@ class ExamSetupTest extends BaseTrainingPanelTestCase
         ]);
 
         $studentAccount = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         ExamBooking::factory()->create([
             'student_id' => $student->id,
@@ -405,10 +384,7 @@ class ExamSetupTest extends BaseTrainingPanelTestCase
         $this->panelUser->givePermissionTo('training.exams.setup');
 
         $studentAccount = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         ExamBooking::factory()->create([
             'student_id' => $student->id,

--- a/tests/Feature/TrainingPanel/Exams/ExamsOverviewTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamsOverviewTest.php
@@ -47,12 +47,12 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
         $this->panelUser->givePermissionTo('training.exams.access');
 
         $student = Account::factory()->create();
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        $studentMember = Member::factory()->forAccount($student)->create();
 
-        $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'student_id' => $student->id]);
+        $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'student_id' => $studentMember->id]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         Livewire::actingAs($this->panelUser)
@@ -69,12 +69,12 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
         $this->panelUser->givePermissionTo('training.exams.access');
 
         $student = Account::factory()->create();
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        $studentMember = Member::factory()->forAccount($student)->create();
 
-        $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'student_id' => $student->id]);
+        $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'student_id' => $studentMember->id]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'other' => $this->panelUser->id,
+            'other' => $this->panelUser->member->id,
         ]);
 
         Livewire::actingAs($this->panelUser)
@@ -91,12 +91,12 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
         $this->panelUser->givePermissionTo('training.exams.access');
 
         $student = Account::factory()->create();
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        $studentMember = Member::factory()->forAccount($student)->create();
 
-        $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'student_id' => $student->id]);
+        $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'student_id' => $studentMember->id]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'trainee' => $this->panelUser->id,
+            'trainee' => $this->panelUser->member->id,
         ]);
 
         Livewire::actingAs($this->panelUser)
@@ -113,12 +113,12 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
         $this->panelUser->givePermissionTo('training.exams.access');
 
         $student = Account::factory()->create();
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        $studentMember = Member::factory()->forAccount($student)->create();
 
-        $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'student_id' => $student->id]);
+        $exam = ExamBooking::factory()->create(['taken' => 1, 'finished' => ExamBooking::NOT_FINISHED_FLAG, 'student_id' => $studentMember->id]);
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         Livewire::actingAs($this->panelUser)
@@ -137,23 +137,23 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
             'name_first' => 'Alex',
             'name_last' => 'Student',
         ]);
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        $studentMember = Member::factory()->forAccount($student)->create();
 
         $exam = ExamBooking::factory()->create([
             'taken' => 1,
             'finished' => ExamBooking::NOT_FINISHED_FLAG,
-            'student_id' => $student->id,
+            'student_id' => $studentMember->id,
             'exam' => 'TWR',
             'position_1' => 'EGKK_TWR',
             'taken_date' => now()->addDays(3)->format('Y-m-d'),
             'taken_from' => '14:00:00',
             'taken_to' => '16:00:00',
-            'exmr_id' => $this->panelUser->id,
+            'exmr_id' => $this->panelUser->member->id,
         ]);
 
         $examSetup = ExamSetup::create([
             'rts_id' => 1,
-            'student_id' => $student->id,
+            'student_id' => $studentMember->id,
             'position_1' => 'EGKK_TWR',
             'exam' => 'TWR',
             'bookid' => $exam->id,
@@ -162,7 +162,7 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
 
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $reason = 'Unforeseen circumstances.';
@@ -186,7 +186,7 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
             'sesh_id' => $exam->id,
             'sesh_type' => 'EX',
             'reason' => $reason,
-            'reason_by' => $this->panelUser->id,
+            'reason_by' => $this->panelUser->member->id,
         ], 'cts');
 
         Notification::assertSentTo(
@@ -212,21 +212,21 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
         $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
 
         $coExaminer = Account::factory()->create();
-        Member::factory()->create(['id' => $coExaminer->id, 'cid' => $coExaminer->id]);
+        Member::factory()->forAccount($coExaminer)->create();
 
         $student = Account::factory()->create();
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        $studentMember = Member::factory()->forAccount($student)->create();
 
         $exam = ExamBooking::factory()->create([
             'taken' => 1,
             'finished' => ExamBooking::NOT_FINISHED_FLAG,
-            'student_id' => $student->id,
+            'student_id' => $studentMember->id,
             'exam' => 'TWR',
         ]);
 
         ExamSetup::create([
             'rts_id' => 1,
-            'student_id' => $student->id,
+            'student_id' => $studentMember->id,
             'position_1' => 'EGKK_TWR',
             'exam' => 'TWR',
             'bookid' => $exam->id,
@@ -235,8 +235,8 @@ class ExamsOverviewTest extends BaseTrainingPanelTestCase
 
         PracticalExaminers::create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
-            'other' => $coExaminer->id,
+            'senior' => $this->panelUser->member->id,
+            'other' => $coExaminer->member->id,
         ]);
 
         Livewire::actingAs($this->panelUser)

--- a/tests/Feature/TrainingPanel/Exams/UpcomingExamsTest.php
+++ b/tests/Feature/TrainingPanel/Exams/UpcomingExamsTest.php
@@ -326,10 +326,7 @@ class UpcomingExamsTest extends BaseTrainingPanelTestCase
     {
         $account = Account::factory()->create();
 
-        return Member::factory()->create([
-            'id' => $account->id,
-            'cid' => $account->id,
-        ]);
+        return Member::factory()->forAccount($account)->create();
     }
 
     private function createExam(
@@ -347,7 +344,7 @@ class UpcomingExamsTest extends BaseTrainingPanelTestCase
         if ($withExaminers) {
             $exam->examiners()->create(array_merge([
                 'examid' => $exam->id,
-                'senior' => $this->panelUser->id,
+                'senior' => $this->panelUser->member->id,
             ], $examinerOverrides ?? []));
         }
 
@@ -378,7 +375,7 @@ class UpcomingExamsTest extends BaseTrainingPanelTestCase
 
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         return $exam->fresh(['student', 'examiners.primaryExaminer']);

--- a/tests/Feature/TrainingPanel/Exams/ViewExamReportTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ViewExamReportTest.php
@@ -37,10 +37,7 @@ class ViewExamReportTest extends BaseTrainingPanelTestCase
 
         // Create a student account and member
         $this->student = Account::factory()->withQualification()->create();
-        $this->studentMember = Member::factory()->create([
-            'id' => $this->student->id,
-            'cid' => $this->student->id,
-        ]);
+        $this->studentMember = Member::factory()->forAccount($this->student)->create();
 
         // Create an exam booking
         $this->examBooking = ExamBooking::factory()->create([
@@ -55,7 +52,7 @@ class ViewExamReportTest extends BaseTrainingPanelTestCase
         // Create examiners
         $this->examBooking->examiners()->create([
             'examid' => $this->examBooking->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         // Create a practical result
@@ -295,12 +292,12 @@ class ViewExamReportTest extends BaseTrainingPanelTestCase
         $secondaryExaminer = Account::factory()->create();
         $traineeExaminer = Account::factory()->create();
 
-        Member::factory()->create(['id' => $secondaryExaminer->id, 'cid' => $secondaryExaminer->id]);
-        Member::factory()->create(['id' => $traineeExaminer->id, 'cid' => $traineeExaminer->id]);
+        $secondaryExaminerMember = Member::factory()->forAccount($secondaryExaminer)->create();
+        $traineeExaminerMember = Member::factory()->forAccount($traineeExaminer)->create();
 
         $this->examBooking->examiners()->update([
-            'other' => $secondaryExaminer->id,
-            'trainee' => $traineeExaminer->id,
+            'other' => $secondaryExaminerMember->id,
+            'trainee' => $traineeExaminerMember->id,
         ]);
 
         $this->panelUser->givePermissionTo(['training.exams.access', 'training.exams.conduct.twr']);
@@ -507,10 +504,7 @@ class ViewExamReportTest extends BaseTrainingPanelTestCase
     public function it_resubmits_student_for_exam_when_result_is_overridden_to_incomplete()
     {
         $account = Account::factory()->withQualification()->create();
-        $student = Member::factory()->create([
-            'id' => $account->id,
-            'cid' => $account->id,
-        ]);
+        $student = Member::factory()->forAccount($account)->create();
 
         $position = Position::factory()->create([
             'callsign' => 'EGKK_TWR',
@@ -528,7 +522,7 @@ class ViewExamReportTest extends BaseTrainingPanelTestCase
 
         $exam->examiners()->create([
             'examid' => $exam->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $practicalResult = PracticalResult::factory()->create([

--- a/tests/Feature/TrainingPanel/Mentor/ConductMentoringSessionTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ConductMentoringSessionTest.php
@@ -48,16 +48,10 @@ class ConductMentoringSessionTest extends BaseTrainingPanelTestCase
         parent::setUp();
 
         $this->mentor = Account::factory()->create();
-        $this->mentorMember = Member::factory()->create([
-            'id' => $this->mentor->id,
-            'cid' => $this->mentor->id,
-        ]);
+        $this->mentorMember = Member::factory()->forAccount($this->mentor)->create();
 
         $this->student = Account::factory()->create();
-        $this->studentMember = Member::factory()->create([
-            'id' => $this->student->id,
-            'cid' => $this->student->id,
-        ]);
+        $this->studentMember = Member::factory()->forAccount($this->student)->create();
 
         $trainingPosition = TrainingPosition::factory()->create([
             'cts_positions' => ['EGLL_APP'],
@@ -108,7 +102,7 @@ class ConductMentoringSessionTest extends BaseTrainingPanelTestCase
     public function non_assigned_mentor_cannot_access_conduct_page(): void
     {
         $otherMentor = Account::factory()->create();
-        Member::factory()->create(['id' => $otherMentor->id, 'cid' => $otherMentor->id]);
+        Member::factory()->forAccount($otherMentor)->create();
 
         Livewire::actingAs($otherMentor)
             ->test(ConductMentoringSession::class, ['sessionId' => $this->session->id])

--- a/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
@@ -31,10 +31,7 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
         parent::setUp();
 
         $this->mentor = Account::factory()->create();
-        $this->mentorMember = Member::factory()->create([
-            'id' => $this->mentor->id,
-            'cid' => $this->mentor->id,
-        ]);
+        $this->mentorMember = Member::factory()->forAccount($this->mentor)->create();
 
         $this->trainingPosition = TrainingPosition::factory()->create([
             'cts_positions' => ['EGLL_APP'],
@@ -271,10 +268,7 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
     public function students_property_returns_empty_collection_when_mentor_has_no_callsigns(): void
     {
         $noCallsignMentor = Account::factory()->create();
-        Member::factory()->create([
-            'id' => $noCallsignMentor->id,
-            'cid' => $noCallsignMentor->id,
-        ]);
+        Member::factory()->forAccount($noCallsignMentor)->create();
 
         $emptyPosition = TrainingPosition::factory()->create([
             'cts_positions' => [],

--- a/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/ViewMentoringReportTest.php
@@ -47,16 +47,10 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
         parent::setUp();
 
         $this->student = Account::factory()->create();
-        $this->studentMember = Member::factory()->create([
-            'id' => $this->student->id,
-            'cid' => $this->student->id,
-        ]);
+        $this->studentMember = Member::factory()->forAccount($this->student)->create();
 
         $this->mentor = Account::factory()->create();
-        $this->mentorMember = Member::factory()->create([
-            'id' => $this->mentor->id,
-            'cid' => $this->mentor->id,
-        ]);
+        $this->mentorMember = Member::factory()->forAccount($this->mentor)->create();
 
         $this->mentoringSession = Session::factory()->create([
             'student_id' => $this->studentMember->id,
@@ -113,10 +107,7 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
     public function it_loads_for_a_user_with_a_mentor_training_position_for_the_session_position(): void
     {
         $authorisedMentor = Account::factory()->create();
-        Member::factory()->create([
-            'id' => $authorisedMentor->id,
-            'cid' => $authorisedMentor->id,
-        ]);
+        Member::factory()->forAccount($authorisedMentor)->create();
 
         $trainingPosition = TrainingPosition::factory()->create([
             'cts_positions' => ['EGLL_APP'],
@@ -176,10 +167,7 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
     public function it_denies_a_different_student_viewing_another_students_session(): void
     {
         $otherStudent = Account::factory()->create();
-        Member::factory()->create([
-            'id' => $otherStudent->id,
-            'cid' => $otherStudent->id,
-        ]);
+        Member::factory()->forAccount($otherStudent)->create();
 
         $this->mock(MentorPermissionService::class, fn ($mock) => $mock
             ->shouldReceive('getCtsCallsignsForMentorable')->andReturn([])
@@ -195,10 +183,7 @@ class ViewMentoringReportTest extends BaseTrainingPanelTestCase
     public function it_denies_a_mentor_who_did_not_conduct_the_session_and_lacks_position_permission(): void
     {
         $otherMentor = Account::factory()->create();
-        Member::factory()->create([
-            'id' => $otherMentor->id,
-            'cid' => $otherMentor->id,
-        ]);
+        Member::factory()->forAccount($otherMentor)->create();
 
         $this->mock(MentorPermissionService::class, fn ($mock) => $mock
             ->shouldReceive('getCtsCallsignsForMentorable')->andReturn([])

--- a/tests/Feature/TrainingPanel/MyTraining/MyAcceptedMentoringSessionsTableTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyAcceptedMentoringSessionsTableTest.php
@@ -31,16 +31,10 @@ class MyAcceptedMentoringSessionsTableTest extends BaseTrainingPanelTestCase
         parent::setUp();
 
         $this->studentAccount = Account::factory()->create();
-        $this->studentMember = Member::factory()->create([
-            'id' => $this->studentAccount->id,
-            'cid' => $this->studentAccount->id,
-        ]);
+        $this->studentMember = Member::factory()->forAccount($this->studentAccount)->create();
 
         $mentorAccount = Account::factory()->create();
-        $this->mentorMember = Member::factory()->create([
-            'id' => $mentorAccount->id,
-            'cid' => $mentorAccount->id,
-        ]);
+        $this->mentorMember = Member::factory()->forAccount($mentorAccount)->create();
 
         $this->acceptedSession = Session::factory()->create([
             'student_id' => $this->studentMember->id,
@@ -79,10 +73,7 @@ class MyAcceptedMentoringSessionsTableTest extends BaseTrainingPanelTestCase
     public function it_excludes_sessions_for_other_students(): void
     {
         $otherAccount = Account::factory()->create();
-        $otherMember = Member::factory()->create([
-            'id' => $otherAccount->id,
-            'cid' => $otherAccount->id,
-        ]);
+        $otherMember = Member::factory()->forAccount($otherAccount)->create();
 
         $otherSession = Session::factory()->create([
             'student_id' => $otherMember->id,
@@ -192,10 +183,7 @@ class MyAcceptedMentoringSessionsTableTest extends BaseTrainingPanelTestCase
     public function it_shows_empty_state_when_no_sessions_exist(): void
     {
         $emptyAccount = Account::factory()->create();
-        Member::factory()->create([
-            'id' => $emptyAccount->id,
-            'cid' => $emptyAccount->id,
-        ]);
+        Member::factory()->forAccount($emptyAccount)->create();
         $emptyAccount->givePermissionTo('training.access');
 
         Livewire::actingAs($emptyAccount)

--- a/tests/Feature/TrainingPanel/MyTraining/MyExamHistoryTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyExamHistoryTest.php
@@ -49,7 +49,7 @@ class MyExamHistoryTest extends BaseTrainingPanelTestCase
         ]);
         $this->examBooking->examiners()->create([
             'examid' => $this->examBooking->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
 
         $this->practicalResult = PracticalResult::factory()->create([
@@ -121,7 +121,7 @@ class MyExamHistoryTest extends BaseTrainingPanelTestCase
         ]);
         $otherBooking->examiners()->create([
             'examid' => $otherBooking->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
         PracticalResult::factory()->create([
             'examid' => $otherBooking->id,
@@ -154,7 +154,7 @@ class MyExamHistoryTest extends BaseTrainingPanelTestCase
         ]);
         $secondBooking->examiners()->create([
             'examid' => $secondBooking->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
         PracticalResult::factory()->create([
             'examid' => $secondBooking->id,

--- a/tests/Feature/TrainingPanel/MyTraining/MyMentoringHistoryTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyMentoringHistoryTest.php
@@ -31,16 +31,10 @@ class MyMentoringHistoryTest extends BaseTrainingPanelTestCase
         parent::setUp();
 
         $this->studentAccount = Account::factory()->create();
-        $this->studentMember = Member::factory()->create([
-            'id' => $this->studentAccount->id,
-            'cid' => $this->studentAccount->id,
-        ]);
+        $this->studentMember = Member::factory()->forAccount($this->studentAccount)->create();
 
         $mentorAccount = Account::factory()->create();
-        $this->mentorMember = Member::factory()->create([
-            'id' => $mentorAccount->id,
-            'cid' => $mentorAccount->id,
-        ]);
+        $this->mentorMember = Member::factory()->forAccount($mentorAccount)->create();
 
         $this->filedSession = Session::factory()->create([
             'student_id' => $this->studentMember->id,
@@ -89,10 +83,7 @@ class MyMentoringHistoryTest extends BaseTrainingPanelTestCase
         ]);
 
         $otherAccount = Account::factory()->create();
-        $otherMember = Member::factory()->create([
-            'id' => $otherAccount->id,
-            'cid' => $otherAccount->id,
-        ]);
+        $otherMember = Member::factory()->forAccount($otherAccount)->create();
 
         Session::factory()->create([
             'student_id' => $otherMember->id,
@@ -154,10 +145,7 @@ class MyMentoringHistoryTest extends BaseTrainingPanelTestCase
     public function it_shows_an_empty_table_when_member_has_no_past_mentoring_sessions(): void
     {
         $emptyAccount = Account::factory()->create();
-        Member::factory()->create([
-            'id' => $emptyAccount->id,
-            'cid' => $emptyAccount->id,
-        ]);
+        Member::factory()->forAccount($emptyAccount)->create();
         $emptyAccount->givePermissionTo('training.access');
 
         Livewire::actingAs($emptyAccount)

--- a/tests/Feature/TrainingPanel/MyTraining/MyPendingExamsTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyPendingExamsTest.php
@@ -166,25 +166,21 @@ class MyPendingExamsTest extends BaseTrainingPanelTestCase
         Notification::fake();
 
         $examinerAccount = Account::factory()->create();
-        Member::factory()->create([
-            'id' => $examinerAccount->id,
-            'cid' => $examinerAccount->id,
-            'examiner' => true,
-        ]);
+        $examinerMember = Member::factory()->forAccount($examinerAccount)->create(['examiner' => true]);
 
         $this->examBooking->update([
             'taken' => 1,
             'taken_date' => now()->addDays(3)->format('Y-m-d'),
             'taken_from' => '14:00:00',
             'taken_to' => '16:00:00',
-            'exmr_id' => $examinerAccount->id,
+            'exmr_id' => $examinerMember->id,
         ]);
 
         $this->examSetup->update(['booked' => 1]);
 
         PracticalExaminers::create([
             'examid' => $this->examBooking->id,
-            'senior' => $examinerAccount->id,
+            'senior' => $examinerMember->id,
         ]);
 
         $reason = 'I can no longer make the scheduled time.';
@@ -208,7 +204,7 @@ class MyPendingExamsTest extends BaseTrainingPanelTestCase
             'sesh_id' => $this->examBooking->id,
             'sesh_type' => 'EX',
             'reason' => $reason,
-            'reason_by' => $this->studentAccount->id,
+            'reason_by' => $this->studentMember->id,
         ], 'cts');
 
         Notification::assertSentTo(

--- a/tests/Feature/TrainingPanel/MyTraining/MyTrainingPermissionsTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyTrainingPermissionsTest.php
@@ -41,10 +41,7 @@ class MyTrainingPermissionsTest extends BaseTrainingPanelTestCase
 
         // Primary student
         $this->studentAccount = Account::factory()->create();
-        $this->studentMember = Member::factory()->create([
-            'id' => $this->studentAccount->id,
-            'cid' => $this->studentAccount->id,
-        ]);
+        $this->studentMember = Member::factory()->forAccount($this->studentAccount)->create();
         $this->studentExamBooking = ExamBooking::factory()->create([
             'taken' => 1,
             'finished' => ExamBooking::FINISHED_FLAG,
@@ -55,7 +52,7 @@ class MyTrainingPermissionsTest extends BaseTrainingPanelTestCase
         ]);
         $this->studentExamBooking->examiners()->create([
             'examid' => $this->studentExamBooking->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
         $this->studentPracticalResult = PracticalResult::factory()->create([
             'examid' => $this->studentExamBooking->id,
@@ -67,10 +64,7 @@ class MyTrainingPermissionsTest extends BaseTrainingPanelTestCase
 
         // Second student
         $this->otherStudentAccount = Account::factory()->create();
-        $this->otherStudentMember = Member::factory()->create([
-            'id' => $this->otherStudentAccount->id,
-            'cid' => $this->otherStudentAccount->id,
-        ]);
+        $this->otherStudentMember = Member::factory()->forAccount($this->otherStudentAccount)->create();
         $this->otherStudentExamBooking = ExamBooking::factory()->create([
             'taken' => 1,
             'finished' => ExamBooking::FINISHED_FLAG,
@@ -81,7 +75,7 @@ class MyTrainingPermissionsTest extends BaseTrainingPanelTestCase
         ]);
         $this->otherStudentExamBooking->examiners()->create([
             'examid' => $this->otherStudentExamBooking->id,
-            'senior' => $this->panelUser->id,
+            'senior' => $this->panelUser->member->id,
         ]);
         $this->otherStudentPracticalResult = PracticalResult::factory()->create([
             'examid' => $this->otherStudentExamBooking->id,
@@ -126,7 +120,7 @@ class MyTrainingPermissionsTest extends BaseTrainingPanelTestCase
     public function member_with_no_results_sees_empty_my_exam_history(): void
     {
         $emptyAccount = Account::factory()->create();
-        Member::factory()->create(['id' => $emptyAccount->id, 'cid' => $emptyAccount->id]);
+        Member::factory()->forAccount($emptyAccount)->create();
         $emptyAccount->givePermissionTo('training.access');
 
         Livewire::actingAs($emptyAccount)

--- a/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceExamCancellationsTableTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceExamCancellationsTableTest.php
@@ -92,10 +92,7 @@ class TrainingPlaceExamCancellationsTableTest extends BaseTrainingPanelTestCase
     public function it_only_shows_cancellations_for_the_student(): void
     {
         $otherAccount = Account::factory()->create();
-        $otherMember = Member::factory()->create([
-            'id' => $otherAccount->id,
-            'cid' => $otherAccount->id,
-        ]);
+        $otherMember = Member::factory()->forAccount($otherAccount)->create();
 
         $studentBooking = ExamBooking::factory()->create([
             'position_1' => $this->callsign,

--- a/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceLeaveOfAbsenceTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/TrainingPlaceLeaveOfAbsenceTest.php
@@ -175,7 +175,7 @@ class TrainingPlaceLeaveOfAbsenceTest extends BaseTrainingPanelTestCase
     {
         $student = Account::factory()->create();
         $student->addState(State::findByCode('DIVISION'));
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        Member::factory()->forAccount($student)->create();
 
         $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $waitingListAccount = $waitingList->addToWaitingList($student, $this->panelUser);

--- a/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceRestoreIntegrationTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceRestoreIntegrationTest.php
@@ -57,7 +57,7 @@ class ViewTrainingPlaceRestoreIntegrationTest extends BaseTrainingPanelTestCase
         $ctsPosition = CtsPosition::factory()->create();
         $student = Account::factory()->create();
         $student->addState(State::findByCode('DIVISION'));
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        Member::factory()->forAccount($student)->create();
         $waitingList = WaitingList::factory()->create(['department' => 'atc']);
         $waitingListAccount = $waitingList->addToWaitingList($student, $this->panelUser);
         $position = Position::factory()->create();

--- a/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
@@ -61,7 +61,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         // Create a user without the training-places.view.* permission
         $userWithoutPermission = Account::factory()->create();
-        Member::factory()->create(['id' => $userWithoutPermission->id, 'cid' => $userWithoutPermission->id]);
+        Member::factory()->forAccount($userWithoutPermission)->create();
         $userWithoutPermission->givePermissionTo('training.access'); // Has training panel access but not training places
 
         Livewire::actingAs($userWithoutPermission)
@@ -75,7 +75,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
 
         // Create a user with the training-places.view.* permission
         $userWithPermission = Account::factory()->create();
-        Member::factory()->create(['id' => $userWithPermission->id, 'cid' => $userWithPermission->id]);
+        Member::factory()->forAccount($userWithPermission)->create();
         $userWithPermission->givePermissionTo('training.access');
         $userWithPermission->givePermissionTo('training-places.view.*');
 
@@ -437,7 +437,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
         $student = Account::factory()->create();
         $student->addState(State::findByCode('DIVISION'));
 
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        Member::factory()->forAccount($student)->create();
 
         // Create a waiting list
         $waitingList = WaitingList::factory()->create(['department' => 'atc']);
@@ -575,7 +575,7 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
     {
         $student = Account::factory()->create();
         $student->addState(State::findByCode('DIVISION'));
-        Member::factory()->create(['id' => $student->id, 'cid' => $student->id]);
+        Member::factory()->forAccount($student)->create();
 
         $waitingList = WaitingList::factory()->create(['department' => 'atc']);
 

--- a/tests/Unit/CTS/ExaminerRepositoryTest.php
+++ b/tests/Unit/CTS/ExaminerRepositoryTest.php
@@ -51,7 +51,7 @@ class ExaminerRepositoryTest extends TestCase
     public function it_does_not_return_an_examiner_if_not_set_as_examiner_on_members_table()
     {
         ExaminerSettings::factory()->create([
-            'memberID' => Member::Factory()->create(['examiner' => 0]),
+            'memberID' => Member::factory()->create(['examiner' => 0])->id,
             'S1' => 1,
             'P1' => 1,
         ]);

--- a/tests/Unit/Models/BookingTest.php
+++ b/tests/Unit/Models/BookingTest.php
@@ -163,10 +163,7 @@ class BookingTest extends TestCase
     public function it_resolves_bookable_morph_to_exam_booking(): void
     {
         $account = Account::factory()->create();
-        $member = Member::factory()->create([
-            'id' => $account->id,
-            'cid' => $account->id,
-        ]);
+        $member = Member::factory()->forAccount($account)->create();
         $examBooking = ExamBooking::factory()->create([
             'student_id' => $member->id,
             'exam' => 'TWR',

--- a/tests/Unit/Repositories/Cts/ExamResultRepositoryTest.php
+++ b/tests/Unit/Repositories/Cts/ExamResultRepositoryTest.php
@@ -30,7 +30,7 @@ class ExamResultRepositoryTest extends TestCase
 
         $this->repository = app(ExamResultRepository::class);
         $this->user = Account::factory()->create(['id' => 9000000]);
-        Member::factory()->create(['id' => $this->user->id, 'cid' => $this->user->id]);
+        Member::factory()->forAccount($this->user)->create();
 
         // Create exam data for all levels
         $this->createExamData();
@@ -43,10 +43,7 @@ class ExamResultRepositoryTest extends TestCase
         foreach ($examLevels as $level) {
             // Create a student account and member
             $student = Account::factory()->create();
-            $studentMember = Member::factory()->create([
-                'id' => $student->id,
-                'cid' => $student->id,
-            ]);
+            $studentMember = Member::factory()->forAccount($student)->create();
 
             // Create an exam booking
             $examBooking = ExamBooking::factory()->create([
@@ -61,7 +58,7 @@ class ExamResultRepositoryTest extends TestCase
             // Create examiners
             $examBooking->examiners()->create([
                 'examid' => $examBooking->id,
-                'senior' => $this->user->id,
+                'senior' => $this->user->member->id,
             ]);
 
             // Create a practical result

--- a/tests/Unit/Training/Exams/CancelPendingExamTest.php
+++ b/tests/Unit/Training/Exams/CancelPendingExamTest.php
@@ -42,17 +42,10 @@ class CancelPendingExamTest extends TestCase
         $this->service = new CancelPendingExamService;
 
         $this->studentAccount = Account::factory()->create();
-        $this->studentMember = Member::factory()->create([
-            'id' => $this->studentAccount->id,
-            'cid' => $this->studentAccount->id,
-        ]);
+        $this->studentMember = Member::factory()->forAccount($this->studentAccount)->create();
 
         $this->examinerAccount = Account::factory()->create();
-        $this->examinerMember = Member::factory()->create([
-            'id' => $this->examinerAccount->id,
-            'cid' => $this->examinerAccount->id,
-            'examiner' => true,
-        ]);
+        $this->examinerMember = Member::factory()->forAccount($this->examinerAccount)->create(['examiner' => true]);
 
         $this->examBooking = ExamBooking::factory()->create([
             'student_id' => $this->studentMember->id,
@@ -151,7 +144,7 @@ class CancelPendingExamTest extends TestCase
             'sesh_type' => 'EX',
             'reason' => $reason,
             'used' => 0,
-            'reason_by' => $this->studentAccount->id], 'cts');
+            'reason_by' => $this->studentMember->id], 'cts');
     }
 
     #[Test]
@@ -238,11 +231,8 @@ class CancelPendingExamTest extends TestCase
     public function it_sends_examiner_initiated_notifications_to_student_and_co_examiner(): void
     {
         $coExaminerAccount = Account::factory()->create();
-        Member::factory()->create([
-            'id' => $coExaminerAccount->id,
-            'cid' => $coExaminerAccount->id,
-        ]);
-        $this->examBooking->examiners->update(['other' => $coExaminerAccount->id]);
+        $coExaminerMember = Member::factory()->forAccount($coExaminerAccount)->create();
+        $this->examBooking->examiners->update(['other' => $coExaminerMember->id]);
 
         Notification::fake();
         $this->examinerAccount->givePermissionTo('training.exams.conduct.twr');

--- a/tests/Unit/Training/Exams/CreateCtsBookingEntryTest.php
+++ b/tests/Unit/Training/Exams/CreateCtsBookingEntryTest.php
@@ -28,14 +28,8 @@ class CreateCtsBookingEntryTest extends TestCase
         $examinerAccount = Account::factory()->create();
         $position = Position::factory()->create(['callsign' => 'EGKK_TWR']);
 
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
-        $examiner = Member::factory()->create([
-            'id' => $examinerAccount->id,
-            'cid' => $examinerAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
+        $examiner = Member::factory()->forAccount($examinerAccount)->create();
 
         $examDate = Carbon::tomorrow();
         $examBooking = ExamBooking::factory()->create([
@@ -81,10 +75,7 @@ class CreateCtsBookingEntryTest extends TestCase
     public function it_handles_unknown_position_gracefully(): void
     {
         $studentAccount = Account::factory()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         $examBooking = ExamBooking::factory()->create([
             'student_id' => $student->id,
@@ -111,10 +102,7 @@ class CreateCtsBookingEntryTest extends TestCase
     public function it_creates_booking_entry_with_correct_timestamps(): void
     {
         $studentAccount = Account::factory()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         $examDate = Carbon::parse('2024-12-25');
         $examBooking = ExamBooking::factory()->create([
@@ -161,10 +149,7 @@ class CreateCtsBookingEntryTest extends TestCase
             $position = Position::factory()->create(['callsign' => $examData['position']]);
 
             $studentAccount = Account::factory()->create();
-            $student = Member::factory()->create([
-                'id' => $studentAccount->id,
-                'cid' => $studentAccount->id,
-            ]);
+            $student = Member::factory()->forAccount($studentAccount)->create();
 
             $examDate = Carbon::tomorrow()->addDays($index);
             $examBooking = ExamBooking::factory()->create([
@@ -195,10 +180,7 @@ class CreateCtsBookingEntryTest extends TestCase
     public function it_links_booking_to_exam_booking_via_bookable(): void
     {
         $studentAccount = Account::factory()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         $examBooking = ExamBooking::factory()->create([
             'student_id' => $student->id,
@@ -228,10 +210,7 @@ class CreateCtsBookingEntryTest extends TestCase
     public function it_handles_multiple_exam_bookings_for_same_student(): void
     {
         $studentAccount = Account::factory()->create();
-        $student = Member::factory()->create([
-            'id' => $studentAccount->id,
-            'cid' => $studentAccount->id,
-        ]);
+        $student = Member::factory()->forAccount($studentAccount)->create();
 
         $position1 = Position::factory()->create(['callsign' => 'EGKK_TWR']);
         $position2 = Position::factory()->create(['callsign' => 'EGLL_APP']);

--- a/tests/Unit/Training/Mentoring/MentoringPolicyTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringPolicyTest.php
@@ -83,7 +83,7 @@ class MentoringPolicyTest extends TestCase
     public function view_allows_the_mentor_who_conducted_the_session(): void
     {
         $mentor = Account::factory()->create();
-        $mentorMember = Member::factory()->create(['id' => $mentor->id, 'cid' => $mentor->id]);
+        $mentorMember = Member::factory()->forAccount($mentor)->create();
         $session = Session::factory()->create([
             'mentor_id' => $mentorMember->id,
             'filed' => now(),
@@ -129,7 +129,7 @@ class MentoringPolicyTest extends TestCase
     public function view_denies_unfiled_reports_even_for_the_mentor(): void
     {
         $mentor = Account::factory()->create();
-        $mentorMember = Member::factory()->create(['id' => $mentor->id, 'cid' => $mentor->id]);
+        $mentorMember = Member::factory()->forAccount($mentor)->create();
         $session = Session::factory()->create(['mentor_id' => $mentorMember->id]);
 
         $this->assertFalse($this->policy->view($mentor, $session));
@@ -242,10 +242,7 @@ class MentoringPolicyTest extends TestCase
 
     private function createSessionForStudent(Account $student, ?\DateTimeInterface $filed = null): Session
     {
-        $studentMember = Member::factory()->create([
-            'id' => $student->id,
-            'cid' => $student->id,
-        ]);
+        $studentMember = Member::factory()->forAccount($student)->create();
 
         return Session::factory()->create([
             'student_id' => $studentMember->id,

--- a/tests/Unit/Training/Statistics/TrainingGroupStatisticsServiceTest.php
+++ b/tests/Unit/Training/Statistics/TrainingGroupStatisticsServiceTest.php
@@ -182,7 +182,7 @@ class TrainingGroupStatisticsServiceTest extends TestCase
     private function createAccountWithMember(): Account
     {
         $account = Account::factory()->create();
-        Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        Member::factory()->forAccount($account)->create();
 
         return $account->fresh();
     }

--- a/tests/Unit/Training/TrainingPlace/ExamForwardingServiceTest.php
+++ b/tests/Unit/Training/TrainingPlace/ExamForwardingServiceTest.php
@@ -29,7 +29,7 @@ class ExamForwardingServiceTest extends TestCase
     {
         $account = Account::factory()->withQualification()->create();
 
-        return Member::factory()->create(['id' => $account->id, 'cid' => $account->id]);
+        return Member::factory()->forAccount($account)->create();
     }
 
     private function createTestPosition(): TrainingPosition


### PR DESCRIPTION
Ensures CTS user ID is never the same as the CID

@CLC0609 relevant files are:
 - `tests/Unit/Training/TrainingPlace/ExamForwardingServiceTest.php`
 - `tests/Feature/TrainingPanel/BaseTrainingPanelTestCase.php`
 - `database/factories/Cts/ExamBookingFactory.php`
 - `database/factories/Cts/MemberFactory.php`

I think these 2 files had an actual bug:
 - `app/Listeners/Training/Exams/CreateCtsBookingEntry.php`
 - `app/Services/Training/CancelPendingExamService.php`
 
 Other diffs are just using the new factory setup