### PR TITLE
Refactor logging

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -235,6 +235,14 @@ Copilot skills live in `.github/skills/`: `configuring-horizon`, `laravel-best-p
 - **Frontend**: Tailwind CSS v4 for new components (Filament/Livewire), Bootstrap 5 for legacy pages. Alpine.js for interactivity without Livewire.
 - **Indent**: 4 spaces (PHP, Blade, JS), 2 spaces (YAML, XML). LF line endings.
 
+## Logging
+
+- Use the `Log` facade (never bare `\Log::` or the `logger()` helper).
+- Static message + structured context array, never interpolation. Include entity IDs, e.g. `Log::warning('CTS position not found', ['training_place_id' => $place->id]);`. Log caught exceptions before swallowing/rethrowing, with `['exception' => $e]`.
+- Bugsnag alerts on `notice` and above; `debug`/`info` are breadcrumbs only. So use `info`/`debug` for expected/routine conditions (legitimate not-found, user validation failures, no-op skips, noisy feed diagnostics) and reserve `notice`/`warning`/`error` for things a human should investigate.
+- Actor-attributed staff/member state changes (bans, role grants, endorsements) go to the `audit` channel via the global `audit()` helper (`app/helpers.php`).
+- `app/Libraries/Discord.php` is the reference implementation to emulate.
+
 ## Authorization
 
 - Uses **Spatie Laravel Permission** for roles and permissions. Custom table prefix: `mship_role`, `mship_permission`, `mship_account_role`, etc. Wildcard permissions are enabled (`privacc` role with `*` permission is super-admin).

--- a/app/Console/Commands/Members/ImportDivisionMembers.php
+++ b/app/Console/Commands/Members/ImportDivisionMembers.php
@@ -7,6 +7,7 @@ use App\Models\Mship\Account;
 use App\Notifications\Mship\WelcomeMember;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 
 class ImportDivisionMembers extends Command
@@ -30,6 +31,12 @@ class ImportDivisionMembers extends Command
         while ($response = $this->getMembersFromVatsim()) {
             if ($response->collect('items')->isEmpty()) {
                 $this->info('No more users to process.');
+
+                Log::info('import:division-members completed', [
+                    'created' => $this->countNewlyCreated,
+                    'updated' => $this->countUpdated,
+                    'skipped' => $this->countSkipped,
+                ]);
 
                 return;
             }
@@ -90,12 +97,18 @@ class ImportDivisionMembers extends Command
     {
         $token = config('services.vatsim-net.api.key');
 
-        return Http::withHeaders([
+        $response = Http::withHeaders([
             'Authorization' => "Token $token",
         ])->withUserAgent('VATSIMUK')
             ->get(config('services.vatsim-net.api.base').'orgs/division/GBR', [
                 'limit' => $this->limit,
                 'offset' => $this->offset,
             ]);
+
+        if ($response->failed()) {
+            Log::error('VATSIM division members fetch failed', ['status' => $response->status()]);
+        }
+
+        return $response;
     }
 }

--- a/app/Console/Commands/Members/ImportDivisionMembers.php
+++ b/app/Console/Commands/Members/ImportDivisionMembers.php
@@ -107,6 +107,8 @@ class ImportDivisionMembers extends Command
 
         if ($response->failed()) {
             Log::error('VATSIM division members fetch failed', ['status' => $response->status()]);
+
+            return false;
         }
 
         return $response;

--- a/app/Console/Commands/Members/SyncCtsRoles.php
+++ b/app/Console/Commands/Members/SyncCtsRoles.php
@@ -10,6 +10,7 @@ use App\Repositories\Cts\MentorRepository;
 use App\Repositories\Cts\StudentRepository;
 use App\Repositories\Cts\ValidationPositionRepository;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Spatie\Permission\Models\Role;
 
 class SyncCtsRoles extends Command
@@ -27,6 +28,10 @@ class SyncCtsRoles extends Command
      * @var string
      */
     protected $description = 'Allocate the relevant roles on Core depending on CTS permissions.';
+
+    private int $assignedCount = 0;
+
+    private int $removedCount = 0;
 
     /**
      * Execute the console command.
@@ -64,6 +69,11 @@ class SyncCtsRoles extends Command
         $this->syncStudentsByRts(17, Role::findByName('ATC Students (ENR)')->id); // Enroute Students
 
         $this->syncPilotExaminers(40); // Pilot
+
+        Log::info('sync:cts-roles completed', [
+            'assigned' => $this->assignedCount,
+            'removed' => $this->removedCount,
+        ]);
     }
 
     private function syncMentorsByRts(int $rtsId, int $roleId): void
@@ -139,10 +149,12 @@ class SyncCtsRoles extends Command
 
         foreach ($assignRole as $account) {
             Account::find($account)->assignRole($roleId);
+            $this->assignedCount++;
         }
 
         foreach ($removeRole as $account) {
             Account::find($account)->removeRole($roleId);
+            $this->removedCount++;
         }
     }
 

--- a/app/Console/Commands/NetworkData/ProcessNetworkData.php
+++ b/app/Console/Commands/NetworkData/ProcessNetworkData.php
@@ -50,7 +50,7 @@ class ProcessNetworkData extends Command
         $this->info('Getting network data from VATSIM.');
 
         if ($this->networkData->failed() || ! $this->networkData->json()) {
-            Log::error("Unable to process VATSIM network data. Status {$this->networkData->status()}");
+            Log::error('Unable to process VATSIM network data', ['status' => $this->networkData->status()]);
 
             return;
         }
@@ -62,6 +62,10 @@ class ProcessNetworkData extends Command
         event(new NetworkDataParsed);
 
         $this->info('Network data updated.');
+
+        Log::info('networkdata:download completed', [
+            'controllers' => count($this->networkData->json('controllers') ?? []),
+        ]);
     }
 
     /**
@@ -110,6 +114,7 @@ class ProcessNetworkData extends Command
                 $account = Account::findOrRetrieve($controller['cid']);
             } catch (InvalidCIDException $e) {
                 $this->info('Invalid CID: '.$controller['cid'], 'vvv');
+                Log::debug('Invalid CID in network data', ['cid' => $controller['cid']]);
                 DB::commit();
 
                 continue;
@@ -201,6 +206,7 @@ class ProcessNetworkData extends Command
                 $account = Account::findOrRetrieve($pilot['cid']);
             } catch (InvalidCIDException $e) {
                 $this->info('Invalid CID: '.$pilot['cid'], 'vvv');
+                Log::debug('Invalid CID in network data', ['cid' => $pilot['cid']]);
                 DB::commit();
 
                 continue;

--- a/app/Console/Commands/Roster/UpdateRoster.php
+++ b/app/Console/Commands/Roster/UpdateRoster.php
@@ -11,6 +11,7 @@ use App\Models\Training\WaitingList\WaitingListAccount;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class UpdateRoster extends Command
 {
@@ -60,8 +61,14 @@ class UpdateRoster extends Command
         );
 
         // Automatically mark those on the Gander Oceanic roster as eligible
+        $ganderResponse = Http::get(config('services.gander-oceanic.api.base').'/roster');
+
+        if ($ganderResponse->failed()) {
+            Log::error('Gander roster fetch failed', ['status' => $ganderResponse->status()]);
+        }
+
         $eligible->push(
-            $ganderControllers = Http::get(config('services.gander-oceanic.api.base').'/roster')
+            $ganderControllers = $ganderResponse
                 ->collect()
                 ->where('active', true)
                 ->pluck('cid')
@@ -111,7 +118,10 @@ class UpdateRoster extends Command
         $removeFromWaitingList
             ->each(function (WaitingListAccount $waitingListAccount) use ($removal) {
                 $waitingListAccount->waitingList->removeFromWaitingList($waitingListAccount->account, $removal);
-                \Log::debug("Removed {$waitingListAccount->account->id} from {$waitingListAccount->waitingList->id} due to roster removal");
+                Log::debug('Removed account from waiting list due to roster removal', [
+                    'account_id' => $waitingListAccount->account->id,
+                    'waiting_list_id' => $waitingListAccount->waitingList->id,
+                ]);
             });
 
         // Not on the roster, need to be on...
@@ -131,6 +141,17 @@ class UpdateRoster extends Command
                 'visitingAndTransferringRemovals' => $visitingAndTransferringRemovalsCount,
                 'removeFromWaitingList' => $removeFromWaitingList->countBy('list_id'),
             ],
+        ]);
+
+        Log::info('roster:update completed', [
+            'meetHourRequirement' => $meetHourRequirement->count(),
+            'newS1Members' => $newS1Members->count(),
+            'ganderControllers' => $ganderControllers->count(),
+            'eligible' => $eligible->count(),
+            'removeFromRoster' => $removeFromRosterCount,
+            'homeRemovals' => $homeRemovalsCount,
+            'visitingAndTransferringRemovals' => $visitingAndTransferringRemovalsCount,
+            'removeFromWaitingList' => $removeFromWaitingList->count(),
         ]);
 
         $this->comment('✅ Roster updated!');

--- a/app/Console/Commands/Roster/UpdateRoster.php
+++ b/app/Console/Commands/Roster/UpdateRoster.php
@@ -61,18 +61,24 @@ class UpdateRoster extends Command
         );
 
         // Automatically mark those on the Gander Oceanic roster as eligible
-        $ganderResponse = Http::get(config('services.gander-oceanic.api.base').'/roster');
+        try {
+            $ganderResponse = Http::get(config('services.gander-oceanic.api.base').'/roster');
+        } catch (\Exception $e) {
+            Log::error('Gander roster fetch failed', ['exception' => $e]);
+            $ganderResponse = null;
+        }
 
-        if ($ganderResponse->failed()) {
+        if ($ganderResponse && $ganderResponse->failed()) {
             Log::error('Gander roster fetch failed', ['status' => $ganderResponse->status()]);
+            $ganderResponse = null;
         }
 
         $eligible->push(
             $ganderControllers = $ganderResponse
-                ->collect()
+                ?->collect()
                 ->where('active', true)
                 ->pluck('cid')
-                ->flatten()
+                ->flatten() ?? collect()
         );
 
         $eligible = $eligible->flatten()->unique();

--- a/app/Console/Commands/Roster/UpdateRosterGanderControllers.php
+++ b/app/Console/Commands/Roster/UpdateRosterGanderControllers.php
@@ -26,7 +26,7 @@ class UpdateRosterGanderControllers extends Command
         if ($ganderResponse->failed()) {
             Log::error('Gander roster fetch failed', ['status' => $ganderResponse->status()]);
 
-            return;
+            return Command::FAILURE;
         }
 
         $ganderValidatedAccountIds = $ganderResponse

--- a/app/Console/Commands/Roster/UpdateRosterGanderControllers.php
+++ b/app/Console/Commands/Roster/UpdateRosterGanderControllers.php
@@ -9,6 +9,7 @@ use App\Models\Roster;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class UpdateRosterGanderControllers extends Command
 {
@@ -20,7 +21,13 @@ class UpdateRosterGanderControllers extends Command
 
     public function handle()
     {
-        $ganderValidatedAccountIds = Http::get(config('services.gander-oceanic.api.base').'/roster')
+        $ganderResponse = Http::get(config('services.gander-oceanic.api.base').'/roster');
+
+        if ($ganderResponse->failed()) {
+            Log::error('Gander roster fetch failed', ['status' => $ganderResponse->status()]);
+        }
+
+        $ganderValidatedAccountIds = $ganderResponse
             ->collect()
             ->where('active', true)
             ->pluck('cid');
@@ -71,5 +78,9 @@ class UpdateRosterGanderControllers extends Command
                 'created_by' => $this->ganderServiceAccount,
             ])->whereNotIn('account_id', $ganderValidatedAccountIds)->delete();
         });
+
+        Log::info('roster:gander completed', [
+            'ganderControllers' => $ganderValidatedAccountIds->count(),
+        ]);
     }
 }

--- a/app/Console/Commands/Roster/UpdateRosterGanderControllers.php
+++ b/app/Console/Commands/Roster/UpdateRosterGanderControllers.php
@@ -25,6 +25,8 @@ class UpdateRosterGanderControllers extends Command
 
         if ($ganderResponse->failed()) {
             Log::error('Gander roster fetch failed', ['status' => $ganderResponse->status()]);
+
+            return;
         }
 
         $ganderValidatedAccountIds = $ganderResponse

--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/EndorsementsRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/EndorsementsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\Accounts\RelationManagers;
 
+use App\Filament\Admin\Helpers\Pages\LogRelationAccess;
 use App\Models\Atc\Position;
 use App\Models\Atc\PositionGroup;
 use App\Models\Mship\Account\Endorsement;
@@ -23,11 +24,18 @@ use Illuminate\Database\Eloquent\Builder;
 
 class EndorsementsRelationManager extends RelationManager
 {
+    use LogRelationAccess;
+
     protected static string $relationship = 'endorsements';
 
     protected static ?string $inverseRelationship = 'account';
 
     protected static ?string $recordTitleAttribute = 'endorsable.name';
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewEndorsements';
+    }
 
     public function form(Schema $schema): Schema
     {

--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/FeedbackRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/FeedbackRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\Accounts\RelationManagers;
 
+use App\Filament\Admin\Helpers\Pages\LogRelationAccess;
 use App\Filament\Admin\Resources\Feedback\FeedbackResource;
 use Filament\Actions\ViewAction;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -11,7 +12,14 @@ use Filament\Tables\Table;
 
 class FeedbackRelationManager extends RelationManager
 {
+    use LogRelationAccess;
+
     protected static string $relationship = 'feedback';
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewFeedback';
+    }
 
     public function table(Table $table): Table
     {

--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/QualificationsRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/QualificationsRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Admin\Resources\Accounts\RelationManagers;
 
 use App\Enums\QualificationTypeEnum;
+use App\Filament\Admin\Helpers\Pages\LogRelationAccess;
 use App\Models\Mship\Qualification;
 use App\Services\Training\ManualAtcUpgradeService;
 use Carbon\CarbonImmutable;
@@ -19,9 +20,16 @@ use Illuminate\Support\Facades\Auth;
 
 class QualificationsRelationManager extends RelationManager
 {
+    use LogRelationAccess;
+
     protected static string $relationship = 'qualifications';
 
     protected static ?string $recordTitleAttribute = 'name';
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewQualifications';
+    }
 
     public function table(Table $table): Table
     {

--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/RetentionChecksRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/RetentionChecksRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\Accounts\RelationManagers;
 
+use App\Filament\Admin\Helpers\Pages\LogRelationAccess;
 use App\Models\Training\WaitingList\WaitingListRetentionCheck;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
@@ -11,11 +12,18 @@ use Filament\Tables\Table;
 
 class RetentionChecksRelationManager extends RelationManager
 {
+    use LogRelationAccess;
+
     protected static string $relationship = 'retentionChecks';
 
     protected static ?string $recordTitleAttribute = 'id';
 
     protected static ?string $title = 'Retention Checks';
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewRetentionChecks';
+    }
 
     public function isReadOnly(): bool
     {

--- a/app/Filament/Admin/Resources/Accounts/RelationManagers/VisitTransferRelationManager.php
+++ b/app/Filament/Admin/Resources/Accounts/RelationManagers/VisitTransferRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\Accounts\RelationManagers;
 
+use App\Filament\Admin\Helpers\Pages\LogRelationAccess;
 use Filament\Actions\ViewAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
@@ -10,7 +11,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class VisitTransferRelationManager extends RelationManager
 {
+    use LogRelationAccess;
+
     protected static string $relationship = 'visitTransferApplications';
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewVisitTransferApplications';
+    }
 
     public static function getTitle(Model $ownerRecord, string $pageClass): string
     {

--- a/app/Filament/Admin/Resources/Bans/Pages/ViewBan.php
+++ b/app/Filament/Admin/Resources/Bans/Pages/ViewBan.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Admin\Resources\Bans\Pages;
 
 use App\Filament\Admin\Helpers\Pages\BaseViewRecordPage;
+use App\Filament\Admin\Helpers\Pages\LogPageAccess;
 use App\Filament\Admin\Resources\Bans\BanResource;
 use App\Models\Mship\Note\Type;
 use App\Notifications\Mship\BanModified;
@@ -16,7 +17,14 @@ use Filament\Schemas\Components\Grid;
 
 class ViewBan extends BaseViewRecordPage
 {
+    use LogPageAccess;
+
     protected static string $resource = BanResource::class;
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewBan';
+    }
 
     protected function getHeaderActions(): array
     {

--- a/app/Filament/Admin/Resources/Discord/Pages/ViewDiscordTag.php
+++ b/app/Filament/Admin/Resources/Discord/Pages/ViewDiscordTag.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Admin\Resources\Discord\Pages;
 
 use App\Filament\Admin\Helpers\Pages\BaseViewRecordPage;
+use App\Filament\Admin\Helpers\Pages\LogPageAccess;
 use App\Filament\Admin\Resources\Discord\DiscordTagResource;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Section;
@@ -10,7 +11,14 @@ use Filament\Schemas\Schema;
 
 class ViewDiscordTag extends BaseViewRecordPage
 {
+    use LogPageAccess;
+
     protected static string $resource = DiscordTagResource::class;
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewDiscordTag';
+    }
 
     public function form(Schema $schema): Schema
     {

--- a/app/Filament/Admin/Resources/Feedback/Pages/ViewFeedback.php
+++ b/app/Filament/Admin/Resources/Feedback/Pages/ViewFeedback.php
@@ -4,12 +4,20 @@ namespace App\Filament\Admin\Resources\Feedback\Pages;
 
 use App\Filament\Admin\Forms\Components\AccountSelect;
 use App\Filament\Admin\Helpers\Pages\BaseViewRecordPage;
+use App\Filament\Admin\Helpers\Pages\LogPageAccess;
 use App\Filament\Admin\Resources\Feedback\FeedbackResource;
 use Filament\Actions\Action;
 
 class ViewFeedback extends BaseViewRecordPage
 {
+    use LogPageAccess;
+
     protected static string $resource = FeedbackResource::class;
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewFeedback';
+    }
 
     protected function getHeaderActions(): array
     {

--- a/app/Filament/Admin/Resources/RosterUpdates/Pages/ViewRosterUpdate.php
+++ b/app/Filament/Admin/Resources/RosterUpdates/Pages/ViewRosterUpdate.php
@@ -3,11 +3,19 @@
 namespace App\Filament\Admin\Resources\RosterUpdates\Pages;
 
 use App\Filament\Admin\Helpers\Pages\BaseViewRecordPage;
+use App\Filament\Admin\Helpers\Pages\LogPageAccess;
 use App\Filament\Admin\Resources\RosterUpdates\RosterUpdateResource;
 
 class ViewRosterUpdate extends BaseViewRecordPage
 {
+    use LogPageAccess;
+
     protected static string $resource = RosterUpdateResource::class;
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewRosterUpdate';
+    }
 
     protected function getHeaderActions(): array
     {

--- a/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ViewVisitTransferApplication.php
+++ b/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ViewVisitTransferApplication.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Admin\Resources\VisitTransfer\VisitTransferApplications\Pages;
 
 use App\Enums\VTCheckStatus;
+use App\Filament\Admin\Helpers\Pages\LogPageAccess;
 use App\Filament\Admin\Resources\VisitTransfer\VisitTransferApplications\VisitTransferApplicationResource;
 use App\Models\Mship\Note\Type;
 use Carbon\Carbon;
@@ -20,7 +21,14 @@ use Filament\Schemas\Schema;
 
 class ViewVisitTransferApplication extends ViewRecord
 {
+    use LogPageAccess;
+
     protected static string $resource = VisitTransferApplicationResource::class;
+
+    protected function getLogActionName(): string
+    {
+        return 'ViewVisitTransferApplication';
+    }
 
     public function getTitle(): string
     {

--- a/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
+++ b/app/Filament/Training/Pages/Mentor/ConductMentoringSession.php
@@ -37,6 +37,7 @@ use Filament\Support\Enums\IconSize;
 use Filament\Support\Enums\TextSize;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 
 class ConductMentoringSession extends Page implements HasForms, HasInfolists
@@ -326,6 +327,8 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
         try {
             app(MentoringReportService::class)->submit($this->session->fresh());
         } catch (ValidationException $exception) {
+            Log::debug('Submit mentoring report failed', ['exception' => $exception, 'session_id' => $this->session->id]);
+
             Notification::make()
                 ->title('Cannot submit mentoring report')
                 ->body(collect($exception->errors())->flatten()->first())
@@ -351,6 +354,8 @@ class ConductMentoringSession extends Page implements HasForms, HasInfolists
         try {
             app(MentoringReportService::class)->markNoShow($this->session->fresh(), $confirmed);
         } catch (ValidationException $exception) {
+            Log::debug('Mark mentoring session no-show failed', ['exception' => $exception, 'session_id' => $this->session->id]);
+
             Notification::make()
                 ->title('Unable to mark no-show')
                 ->body(collect($exception->errors())->flatten()->first())

--- a/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
+++ b/app/Filament/Training/Pages/Mentor/UpcomingMentoringSessions.php
@@ -24,6 +24,7 @@ use Filament\Notifications\Notification;
 use Filament\Tables\Table;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\Url;
 use Spatie\CalendarLinks\Link;
 
@@ -199,6 +200,8 @@ class UpcomingMentoringSessions extends BaseMentoringHistoryPage
                                     ->send();
                             }
                         } catch (AuthorizationException $e) {
+                            Log::warning('Reallocate mentoring session failed', ['exception' => $e, 'session_id' => $record->id]);
+
                             Notification::make()
                                 ->title('Reallocation Failed')
                                 ->body($e->getMessage())

--- a/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
+++ b/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
@@ -29,6 +29,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 
 class ViewTrainingPlace extends BaseMentoringHistoryPage implements HasInfolists
 {
@@ -238,6 +239,8 @@ class ViewTrainingPlace extends BaseMentoringHistoryPage implements HasInfolists
                 ->body('Exam setup for '.($trainingPosition->exam_callsign ?? $trainingPosition->position->callsign).' has been created.')
                 ->send();
         } catch (Exception $e) {
+            Log::error('Training place forward for exam failed', ['exception' => $e, 'training_place_id' => $this->trainingPlace->id]);
+
             Notification::make()
                 ->title('Error')
                 ->danger()

--- a/app/Filament/Training/Resources/PositionGroups/RelationManagers/MembershipEndorsementRelationManager.php
+++ b/app/Filament/Training/Resources/PositionGroups/RelationManagers/MembershipEndorsementRelationManager.php
@@ -11,6 +11,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Log;
 
 class MembershipEndorsementRelationManager extends RelationManager
 {
@@ -38,7 +39,9 @@ class MembershipEndorsementRelationManager extends RelationManager
                 ])->action(function (array $data) {
                     try {
                         $account = Account::findOrFail($data['account_id']);
-                    } catch (ModelNotFoundException) {
+                    } catch (ModelNotFoundException $e) {
+                        Log::debug('Membership endorsement account lookup failed', ['exception' => $e, 'account_id' => $data['account_id']]);
+
                         Notification::make()->title('Account not found')->danger()->send();
 
                         return;

--- a/app/Filament/Training/Resources/WaitingLists/Pages/ViewWaitingList.php
+++ b/app/Filament/Training/Resources/WaitingLists/Pages/ViewWaitingList.php
@@ -19,6 +19,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 
 /**
  * @property WaitingList $record
@@ -63,6 +64,8 @@ class ViewWaitingList extends ViewRecord
                                         $fail('The specified member is not a home UK member.');
                                     }
                                 } catch (ModelNotFoundException $e) {
+                                    Log::debug('Waiting list home member check failed', ['exception' => $e, 'account_id' => $value]);
+
                                     $fail('The specified member was not found.');
                                 }
                             }
@@ -75,6 +78,8 @@ class ViewWaitingList extends ViewRecord
                                     $fail('The specified member does not have the required endorsement to join this waiting list.');
                                 }
                             } catch (ModelNotFoundException $e) {
+                                Log::debug('Waiting list endorsement check failed', ['exception' => $e, 'account_id' => $value]);
+
                                 $fail('The specified member was not found.');
                             }
                         })

--- a/app/Http/Controllers/Api/TrackAudioController.php
+++ b/app/Http/Controllers/Api/TrackAudioController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class TrackAudioController
 {
@@ -41,7 +42,7 @@ class TrackAudioController
             return trim($response->body());
 
         } catch (\Exception $e) {
-            \Log::error('Failed to fetch latest TrackAudio version: '.$e->getMessage());
+            Log::error('Failed to fetch latest TrackAudio version', ['exception' => $e]);
 
             return null;
         }

--- a/app/Http/Controllers/External/VatsimNet/ProcessVatsimNetWebhook.php
+++ b/app/Http/Controllers/External/VatsimNet/ProcessVatsimNetWebhook.php
@@ -15,11 +15,11 @@ class ProcessVatsimNetWebhook extends BaseController
         $this->validateAuth($request);
         $webhook = $request->all();
 
-        \Log::info('Raw webhook data', [
+        Log::info('Raw webhook data', [
             'webhook' => $webhook,
         ]);
 
-        \Log::debug('VATSIM.net webhook received', [
+        Log::debug('VATSIM.net webhook received', [
             'resource' => $webhook['resource'],
             'actions.length' => count($webhook['actions']),
         ]);
@@ -41,7 +41,7 @@ class ProcessVatsimNetWebhook extends BaseController
                     $jobs[] = new MemberChangedAction($webhook['resource'], $action);
                     break;
                 default:
-                    Log::error("Unknown action from VATSIM.net webook: {$action['action']}");
+                    Log::error('Unknown action from VATSIM.net webhook', ['action' => $action['action']]);
                     abort(400);
             }
         }

--- a/app/Http/Middleware/AdminPanelFilamentAccessMiddleware.php
+++ b/app/Http/Middleware/AdminPanelFilamentAccessMiddleware.php
@@ -29,7 +29,7 @@ class AdminPanelFilamentAccessMiddleware
         }
 
         if (! $account->can('admin.access')) {
-            Log::warning('Access denied: admin panel access', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
+            Log::warning('Access denied: admin panel access', ['account_id' => $account->id, 'path' => $request->path(), 'ip' => $request->ip()]);
 
             return abort(404);
         }

--- a/app/Http/Middleware/AdminPanelFilamentAccessMiddleware.php
+++ b/app/Http/Middleware/AdminPanelFilamentAccessMiddleware.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
 
 class AdminPanelFilamentAccessMiddleware
@@ -28,6 +29,8 @@ class AdminPanelFilamentAccessMiddleware
         }
 
         if (! $account->can('admin.access')) {
+            Log::warning('Access denied: admin panel access', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
+
             return abort(404);
         }
 

--- a/app/Http/Middleware/CheckAdminPermissions.php
+++ b/app/Http/Middleware/CheckAdminPermissions.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Facades\Log;
 
 class CheckAdminPermissions
 {
@@ -36,6 +37,8 @@ class CheckAdminPermissions
         if ($hasRoutePermission) {
             return $next($request);
         }
+
+        Log::warning('Access denied: missing admin permission', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
 
         abort(403);
     }

--- a/app/Http/Middleware/DenyIfBanned.php
+++ b/app/Http/Middleware/DenyIfBanned.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Auth;
 use Closure;
+use Illuminate\Support\Facades\Log;
 
 class DenyIfBanned
 {
@@ -17,16 +18,24 @@ class DenyIfBanned
     {
         if (Auth::check() && Auth::user()->is_banned) {
             if ($request->expectsJson()) {
+                Log::warning('Access denied: banned account', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
+
                 return response()->json(['error' => 'You are currently banned.'], 403);
             }
 
             if (Auth::user()->is_network_banned) {
+                Log::warning('Access denied: banned account', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
+
                 return redirect()->route('banned.network');
             }
 
             if (Auth::user()->is_system_banned) {
+                Log::warning('Access denied: banned account', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
+
                 return redirect()->route('banned.local');
             }
+
+            Log::warning('Access denied: banned account', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
 
             abort(403, 'You are currently banned.');
         }

--- a/app/Http/Middleware/DenyIfBanned.php
+++ b/app/Http/Middleware/DenyIfBanned.php
@@ -17,25 +17,19 @@ class DenyIfBanned
     public function handle($request, Closure $next)
     {
         if (Auth::check() && Auth::user()->is_banned) {
-            if ($request->expectsJson()) {
-                Log::warning('Access denied: banned account', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
+            Log::warning('Access denied: banned account', ['account_id' => Auth::user()->id, 'path' => $request->path(), 'ip' => $request->ip()]);
 
+            if ($request->expectsJson()) {
                 return response()->json(['error' => 'You are currently banned.'], 403);
             }
 
             if (Auth::user()->is_network_banned) {
-                Log::warning('Access denied: banned account', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
-
                 return redirect()->route('banned.network');
             }
 
             if (Auth::user()->is_system_banned) {
-                Log::warning('Access denied: banned account', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
-
                 return redirect()->route('banned.local');
             }
-
-            Log::warning('Access denied: banned account', ['account_id' => optional(auth()->user())->id, 'path' => $request->path(), 'ip' => $request->ip()]);
 
             abort(403, 'You are currently banned.');
         }

--- a/app/Http/Middleware/MandatoryTwoFactor.php
+++ b/app/Http/Middleware/MandatoryTwoFactor.php
@@ -21,7 +21,7 @@ class MandatoryTwoFactor
     {
         if (Auth::check() && Auth::user()->requiresTwoFactorSetup()) {
             if ($makeResponse) {
-                Log::warning('Access denied: 2FA not enrolled', ['account_id' => optional(auth()->user())->id]);
+                Log::warning('Access denied: 2FA not enrolled', ['account_id' => auth()->user()->id]);
 
                 return redirect()->guest(route('two-factor.setup'))
                     ->withError('You are required to set up two-factor authentication before continuing.');

--- a/app/Http/Middleware/MandatoryTwoFactor.php
+++ b/app/Http/Middleware/MandatoryTwoFactor.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use App\Traits\Middleware\RedirectsOnFailure;
 use Auth;
+use Illuminate\Support\Facades\Log;
 
 class MandatoryTwoFactor
 {
@@ -20,6 +21,8 @@ class MandatoryTwoFactor
     {
         if (Auth::check() && Auth::user()->requiresTwoFactorSetup()) {
             if ($makeResponse) {
+                Log::warning('Access denied: 2FA not enrolled', ['account_id' => optional(auth()->user())->id]);
+
                 return redirect()->guest(route('two-factor.setup'))
                     ->withError('You are required to set up two-factor authentication before continuing.');
             }

--- a/app/Jobs/Concerns/LogsJobFailure.php
+++ b/app/Jobs/Concerns/LogsJobFailure.php
@@ -5,7 +5,7 @@ namespace App\Jobs\Concerns;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
-trait LogsJobLifecycle
+trait LogsJobFailure
 {
     /**
      * Extra context merged into lifecycle log entries. Override per job.

--- a/app/Jobs/Concerns/LogsJobLifecycle.php
+++ b/app/Jobs/Concerns/LogsJobLifecycle.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Jobs\Concerns;
+
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+trait LogsJobLifecycle
+{
+    /**
+     * Extra context merged into lifecycle log entries. Override per job.
+     */
+    protected function logJobContext(): array
+    {
+        return [];
+    }
+
+    public function failed(Throwable $e): void
+    {
+        Log::error('Job failed', [
+            'job' => static::class,
+            'exception' => $e,
+        ] + $this->logJobContext());
+    }
+}

--- a/app/Jobs/Middleware/RateLimited.php
+++ b/app/Jobs/Middleware/RateLimited.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs\Middleware;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redis;
 use Predis\PredisException;
 
@@ -43,6 +44,7 @@ class RateLimited
                 });
         } catch (PredisException $exception) {
             // Redis probably not installed. We will send the job anyway
+            Log::warning('Rate limiter unavailable; job proceeding without throttling', ['job' => get_class($job), 'exception' => $exception]);
             $next($job);
         }
     }

--- a/app/Jobs/Mship/SyncToCTS.php
+++ b/app/Jobs/Mship/SyncToCTS.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs\Mship;
 
-use App\Jobs\Concerns\LogsJobLifecycle;
+use App\Jobs\Concerns\LogsJobFailure;
 use App\Jobs\Job;
 use App\Models\Mship\Account;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Log;
 
 class SyncToCTS extends Job implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, LogsJobLifecycle, SerializesModels;
+    use Dispatchable, InteractsWithQueue, LogsJobFailure, SerializesModels;
 
     private $account;
 

--- a/app/Jobs/Mship/SyncToCTS.php
+++ b/app/Jobs/Mship/SyncToCTS.php
@@ -2,16 +2,18 @@
 
 namespace App\Jobs\Mship;
 
+use App\Jobs\Concerns\LogsJobLifecycle;
 use App\Jobs\Job;
 use App\Models\Mship\Account;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 
 class SyncToCTS extends Job implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, SerializesModels;
+    use Dispatchable, InteractsWithQueue, LogsJobLifecycle, SerializesModels;
 
     private $account;
 
@@ -23,5 +25,12 @@ class SyncToCTS extends Job implements ShouldQueue
     public function handle()
     {
         $this->account->syncToCTS();
+
+        Log::info('Member sync completed', ['service' => 'cts', 'account_id' => $this->account->id]);
+    }
+
+    protected function logJobContext(): array
+    {
+        return ['account_id' => $this->account->id];
     }
 }

--- a/app/Jobs/Mship/SyncToDiscord.php
+++ b/app/Jobs/Mship/SyncToDiscord.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs\Mship;
 
-use App\Jobs\Concerns\LogsJobLifecycle;
+use App\Jobs\Concerns\LogsJobFailure;
 use App\Jobs\Job;
 use App\Models\Mship\Account;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Log;
 
 class SyncToDiscord extends Job implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, LogsJobLifecycle, SerializesModels;
+    use Dispatchable, InteractsWithQueue, LogsJobFailure, SerializesModels;
 
     private Account $account;
 

--- a/app/Jobs/Mship/SyncToDiscord.php
+++ b/app/Jobs/Mship/SyncToDiscord.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs\Mship;
 
+use App\Jobs\Concerns\LogsJobLifecycle;
 use App\Jobs\Job;
 use App\Models\Mship\Account;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -10,10 +11,11 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\RateLimitedWithRedis;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 
 class SyncToDiscord extends Job implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, SerializesModels;
+    use Dispatchable, InteractsWithQueue, LogsJobLifecycle, SerializesModels;
 
     private Account $account;
 
@@ -31,6 +33,13 @@ class SyncToDiscord extends Job implements ShouldQueue
     public function handle()
     {
         $this->account->syncToDiscord();
+
+        Log::info('Member sync completed', ['service' => 'discord', 'account_id' => $this->account->id]);
+    }
+
+    protected function logJobContext(): array
+    {
+        return ['account_id' => $this->getAccountId()];
     }
 
     public function getAccountId(): int

--- a/app/Jobs/Mship/SyncToHelpdesk.php
+++ b/app/Jobs/Mship/SyncToHelpdesk.php
@@ -2,16 +2,18 @@
 
 namespace App\Jobs\Mship;
 
+use App\Jobs\Concerns\LogsJobLifecycle;
 use App\Jobs\Job;
 use App\Models\Mship\Account;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 
 class SyncToHelpdesk extends Job implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, SerializesModels;
+    use Dispatchable, InteractsWithQueue, LogsJobLifecycle, SerializesModels;
 
     private $account;
 
@@ -23,5 +25,12 @@ class SyncToHelpdesk extends Job implements ShouldQueue
     public function handle()
     {
         $this->account->syncToHelpdesk();
+
+        Log::info('Member sync completed', ['service' => 'helpdesk', 'account_id' => $this->account->id]);
+    }
+
+    protected function logJobContext(): array
+    {
+        return ['account_id' => $this->account->id];
     }
 }

--- a/app/Jobs/Mship/SyncToHelpdesk.php
+++ b/app/Jobs/Mship/SyncToHelpdesk.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs\Mship;
 
-use App\Jobs\Concerns\LogsJobLifecycle;
+use App\Jobs\Concerns\LogsJobFailure;
 use App\Jobs\Job;
 use App\Models\Mship\Account;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Log;
 
 class SyncToHelpdesk extends Job implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, LogsJobLifecycle, SerializesModels;
+    use Dispatchable, InteractsWithQueue, LogsJobFailure, SerializesModels;
 
     private $account;
 

--- a/app/Jobs/Mship/SyncToMoodle.php
+++ b/app/Jobs/Mship/SyncToMoodle.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs\Mship;
 
-use App\Jobs\Concerns\LogsJobLifecycle;
+use App\Jobs\Concerns\LogsJobFailure;
 use App\Jobs\Job;
 use App\Models\Mship\Account;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Log;
 
 class SyncToMoodle extends Job implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, LogsJobLifecycle, SerializesModels;
+    use Dispatchable, InteractsWithQueue, LogsJobFailure, SerializesModels;
 
     private $account;
 

--- a/app/Jobs/Mship/SyncToMoodle.php
+++ b/app/Jobs/Mship/SyncToMoodle.php
@@ -2,16 +2,18 @@
 
 namespace App\Jobs\Mship;
 
+use App\Jobs\Concerns\LogsJobLifecycle;
 use App\Jobs\Job;
 use App\Models\Mship\Account;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 
 class SyncToMoodle extends Job implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, SerializesModels;
+    use Dispatchable, InteractsWithQueue, LogsJobLifecycle, SerializesModels;
 
     private $account;
 
@@ -23,5 +25,12 @@ class SyncToMoodle extends Job implements ShouldQueue
     public function handle()
     {
         $this->account->syncUserToMoodle();
+
+        Log::info('Member sync completed', ['service' => 'moodle', 'account_id' => $this->account->id]);
+    }
+
+    protected function logJobContext(): array
+    {
+        return ['account_id' => $this->account->id];
     }
 }

--- a/app/Jobs/SyncUkcpPositions.php
+++ b/app/Jobs/SyncUkcpPositions.php
@@ -83,7 +83,10 @@ class SyncUkcpPositions extends Job
                         ->where('id', '!=', $core->id)
                         ->exists()
                     ) {
-                        Log::warning("SyncUkcpPositions: Skipping callsign update for {$core->callsign} -> {$changes['callsign']} because it would conflict with an existing position.");
+                        Log::warning('SyncUkcpPositions: Skipping callsign update because it would conflict with an existing position', [
+                            'callsign' => $core->callsign,
+                            'new_callsign' => $changes['callsign'],
+                        ]);
                         unset($changes['callsign']);
                     }
 
@@ -133,9 +136,14 @@ class SyncUkcpPositions extends Job
 
         $deleted += $removedCount;
 
-        $dryRunLabel = $this->dryRun ? ' (DRY RUN)' : '';
-
-        Log::info("SyncUkcpPositions complete. Created: {$created}, Updated: {$updated}, Restored: {$restored}, Top-down updated: {$topDownUpdated}, Soft-deleted: {$deleted}{$dryRunLabel}");
+        Log::info('SyncUkcpPositions complete', [
+            'created' => $created,
+            'updated' => $updated,
+            'restored' => $restored,
+            'top_down_updated' => $topDownUpdated,
+            'soft_deleted' => $deleted,
+            'dry_run' => $this->dryRun,
+        ]);
     }
 
     private function syncTopDown(UKCP $ukcp): int

--- a/app/Jobs/Training/ActionExpiredAvailabilityWarningRemoval.php
+++ b/app/Jobs/Training/ActionExpiredAvailabilityWarningRemoval.php
@@ -27,13 +27,13 @@ class ActionExpiredAvailabilityWarningRemoval implements ShouldQueue
         $this->availabilityWarning->refresh();
 
         if ($this->availabilityWarning->status !== 'pending') {
-            Log::info("Availability warning {$this->availabilityWarning->id} is no longer pending, skipping.");
+            Log::info('Availability warning is no longer pending, skipping', ['availability_warning_id' => $this->availabilityWarning->id]);
 
             return;
         }
 
         if ($this->availabilityWarning->expires_at->isFuture()) {
-            Log::info("Availability warning {$this->availabilityWarning->id} has not yet expired, skipping.");
+            Log::info('Availability warning has not yet expired, skipping', ['availability_warning_id' => $this->availabilityWarning->id]);
 
             return;
         }
@@ -41,7 +41,7 @@ class ActionExpiredAvailabilityWarningRemoval implements ShouldQueue
         $trainingPlace = $this->availabilityWarning->trainingPlace;
 
         if (! $trainingPlace) {
-            Log::warning("Training place not found for availability warning {$this->availabilityWarning->id}. Cannot process removal.");
+            Log::warning('Training place not found for availability warning. Cannot process removal', ['availability_warning_id' => $this->availabilityWarning->id]);
 
             return;
         }
@@ -55,12 +55,19 @@ class ActionExpiredAvailabilityWarningRemoval implements ShouldQueue
                 $account->notify(new TrainingPlaceRemovedDueToExpiredAvailability($this->availabilityWarning));
             });
         } catch (Exception $e) {
-            Log::error("Failed to process expired availability warning {$this->availabilityWarning->id}: {$e->getMessage()}. Will be retried on the next run.");
+            Log::error('Failed to process expired availability warning. Will be retried on the next run', [
+                'availability_warning_id' => $this->availabilityWarning->id,
+                'exception' => $e,
+            ]);
             $this->fail($e);
 
             return;
         }
 
-        Log::info("Training place {$trainingPlace->id} removed due to expired availability warning {$this->availabilityWarning->id}. Account {$account->id} notified.");
+        Log::info('Training place removed due to expired availability warning, account notified', [
+            'training_place_id' => $trainingPlace->id,
+            'availability_warning_id' => $this->availabilityWarning->id,
+            'account_id' => $account->id,
+        ]);
     }
 }

--- a/app/Jobs/Training/ActionFourthAvailabilityFailureRemoval.php
+++ b/app/Jobs/Training/ActionFourthAvailabilityFailureRemoval.php
@@ -31,7 +31,7 @@ class ActionFourthAvailabilityFailureRemoval implements ShouldQueue
         $this->availabilityWarning->refresh();
 
         if ($this->availabilityWarning->status !== 'pending') {
-            Log::info("Availability warning {$this->availabilityWarning->id} is no longer pending, skipping fourth-failure removal.");
+            Log::info('Availability warning is no longer pending, skipping fourth-failure removal', ['availability_warning_id' => $this->availabilityWarning->id]);
 
             return;
         }
@@ -39,7 +39,7 @@ class ActionFourthAvailabilityFailureRemoval implements ShouldQueue
         $trainingPlace = $this->availabilityWarning->trainingPlace;
 
         if (! $trainingPlace) {
-            Log::warning("Training place not found for availability warning {$this->availabilityWarning->id}. Cannot process fourth-failure removal.");
+            Log::warning('Training place not found for availability warning. Cannot process fourth-failure removal', ['availability_warning_id' => $this->availabilityWarning->id]);
 
             return;
         }
@@ -53,12 +53,19 @@ class ActionFourthAvailabilityFailureRemoval implements ShouldQueue
                 $account->notify(new TrainingPlaceRemovedDueToFourthAvailabilityFailure($this->availabilityWarning));
             });
         } catch (Exception $e) {
-            Log::error("Failed to process fourth availability failure {$this->availabilityWarning->id}: {$e->getMessage()}. Will be retried on the next run.");
+            Log::error('Failed to process fourth availability failure. Will be retried on the next run', [
+                'availability_warning_id' => $this->availabilityWarning->id,
+                'exception' => $e,
+            ]);
             $this->fail($e);
 
             return;
         }
 
-        Log::info("Training place {$trainingPlace->id} removed due to fourth availability failure {$this->availabilityWarning->id}. Account {$account->id} notified.");
+        Log::info('Training place removed due to fourth availability failure, account notified', [
+            'training_place_id' => $trainingPlace->id,
+            'availability_warning_id' => $this->availabilityWarning->id,
+            'account_id' => $account->id,
+        ]);
     }
 }

--- a/app/Jobs/Training/ActionWaitingListRetentionCheckRemoval.php
+++ b/app/Jobs/Training/ActionWaitingListRetentionCheckRemoval.php
@@ -35,7 +35,7 @@ class ActionWaitingListRetentionCheckRemoval implements ShouldQueue
     public function handle()
     {
         if (! $this->retentionCheck->waitingListAccount) {
-            Log::warning("WaitingListAccount not found for retention check {$this->retentionCheck->id}. Cannot remove from waiting list.");
+            Log::warning('WaitingListAccount not found for retention check. Cannot remove from waiting list', ['retention_check_id' => $this->retentionCheck->id]);
 
             return;
         }
@@ -45,7 +45,11 @@ class ActionWaitingListRetentionCheckRemoval implements ShouldQueue
         try {
             $account->notify(new RemovedFromWaitingListFailedRetention($this->retentionCheck));
         } catch (Exception $e) {
-            Log::error("Failed to notify account {$account->id} of failed retention check {$this->retentionCheck->id}: {$e->getMessage()}");
+            Log::error('Failed to notify account of failed retention check', [
+                'account_id' => $account->id,
+                'retention_check_id' => $this->retentionCheck->id,
+                'exception' => $e,
+            ]);
             // deliberately return here to avoid removing the account from the waiting list
             $this->fail($e);
 
@@ -64,7 +68,11 @@ class ActionWaitingListRetentionCheckRemoval implements ShouldQueue
                 });
         }
 
-        Log::info("Member {$account->id} was removed from waiting list  {$waitingList->id} due to failed retention check {$this->retentionCheck->id}");
+        Log::info('Member was removed from waiting list due to failed retention check', [
+            'account_id' => $account->id,
+            'waiting_list_id' => $waitingList->id,
+            'retention_check_id' => $this->retentionCheck->id,
+        ]);
 
         WaitingListRetentionChecks::markRetentionCheckAsExpired($this->retentionCheck);
     }

--- a/app/Jobs/Training/SendWaitingListRetentionCheck.php
+++ b/app/Jobs/Training/SendWaitingListRetentionCheck.php
@@ -39,7 +39,11 @@ class SendWaitingListRetentionCheck implements ShouldQueue
         try {
             $this->waitingListAccount->account->notify(new WaitingListRetentionCheckAccountNotification($retentionCheck));
         } catch (Exception $e) {
-            Log::error("Failed to notify account {$this->waitingListAccount->account->id} of retention check {$retentionCheck->id}: {$e->getMessage()}");
+            Log::error('Failed to notify account of retention check', [
+                'account_id' => $this->waitingListAccount->account->id,
+                'retention_check_id' => $retentionCheck->id,
+                'exception' => $e,
+            ]);
             DB::rollBack();
             $this->fail($e);
 

--- a/app/Jobs/UpdateMember.php
+++ b/app/Jobs/UpdateMember.php
@@ -58,7 +58,7 @@ class UpdateMember extends Job implements ShouldQueue
         try {
             $member = Account::findOrFail(['id' => $this->accountID])->first();
         } catch (ModelNotFoundException $e) {
-            Log::debug("Member {$this->accountID} not found in database. Auth needed to fetch data.");
+            Log::debug('Member not found in database. Auth needed to fetch data', ['account_id' => $this->accountID]);
 
             return;
         }
@@ -72,7 +72,7 @@ class UpdateMember extends Job implements ShouldQueue
             ])->withUserAgent('VATSIMUK')->get($url);
 
             if ($response->status() === 404) {
-                Log::info("Member {$this->accountID} not found in VATSIM API. Deleting.");
+                Log::info('Member not found in VATSIM API. Deleting', ['account_id' => $this->accountID]);
                 $member->delete();
 
                 return;
@@ -102,6 +102,7 @@ class UpdateMember extends Job implements ShouldQueue
                 'cid' => $response['id'],
             ];
         } catch (\Exception $e) {
+            Log::error('Member update failed', ['account_id' => $this->accountID, 'exception' => $e]);
             Bugsnag::notifyException($e, function ($report) {
                 $report->setSeverity('error');
                 $report->setMetaData([
@@ -231,7 +232,7 @@ class UpdateMember extends Job implements ShouldQueue
         foreach ($pilotRatings as $pr) {
             if (! $member->hasQualification($pr)) {
                 $member->addQualification($pr);
-                Log::debug("Added rating {$pr->code} to member {$member->id}");
+                Log::debug('Added rating to member', ['rating_code' => $pr->code, 'account_id' => $member->id]);
             }
         }
 
@@ -244,7 +245,7 @@ class UpdateMember extends Job implements ShouldQueue
 
         $pilotRatingsCollection = collect($pilotRatings);
         foreach ($memberPilotRatings as $mpr) {
-            Log::debug("Checking pilot rating {$mpr->code} for member {$member->id}");
+            Log::debug('Checking pilot rating for member', ['rating_code' => $mpr->code, 'account_id' => $member->id]);
 
             if (! $pilotRatingsCollection->contains($mpr->code) && $mpr->code != 'P0') {
                 $member->removeQualification($mpr);
@@ -255,7 +256,7 @@ class UpdateMember extends Job implements ShouldQueue
         foreach ($militaryRatings as $militaryRating) {
             if (! $member->hasQualification($militaryRating)) {
                 $member->addQualification($militaryRating);
-                Log::debug("Added military rating {$militaryRating->code} to member {$member->id}");
+                Log::debug('Added military rating to member', ['rating_code' => $militaryRating->code, 'account_id' => $member->id]);
             }
         }
 

--- a/app/Libraries/Discord.php
+++ b/app/Libraries/Discord.php
@@ -499,7 +499,10 @@ class Discord
         }
 
         $choicesCount = count($commandPayload['options'][0]['choices'] ?? []);
-        Log::info("Synced /{$commandPayload['name']} command with {$choicesCount} choices");
+        Log::info('Synced slash command with choices', [
+            'command' => $commandPayload['name'],
+            'choices_count' => $choicesCount,
+        ]);
     }
 
     /**

--- a/app/Libraries/TeamSpeak.php
+++ b/app/Libraries/TeamSpeak.php
@@ -116,6 +116,8 @@ class TeamSpeak
             $customInfo = $client->customInfo();
         } catch (TeamSpeak3Exception $e) {
             if ($e->getCode() !== self::DATABASE_EMPTY_RESULT_SET) {
+                Log::error('Failed to retrieve TeamSpeak client custom info', ['exception' => $e]);
+
                 throw $e;
             } else {
                 return;
@@ -205,12 +207,26 @@ class TeamSpeak
         if ($member->is_network_banned) {
             $duration = 60 * 60 * 12; // 12 hours
             self::banClient($client, trans('teamspeak.ban.network.ban'), $duration);
+            Log::info('TeamSpeak client banned: network ban', [
+                'client_db_id' => $client['client_database_id'],
+                'account_id' => $member->id,
+                'duration' => $duration,
+            ]);
         } elseif ($member->is_system_banned) {
             self::kickClient($client, trans('teamspeak.ban.system.ban'));
             sleep(2);
             $duration = $member->system_ban->period_left;
             self::banClient($client, trans('teamspeak.ban.system.ban'), $duration);
+            Log::info('TeamSpeak client kicked and banned: system ban', [
+                'client_db_id' => $client['client_database_id'],
+                'account_id' => $member->id,
+                'duration' => $duration,
+            ]);
         } elseif ($member->is_inactive) {
+            Log::info('TeamSpeak client deactivated: member inactive', [
+                'client_db_id' => $client['client_database_id'],
+                'account_id' => $member->id,
+            ]);
             self::deactivateClient($client, trans('teamspeak.inactive'));
         }
     }
@@ -239,6 +255,10 @@ class TeamSpeak
             } else {
                 self::pokeClient($client, trans('teamspeak.notification.mandatory.poke'));
                 self::kickClient($client, trans('teamspeak.notification.mandatory.kick'));
+                Log::info('TeamSpeak client kicked: mandatory notification not acknowledged', [
+                    'client_db_id' => $client['client_database_id'],
+                    'account_id' => $member->id,
+                ]);
                 throw new ClientKickedFromServerException;
             }
         } elseif ($member->has_unread_important_notifications) {
@@ -284,6 +304,10 @@ class TeamSpeak
             self::pokeClient($client, trans('teamspeak.nickname.invalid.poke1'));
             self::pokeClient($client, trans('teamspeak.nickname.invalid.poke2'));
             self::kickClient($client, trans('teamspeak.nickname.invalid.kick'));
+            Log::info('TeamSpeak client kicked: invalid nickname', [
+                'client_db_id' => $client['client_database_id'],
+                'account_id' => $member->id,
+            ]);
             Cache::forget(self::CACHE_NICKNAME_PARTIALLY_CORRECT.$client['client_database_id']);
             Cache::forget(self::CACHE_NICKNAME_PARTIALLY_CORRECT_GRACE.$client['client_database_id']);
             throw new ClientKickedFromServerException;
@@ -310,13 +334,24 @@ class TeamSpeak
                 $qualifiesForGroup = $memberHasRequiredQualification || $memberHasGroupPermission;
                 $alreadyInGroup = in_array($group->dbid, $currentGroups);
 
-                Log::info("Account {$member->id} qualifies for group {$group->name}: {$qualifiesForGroup}, alreadyInGroup: {$alreadyInGroup}");
+                Log::debug('Account group qualification evaluated', [
+                    'account_id' => $member->id,
+                    'group_name' => $group->name,
+                    'qualifies_for_group' => $qualifiesForGroup,
+                    'already_in_group' => $alreadyInGroup,
+                ]);
 
                 if ($qualifiesForGroup && ! $alreadyInGroup) {
-                    Log::info("servergroupaddclient sgid={$group->dbid} cldbid={$client['client_database_id']}");
+                    Log::info('servergroupaddclient', [
+                        'sgid' => $group->dbid,
+                        'cldbid' => $client['client_database_id'],
+                    ]);
                     $client->request("servergroupaddclient sgid={$group->dbid} cldbid={$client['client_database_id']}");
                 } elseif (! $group->default && $alreadyInGroup && ! $qualifiesForGroup) {
-                    Log::info("servergroupdelclient sgid={$group->dbid} cldbid={$client['client_database_id']}");
+                    Log::info('servergroupdelclient', [
+                        'sgid' => $group->dbid,
+                        'cldbid' => $client['client_database_id'],
+                    ]);
                     $client->request("servergroupdelclient sgid={$group->dbid} cldbid={$client['client_database_id']}");
                 }
             } catch (ServerQueryException $e) {
@@ -364,6 +399,8 @@ class TeamSpeak
                 if ($e->getCode() == self::DATABASE_EMPTY_RESULT_SET) {
                     $currentGroup = $defaultGroup->dbid;
                 } else {
+                    Log::error('Failed to retrieve TeamSpeak client channel group', ['exception' => $e]);
+
                     throw $e;
                 }
             }
@@ -490,7 +527,13 @@ class TeamSpeak
         self::pokeClient($client, $reason);
         self::kickClient($client, $reason);
         $client->deleteDb();
-        self::getActiveRegistration($client)->delete($client->getParent());
+        $registration = self::getActiveRegistration($client);
+        $registration->delete($client->getParent());
+        Log::info('TeamSpeak client deactivated: removed from server and registration deleted', [
+            'client_db_id' => $client['client_database_id'],
+            'account_id' => $registration->account_id,
+            'reason' => $reason,
+        ]);
         throw new ClientKickedFromServerException;
     }
 }

--- a/app/Libraries/UKCP.php
+++ b/app/Libraries/UKCP.php
@@ -74,7 +74,7 @@ class UKCP
                 'Authorization' => 'Bearer '.$this->apiKey,
             ]]);
         } catch (ClientException $e) {
-            Log::debug('UKCP account not found for user.', [
+            Log::warning('Failed to fetch UKCP account for user.', [
                 'exception' => $e,
                 'account_id' => $account->id,
             ]);
@@ -148,7 +148,7 @@ class UKCP
 
             return json_decode($result->getBody()->getContents(), true);
         } catch (ClientException $e) {
-            Log::debug('UKCP notifications not found for user.', [
+            Log::warning('Failed to fetch UKCP notifications for user.', [
                 'exception' => $e,
                 'account_id' => $account->id,
             ]);

--- a/app/Libraries/UKCP.php
+++ b/app/Libraries/UKCP.php
@@ -55,7 +55,11 @@ class UKCP
                 'Authorization' => 'Bearer '.$this->apiKey,
             ]]);
         } catch (ClientException $e) {
-            Log::info("UKCP Client Exception $e when getting user account {$account->id}");
+            Log::error('UKCP client exception while deleting token.', [
+                'exception' => $e,
+                'account_id' => $account->id,
+                'token_id' => $tokenId,
+            ]);
 
             return false;
         }
@@ -70,7 +74,10 @@ class UKCP
                 'Authorization' => 'Bearer '.$this->apiKey,
             ]]);
         } catch (ClientException $e) {
-            Log::info("UKCP Client Exception {$e->getMessage()} when getting user account {$account->id}");
+            Log::debug('UKCP account not found for user.', [
+                'exception' => $e,
+                'account_id' => $account->id,
+            ]);
 
             return;
         }
@@ -120,7 +127,10 @@ class UKCP
                 return [];
             }
 
-            Log::warning("UKCP Client Error {$e->getMessage()} when getting stand status for {$airfield}");
+            Log::error('Failed to fetch UKCP stand status.', [
+                'exception' => $e,
+                'airfield' => $airfield,
+            ]);
 
             return [];
         }
@@ -138,7 +148,10 @@ class UKCP
 
             return json_decode($result->getBody()->getContents(), true);
         } catch (ClientException $e) {
-            Log::info("UKCP Client Exception {$e->getMessage()} when getting notifications");
+            Log::debug('UKCP notifications not found for user.', [
+                'exception' => $e,
+                'account_id' => $account->id,
+            ]);
 
             return [];
         }
@@ -157,7 +170,11 @@ class UKCP
             return true;
         } catch (ClientException $e) {
             dd($e);
-            Log::info("UKCP Client Exception {$e->getMessage()} when marking notification read");
+            Log::error('Failed to mark UKCP notification as read.', [
+                'exception' => $e,
+                'account_id' => $account->id,
+                'notification_id' => $notificationId,
+            ]);
 
             return [];
         }
@@ -186,7 +203,9 @@ class UKCP
 
             return collect(json_decode($response->getBody()->getContents()));
         } catch (ClientException|GuzzleException $e) {
-            Log::error("UKCP Client Exception when fetching controller positions: {$e->getMessage()}");
+            Log::error('Failed to fetch UKCP controller positions.', [
+                'exception' => $e,
+            ]);
 
             return collect();
         }
@@ -215,7 +234,9 @@ class UKCP
 
             return collect(json_decode($response->getBody()->getContents()));
         } catch (ClientException|GuzzleException $e) {
-            Log::error("UKCP Client Exception when fetching controller positions v2: {$e->getMessage()}");
+            Log::error('Failed to fetch UKCP controller positions (v2 dependency).', [
+                'exception' => $e,
+            ]);
 
             return collect();
         }

--- a/app/Libraries/UKCP.php
+++ b/app/Libraries/UKCP.php
@@ -169,7 +169,6 @@ class UKCP
 
             return true;
         } catch (ClientException $e) {
-            dd($e);
             Log::error('Failed to mark UKCP notification as read.', [
                 'exception' => $e,
                 'account_id' => $account->id,

--- a/app/Listeners/Mship/CheckEmailPreferences.php
+++ b/app/Listeners/Mship/CheckEmailPreferences.php
@@ -25,7 +25,11 @@ class CheckEmailPreferences
 
         if (! $notifiable->isEmailEnabled($emailType)) {
             $notifiableId = method_exists($notifiable, 'getKey') ? $notifiable->getKey() : '?';
-            Log::info("Email suppressed for account {$notifiableId}: {$emailType->value} ({$emailType->label()})");
+            Log::info('Email suppressed for account', [
+                'account_id' => $notifiableId,
+                'email_type' => $emailType->value,
+                'email_type_label' => $emailType->label(),
+            ]);
 
             return false;
         }

--- a/app/Listeners/Training/Endorsement/CreateEndorsementFromApproval.php
+++ b/app/Listeners/Training/Endorsement/CreateEndorsementFromApproval.php
@@ -15,15 +15,23 @@ class CreateEndorsementFromApproval
         $endorsementRequest = $event->getEndorsementRequest();
         $endorsableEntity = $endorsementRequest->endorsable;
 
-        Endorsement::create([
+        $createdBy = auth()->id();
+
+        $endorsement = Endorsement::create([
             'account_id' => $endorsementRequest->account_id,
             'endorsement_request_id' => $endorsementRequest->id,
-            'created_by' => auth()->id(),
+            'created_by' => $createdBy,
             'endorsable_type' => $endorsableEntity::class,
             'endorsable_id' => $endorsableEntity->id,
             'expires_at' => $event->getExpiryDate(),
         ]);
 
         $endorsementRequest->markApproved();
+
+        audit('Endorsement created from approval', [
+            'account_id' => $endorsementRequest->account_id,
+            'endorsement_id' => $endorsement->id,
+            'created_by' => $createdBy,
+        ]);
     }
 }

--- a/app/Listeners/Training/WaitingList/CheckWaitingListAccountInactivity.php
+++ b/app/Listeners/Training/WaitingList/CheckWaitingListAccountInactivity.php
@@ -17,28 +17,34 @@ class CheckWaitingListAccountInactivity
      */
     public function handle(AccountAltered $event)
     {
-        Log::debug("CheckWaitingListAccountInactivity listener triggered for account {$event->account->id}");
+        Log::debug('CheckWaitingListAccountInactivity listener triggered for account', ['account_id' => $event->account->id]);
         $account = $event->account->refresh();
 
         if (! $account->is_inactive) {
-            Log::debug("Account {$account->id} is not inactive, skipping");
+            Log::debug('Account is not inactive, skipping', ['account_id' => $account->id]);
 
             return;
         }
 
         if ($account->currentWaitingLists()->count() == 0) {
-            Log::debug("Inactive account {$account->id} is not in a waiting list, skipping");
+            Log::debug('Inactive account is not in a waiting list, skipping', ['account_id' => $account->id]);
 
             return;
         }
 
         foreach ($account->currentWaitingLists() as $waitingList) {
-            Log::info("Inactive account {$account->id} is in waiting list {$waitingList->id} - removing from waiting list");
+            Log::info('Inactive account is in waiting list - removing from waiting list', [
+                'account_id' => $account->id,
+                'waiting_list_id' => $waitingList->id,
+            ]);
 
             $waitingList->removeFromWaitingList($account, new Removal(RemovalReason::Inactivity, null));
         }
 
-        Log::info("Account {$account->id} is in waiting lists {$account->currentWaitingLists()->pluck('id')->join(', ')}, with inactive account state - (fake) notifying account");
+        Log::info('Account is in waiting lists with inactive account state - (fake) notifying account', [
+            'account_id' => $account->id,
+            'waiting_list_ids' => $account->currentWaitingLists()->pluck('id')->join(', '),
+        ]);
 
         $account->notify(new RemovedFromWaitingListInactiveAccount($account->currentWaitingLists()));
     }

--- a/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
+++ b/app/Listeners/Training/WaitingList/CheckWaitingListAccountMshipState.php
@@ -17,7 +17,7 @@ class CheckWaitingListAccountMshipState
      */
     public function handle(AccountAltered $event)
     {
-        Log::debug("CheckWaitingListAccountMshipState listener triggered for account {$event->account->id}");
+        Log::debug('CheckWaitingListAccountMshipState listener triggered for account', ['account_id' => $event->account->id]);
         // ensure we have the latest data
         $account = $event->account->refresh();
 
@@ -26,24 +26,30 @@ class CheckWaitingListAccountMshipState
         });
 
         if ($account->hasState(State::findByCode('DIVISION'))) {
-            Log::debug("Account {$account->id} has DIVISION state, skipping removal from waiting list");
+            Log::debug('Account has DIVISION state, skipping removal from waiting list', ['account_id' => $account->id]);
 
             return;
         }
 
         if ($accountsWaitingList->count() == 0) {
-            Log::debug("Account {$account->id} is not in a 'home members only' waiting list, skipping.");
+            Log::debug("Account is not in a 'home members only' waiting list, skipping", ['account_id' => $account->id]);
 
             return;
         }
 
         foreach ($accountsWaitingList as $waitingList) {
-            Log::info("Account {$account->id} is in waiting list {$waitingList->id}, with non-home member state - removing from waiting list");
+            Log::info('Account is in waiting list with non-home member state - removing from waiting list', [
+                'account_id' => $account->id,
+                'waiting_list_id' => $waitingList->id,
+            ]);
 
             $waitingList->removeFromWaitingList($account, new WaitingList\Removal(WaitingList\RemovalReason::NonHome, null));
         }
 
-        Log::info("Account {$account->id} is in waiting lists {$accountsWaitingList->pluck('id')->join(', ')}, with non-home member state - notifying account");
+        Log::info('Account is in waiting lists with non-home member state - notifying account', [
+            'account_id' => $account->id,
+            'waiting_list_ids' => $accountsWaitingList->pluck('id')->join(', '),
+        ]);
 
         $account->notify(new RemovedFromWaitingListNonHomeMember($accountsWaitingList));
     }

--- a/app/Listeners/Training/WaitingList/LogAccountAdded.php
+++ b/app/Listeners/Training/WaitingList/LogAccountAdded.php
@@ -26,6 +26,7 @@ class LogAccountAdded
         audit('Account added to waiting list', [
             'account_id' => $event->account->id,
             'waiting_list_id' => $event->waitingList->id,
+            'staff_id' => $event->staffAccount->id,
         ]);
     }
 }

--- a/app/Listeners/Training/WaitingList/LogAccountAdded.php
+++ b/app/Listeners/Training/WaitingList/LogAccountAdded.php
@@ -3,7 +3,6 @@
 namespace App\Listeners\Training\WaitingList;
 
 use App\Events\Training\AccountAddedToWaitingList;
-use Illuminate\Support\Facades\Log;
 
 class LogAccountAdded
 {
@@ -24,7 +23,9 @@ class LogAccountAdded
      */
     public function handle(AccountAddedToWaitingList $event)
     {
-        Log::channel('training')
-            ->info("Account {$event->account} ({$event->account->id}) was added to {$event->waitingList} by {$event->staffAccount} ({$event->staffAccount->id})");
+        audit('Account added to waiting list', [
+            'account_id' => $event->account->id,
+            'waiting_list_id' => $event->waitingList->id,
+        ]);
     }
 }

--- a/app/Listeners/Training/WaitingList/LogAccountRemoved.php
+++ b/app/Listeners/Training/WaitingList/LogAccountRemoved.php
@@ -3,7 +3,6 @@
 namespace App\Listeners\Training\WaitingList;
 
 use App\Events\Training\AccountRemovedFromWaitingList;
-use Illuminate\Support\Facades\Log;
 
 class LogAccountRemoved
 {
@@ -24,7 +23,9 @@ class LogAccountRemoved
      */
     public function handle(AccountRemovedFromWaitingList $event)
     {
-        Log::channel('training')
-            ->info("Account {$event->account} ({$event->account->id}) was removed from {$event->waitingList} by {$event->staffAccount} ({$event->staffAccount->id})");
+        audit('Account removed from waiting list', [
+            'account_id' => $event->account->id,
+            'waiting_list_id' => $event->waitingList->id,
+        ]);
     }
 }

--- a/app/Listeners/Training/WaitingList/LogAccountRemoved.php
+++ b/app/Listeners/Training/WaitingList/LogAccountRemoved.php
@@ -26,6 +26,7 @@ class LogAccountRemoved
         audit('Account removed from waiting list', [
             'account_id' => $event->account->id,
             'waiting_list_id' => $event->waitingList->id,
+            'staff_id' => $event->staffAccount->id,
         ]);
     }
 }

--- a/app/Listeners/Training/WaitingList/LogNoteChanged.php
+++ b/app/Listeners/Training/WaitingList/LogNoteChanged.php
@@ -3,7 +3,6 @@
 namespace App\Listeners\Training\WaitingList;
 
 use App\Events\Training\AccountNoteChanged;
-use Illuminate\Support\Facades\Log;
 
 class LogNoteChanged
 {
@@ -14,8 +13,11 @@ class LogNoteChanged
      */
     public function handle(AccountNoteChanged $event)
     {
-        Log::channel('training')
-            ->info("A note about {$event->account->name} ({$event->account->id}) in waiting list {$event->waitingListAccount->waitingList->name} ({$event->waitingListAccount->waitingList->id}) was changed from
-            {$event->oldNoteContent} to {$event->newNoteContent}");
+        audit('Waiting list note changed', [
+            'account_id' => $event->account->id,
+            'waiting_list_id' => $event->waitingListAccount->waitingList->id,
+            'old_note' => $event->oldNoteContent,
+            'new_note' => $event->newNoteContent,
+        ]);
     }
 }

--- a/app/Listeners/Training/WaitingListEventSubscriber.php
+++ b/app/Listeners/Training/WaitingListEventSubscriber.php
@@ -4,6 +4,13 @@ namespace App\Listeners\Training;
 
 use Illuminate\Support\Facades\Log;
 
+// FIXME (logging plan, out of scope): this subscriber is not registered anywhere
+// (EventServiceProvider::$subscribe only wires SyncSubscriber), so it is dead code.
+// As a result, the promoted/demoted/status-change waiting-list events below are
+// currently NOT written to any audit log. Additionally, subscribe() below calls
+// `$event->listen(...)` instead of `$events->listen(...)` for the status-change
+// registration, a pre-existing bug that would break that registration even if this
+// subscriber were wired up. Both issues are left untouched here - out of scope.
 class WaitingListEventSubscriber
 {
     public function accountAdded($event)

--- a/app/Models/Cts/TheoryResult.php
+++ b/app/Models/Cts/TheoryResult.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Log;
 
 class TheoryResult extends Model
 {
@@ -43,7 +44,7 @@ class TheoryResult extends Model
         try {
             $memberId = Member::where('cid', $account_id)->firstOrFail()->id;
         } catch (ModelNotFoundException) {
-            Log::warning("No member found for account_id {$account_id}. Likely sync problems.");
+            Log::warning('No member found for account_id. Likely sync problems', ['account_id' => $account_id]);
 
             return null;
         }

--- a/app/Models/Mship/Concerns/HasDiscordAccount.php
+++ b/app/Models/Mship/Concerns/HasDiscordAccount.php
@@ -102,7 +102,9 @@ trait HasDiscordAccount
 
             // Only call the API if roles actually changed
             if ($this->rolesNeedUpdate($currentRoles, $targetRoles)) {
-                Log::info("Updating Discord roles for {$this->full_name} ({$this->getKey()})", [
+                Log::info('Updating Discord roles for account', [
+                    'name' => $this->full_name,
+                    'account_id' => $this->getKey(),
                     'current' => $currentRoles->toArray(),
                     'target' => $targetRoles->toArray(),
                 ]);

--- a/app/Models/Mship/Concerns/HasQualifications.php
+++ b/app/Models/Mship/Concerns/HasQualifications.php
@@ -65,7 +65,7 @@ trait HasQualifications
     public function removeQualification(Qualification $qualification)
     {
         if ($this->hasQualification($qualification)) {
-            Log::info("Removing qualification {$qualification->code} from member {$this->id}");
+            Log::info('Removing qualification from member', ['qualification_code' => $qualification->code, 'account_id' => $this->id]);
 
             $memberQualificationPivot = $this->qualifications_pilot->where('code', $qualification->code)->first()->pivot;
 

--- a/app/Notifications/DiscordNotificationChannel.php
+++ b/app/Notifications/DiscordNotificationChannel.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Libraries\Discord;
+use Illuminate\Support\Facades\Log;
 
 class DiscordNotificationChannel
 {
@@ -11,6 +12,8 @@ class DiscordNotificationChannel
         $messageContents = $notification->toDiscord($notifiable);
 
         $discordClient = new Discord;
+
+        Log::info('Sending Discord notification', ['channel_id' => $notification->getChannel()]);
         $discordClient->sendMessageToChannel($notification->getChannel(), $messageContents);
     }
 }

--- a/app/Services/Discord/HoneypotService.php
+++ b/app/Services/Discord/HoneypotService.php
@@ -27,7 +27,10 @@ class HoneypotService
         $account = Account::where('discord_id', $discordUserId)->first();
 
         if (! $account) {
-            Log::warning("Honeypot message from unlinked Discord user {$discordUsername} ({$discordUserId}), skipping");
+            Log::warning('Honeypot message from unlinked Discord user, skipping', [
+                'discord_username' => $discordUsername,
+                'discord_id' => $discordUserId,
+            ]);
 
             $this->discord->deleteMessage(
                 channelId: config('services.discord.honeypot_channel_id'),
@@ -41,12 +44,22 @@ class HoneypotService
             'account_id' => $account->id,
         ]);
 
-        Log::info("Honeypot triggered by {$discordUsername} ({$discordUserId}) linked to account {$account->id}");
+        Log::info('Honeypot triggered by Discord user linked to account', [
+            'discord_username' => $discordUsername,
+            'discord_id' => $discordUserId,
+            'account_id' => $account->id,
+        ]);
 
         $this->discord->softBan($account, 7, 'Honeypot');
 
         $noteType = NoteType::isShortCode('discipline')->first();
         $account->addNote($noteType, 'User sent a message in the honeypot channel, recent messages have been deleted and user has been timed out for 7 days', null);
+
+        Log::info('Honeypot soft-ban applied', [
+            'account_id' => $account->id,
+            'discord_id' => $discordUserId,
+            'action' => 'soft_ban',
+        ]);
 
         $this->discord->sendMessageToChannel(
             channelId: config('services.discord.moderators_chat_channel_id'),
@@ -58,7 +71,7 @@ class HoneypotService
         $honeypotMessageData = Cache::get('discord:honeypot:bot_message');
 
         if (! $honeypotMessageData) {
-            \Log::warning('Cached honeypoot bot message not found');
+            Log::warning('Cached honeypot bot message not found');
 
             return;
         }

--- a/app/Services/Mship/AddNote.php
+++ b/app/Services/Mship/AddNote.php
@@ -27,6 +27,11 @@ class AddNote implements BaseService
 
     public function handle()
     {
-        $this->account->addNote($this->noteType, $this->noteContent, $this->noteTaker);
+        $note = $this->account->addNote($this->noteType, $this->noteContent, $this->noteTaker);
+
+        audit('Note added to account', [
+            'account_id' => $this->account->id,
+            'note_id' => $note->id,
+        ]);
     }
 }

--- a/app/Services/Mship/BanAccount.php
+++ b/app/Services/Mship/BanAccount.php
@@ -41,6 +41,13 @@ class BanAccount implements BaseService
         );
 
         $this->account->notify(new BanCreated($this->ban));
+
+        audit('Account banned', [
+            'account_id' => $this->account->id,
+            'ban_id' => $this->ban->id,
+            'ban_type' => $this->ban->type->name,
+            'reason' => $this->reason->name,
+        ]);
     }
 
     public function getBanIdentifier()

--- a/app/Services/Mship/RepealBan.php
+++ b/app/Services/Mship/RepealBan.php
@@ -20,5 +20,10 @@ class RepealBan implements BaseService
         $this->ban->repeal();
 
         $this->ban->account->notify(new BanRepealed($this->ban));
+
+        audit('Ban repealed', [
+            'account_id' => $this->ban->account_id,
+            'ban_id' => $this->ban->id,
+        ]);
     }
 }

--- a/app/Services/Roles/DelegateRoleManagementService.php
+++ b/app/Services/Roles/DelegateRoleManagementService.php
@@ -25,17 +25,33 @@ class DelegateRoleManagementService
             'name' => $this->delegatePermissionName($role),
             'guard_name' => 'web',
         ]);
+
+        audit('Delegate permission changed', [
+            'role_id' => $role->id,
+            'action' => 'granted',
+        ]);
     }
 
     public function deleteDelegatePermission(Role $role): void
     {
         Permission::where('name', $this->delegatePermissionName($role))->delete();
+
+        audit('Delegate permission changed', [
+            'role_id' => $role->id,
+            'action' => 'revoked',
+        ]);
     }
 
     public function revokeDelegate(Account $account, Role $role): void
     {
         $permissionName = $this->delegatePermissionName($role);
         $account->revokePermissionTo($permissionName);
+
+        audit('Delegate permission changed', [
+            'account_id' => $account->id,
+            'role_id' => $role->id,
+            'action' => 'revoked',
+        ]);
     }
 
     public function getPotentialDelegates(string $search): array

--- a/app/Services/Roles/DelegateRoleManagementService.php
+++ b/app/Services/Roles/DelegateRoleManagementService.php
@@ -34,24 +34,29 @@ class DelegateRoleManagementService
 
     public function deleteDelegatePermission(Role $role): void
     {
-        Permission::where('name', $this->delegatePermissionName($role))->delete();
+        $deleted = Permission::where('name', $this->delegatePermissionName($role))->delete();
 
-        audit('Delegate permission changed', [
-            'role_id' => $role->id,
-            'action' => 'revoked',
-        ]);
+        if ($deleted > 0) {
+            audit('Delegate permission changed', [
+                'role_id' => $role->id,
+                'action' => 'revoked',
+            ]);
+        }
     }
 
     public function revokeDelegate(Account $account, Role $role): void
     {
         $permissionName = $this->delegatePermissionName($role);
-        $account->revokePermissionTo($permissionName);
 
-        audit('Delegate permission changed', [
-            'account_id' => $account->id,
-            'role_id' => $role->id,
-            'action' => 'revoked',
-        ]);
+        if ($account->hasPermissionTo($permissionName)) {
+            $account->revokePermissionTo($permissionName);
+
+            audit('Delegate permission changed', [
+                'account_id' => $account->id,
+                'role_id' => $role->id,
+                'action' => 'revoked',
+            ]);
+        }
     }
 
     public function getPotentialDelegates(string $search): array

--- a/app/Services/TeamSpeak/AtcServerGroupService.php
+++ b/app/Services/TeamSpeak/AtcServerGroupService.php
@@ -20,7 +20,7 @@ class AtcServerGroupService
             ->first();
 
         if (! $registration) {
-            Log::warning("No TS registration for account {$account->id}, skipping ATC group assign.");
+            Log::warning('No TS registration for account, skipping ATC group assign', ['account_id' => $account->id]);
 
             return;
         }
@@ -35,7 +35,11 @@ class AtcServerGroupService
             ['atc_server_group_id' => $group->id]
         );
 
-        Log::info("Assigned account {$account->id} to ATC group '{$callsign}' (sgid={$group->ts_sgid})");
+        Log::info('Assigned account to ATC group', [
+            'account_id' => $account->id,
+            'callsign' => $callsign,
+            'sgid' => $group->ts_sgid,
+        ]);
     }
 
     public function releaseExisting(Account $account, Server $server): void
@@ -58,9 +62,16 @@ class AtcServerGroupService
         if ($registration) {
             try {
                 $server->request("servergroupdelclient sgid={$group->ts_sgid} cldbid={$registration->dbid}");
-                Log::info("Removed account {$account->id} from ATC group '{$group->callsign}' (sgid={$group->ts_sgid})");
+                Log::info('Removed account from ATC group', [
+                    'account_id' => $account->id,
+                    'callsign' => $group->callsign,
+                    'sgid' => $group->ts_sgid,
+                ]);
             } catch (ServerQueryException $e) {
-                Log::warning("servergroupdelclient failed for account {$account->id}: {$e->getMessage()}");
+                Log::warning('servergroupdelclient failed for account', [
+                    'account_id' => $account->id,
+                    'exception' => $e,
+                ]);
             }
         }
 
@@ -127,13 +138,13 @@ class AtcServerGroupService
             // Set the server group to display in front of the username
             $server->request("servergroupaddperm sgid={$sgid} permsid=i_group_show_name_in_tree permvalue=1 permnegated=0 permskip=1");
 
-            Log::info("Created ATC server group '{$callsign}' with sgid={$sgid}");
+            Log::info('Created ATC server group', ['callsign' => $callsign, 'sgid' => $sgid]);
         }
 
         try {
             return AtcServerGroup::create(['callsign' => $callsign, 'ts_sgid' => $sgid]);
         } catch (\Illuminate\Database\QueryException $e) {
-            Log::info("AtcServerGroup create conflict for '{$callsign}' (sgid={$sgid}).");
+            Log::info('AtcServerGroup create conflict', ['callsign' => $callsign, 'sgid' => $sgid]);
 
             return AtcServerGroup::where('callsign', $callsign)
                 ->orWhere('ts_sgid', $sgid)
@@ -148,9 +159,9 @@ class AtcServerGroupService
 
             $group->assignments()->delete();
             $group->delete();
-            Log::info("Deleted empty ATC server group '{$group->callsign}' (sgid={$group->ts_sgid})");
+            Log::info('Deleted empty ATC server group', ['callsign' => $group->callsign, 'sgid' => $group->ts_sgid]);
         } catch (ServerQueryException $e) {
-            Log::warning("serverGroupDelete failed for '{$group->callsign}': {$e->getMessage()}");
+            Log::warning('serverGroupDelete failed', ['callsign' => $group->callsign, 'exception' => $e]);
         }
     }
 }

--- a/app/Services/Training/ExamForwardingService.php
+++ b/app/Services/Training/ExamForwardingService.php
@@ -57,6 +57,12 @@ class ExamForwardingService
             'bookid' => $examBooking->id,
         ]);
 
+        audit('Exam forwarded to CTS', [
+            'account_id' => $ctsMember->account->id,
+            'exam_setup_id' => $setup->id,
+            'exam_booking_id' => $examBooking->id,
+        ]);
+
         return [
             'setup' => $setup,
             'examBooking' => $examBooking,
@@ -100,6 +106,12 @@ class ExamForwardingService
             'bookid' => $examBooking->id,
         ]);
 
+        audit('Exam forwarded to CTS', [
+            'account_id' => $ctsMember->account->id,
+            'exam_setup_id' => $setup->id,
+            'exam_booking_id' => $examBooking->id,
+        ]);
+
         return [
             'setup' => $setup,
             'examBooking' => $examBooking,
@@ -141,6 +153,12 @@ class ExamForwardingService
         ]);
 
         $setup->update(['bookid' => $examBooking->id]);
+
+        audit('Exam forwarded to CTS', [
+            'account_id' => $ctsMember->account->id,
+            'exam_setup_id' => $setup->id,
+            'exam_booking_id' => $examBooking->id,
+        ]);
 
         return [
             'setup' => $setup,

--- a/app/Services/Training/MentorPermissionService.php
+++ b/app/Services/Training/MentorPermissionService.php
@@ -345,17 +345,19 @@ class MentorPermissionService
                 continue;
             }
 
-            PositionValidation::where('member_id', $member->id)
+            $deleted = PositionValidation::where('member_id', $member->id)
                 ->where('position_id', $ctsPosition->id)
                 ->where('status', PositionValidationStatusEnum::Mentor->value)
                 ->delete();
 
-            Log::info('Mentor CTS position validation revoked', [
-                'account_id' => $account->id,
-                'member_id' => $member->id,
-                'position_id' => $ctsPosition->id,
-                'callsign' => $callsign,
-            ]);
+            if ($deleted > 0) {
+                Log::info('Mentor CTS position validation revoked', [
+                    'account_id' => $account->id,
+                    'member_id' => $member->id,
+                    'position_id' => $ctsPosition->id,
+                    'callsign' => $callsign,
+                ]);
+            }
         }
     }
 

--- a/app/Services/Training/MentorPermissionService.php
+++ b/app/Services/Training/MentorPermissionService.php
@@ -219,10 +219,22 @@ class MentorPermissionService
         if ($hasMentorPermissionsForRole) {
             if (! $account->hasRole($roleName)) {
                 $account->assignRole($roleName);
+
+                Log::info('Mentor role assigned', [
+                    'account_id' => $account->id,
+                    'role' => $roleName,
+                    'category' => $category,
+                ]);
             }
         } else {
             if ($account->hasRole($roleName)) {
                 $account->removeRole($roleName);
+
+                Log::info('Mentor role removed', [
+                    'account_id' => $account->id,
+                    'role' => $roleName,
+                    'category' => $category,
+                ]);
             }
         }
     }
@@ -230,7 +242,9 @@ class MentorPermissionService
     private function resolveMember(Account $account): ?Member
     {
         if (! $account->member) {
-            Log::error("MentorPermissionService: account {$account->id} has no CTS member model");
+            Log::error('MentorPermissionService: account has no CTS member model', [
+                'account_id' => $account->id,
+            ]);
 
             return null;
         }
@@ -256,6 +270,10 @@ class MentorPermissionService
     private function syncCtsAssign(Account $account, $mentorable, Account $actor): void
     {
         if (($member = $this->resolveMember($account)) === null) {
+            Log::info('Mentor permission sync skipped: member not resolved', [
+                'account_id' => $account->id,
+            ]);
+
             return;
         }
 
@@ -268,7 +286,10 @@ class MentorPermissionService
             $ctsPosition = Position::where('callsign', $callsign)->first();
 
             if (! $ctsPosition) {
-                Log::error("MentorPermissionService: CTS position {$callsign} not found");
+                Log::error('MentorPermissionService: CTS position not found', [
+                    'callsign' => $callsign,
+                    'account_id' => $account->id,
+                ]);
 
                 continue;
             }
@@ -289,12 +310,24 @@ class MentorPermissionService
                 'changed_by' => $changedBy,
                 'date_changed' => now(),
             ]);
+
+            Log::info('Mentor CTS position validation granted', [
+                'account_id' => $account->id,
+                'member_id' => $member->id,
+                'position_id' => $ctsPosition->id,
+                'callsign' => $callsign,
+                'changed_by' => $changedBy,
+            ]);
         }
     }
 
     private function syncCtsRevoke(Account $account, $mentorable): void
     {
         if (($member = $this->resolveMember($account)) === null) {
+            Log::info('Mentor permission sync skipped: member not resolved', [
+                'account_id' => $account->id,
+            ]);
+
             return;
         }
 
@@ -304,7 +337,10 @@ class MentorPermissionService
             $ctsPosition = Position::where('callsign', $callsign)->first();
 
             if (! $ctsPosition) {
-                Log::error("MentorPermissionService: CTS position {$callsign} not found");
+                Log::error('MentorPermissionService: CTS position not found', [
+                    'callsign' => $callsign,
+                    'account_id' => $account->id,
+                ]);
 
                 continue;
             }
@@ -313,6 +349,13 @@ class MentorPermissionService
                 ->where('position_id', $ctsPosition->id)
                 ->where('status', PositionValidationStatusEnum::Mentor->value)
                 ->delete();
+
+            Log::info('Mentor CTS position validation revoked', [
+                'account_id' => $account->id,
+                'member_id' => $member->id,
+                'position_id' => $ctsPosition->id,
+                'callsign' => $callsign,
+            ]);
         }
     }
 

--- a/app/Services/Training/MentoringReportService.php
+++ b/app/Services/Training/MentoringReportService.php
@@ -219,7 +219,8 @@ class MentoringReportService
         try {
             $recipients = Account::role($tgiRoleName)->get();
         } catch (RoleDoesNotExist $e) {
-            Log::warning("TGI notification skipped: role '{$tgiRoleName}' does not exist.", [
+            Log::warning('TGI notification skipped: role does not exist', [
+                'role' => $tgiRoleName,
                 'session_id' => $session->id,
                 'category' => $category,
             ]);

--- a/app/Services/Training/TrainingPlaceService.php
+++ b/app/Services/Training/TrainingPlaceService.php
@@ -66,7 +66,7 @@ class TrainingPlaceService
                 'date_changed' => now(),
             ]);
 
-            Log::info('CTS position validation granted', [
+            Log::channel('audit')->info('CTS position validation granted', [
                 'account_id' => $student->id,
                 'member_id' => $student->member->id,
                 'position_id' => $ctsPositionModel->id,
@@ -109,7 +109,7 @@ class TrainingPlaceService
                 ->where('status', PositionValidationStatusEnum::Student->value)
                 ->delete();
 
-            Log::info('CTS position validation revoked', [
+            Log::channel('audit')->info('CTS position validation revoked', [
                 'account_id' => $student->id,
                 'member_id' => $student->member->id,
                 'position_id' => $ctsPositionModel->id,
@@ -166,18 +166,20 @@ class TrainingPlaceService
             return;
         }
 
-        Membership::query()
+        $deleted = Membership::query()
             ->where('member_id', $student->member->id)
             ->whereIn('rts_id', array_keys($rtsIds))
             ->whereIn('type', ['H', 'V'])
             ->delete();
 
-        Log::info('CTS membership revoked', [
-            'account_id' => $student->id,
-            'member_id' => $student->member->id,
-            'rts_ids' => array_keys($rtsIds),
-            'training_place_id' => $trainingPlace->id,
-        ]);
+        if ($deleted > 0) {
+            Log::channel('audit')->info('CTS membership revoked', [
+                'account_id' => $student->id,
+                'member_id' => $student->member->id,
+                'rts_ids' => array_keys($rtsIds),
+                'training_place_id' => $trainingPlace->id,
+            ]);
+        }
     }
 
     public function createManualTrainingPlace(WaitingListAccount $waitingListAccount, TrainingPosition|Qualification $trainable): TrainingPlace
@@ -189,7 +191,7 @@ class TrainingPlaceService
             'trainable_id' => $trainable->getKey(),
         ]);
 
-        Log::info('Manual training place created', [
+        Log::channel('audit')->info('Manual training place created', [
             'account_id' => $waitingListAccount->account_id,
             'training_place_id' => $trainingPlace->id,
             'waiting_list_account_id' => $waitingListAccount->id,
@@ -219,13 +221,13 @@ class TrainingPlaceService
             'waiting_list_account_id' => null,
         ]);
 
-        Log::info('Adhoc training place created', [
+        Log::channel('audit')->info('Adhoc training place created', [
             'account_id' => $account->id,
             'training_place_id' => $trainingPlace->id,
             'trainable_type' => $trainable->getMorphClass(),
             'trainable_id' => $trainable->getKey(),
             'actor_id' => $actor->id,
-            'reason' => $reason,
+            'reason' => preg_replace('/[\x00-\x1F\x7F]/', '', $reason),
         ]);
 
         $account->addNote(

--- a/app/Services/Training/TrainingPlaceService.php
+++ b/app/Services/Training/TrainingPlaceService.php
@@ -24,7 +24,10 @@ class TrainingPlaceService
         $student = $trainingPlace->account;
 
         if (! $student->member) {
-            Log::error('Student does not have a CTS member model attached');
+            Log::error('Student does not have a CTS member model attached', [
+                'account_id' => $student->id,
+                'training_place_id' => $trainingPlace->id,
+            ]);
 
             return;
         }
@@ -35,7 +38,11 @@ class TrainingPlaceService
             $ctsPositionModel = Position::where('callsign', $ctsPosition)->first();
 
             if (! $ctsPositionModel) {
-                Log::error("CTS position with callsign {$ctsPosition} not found");
+                Log::error('CTS position not found', [
+                    'callsign' => $ctsPosition,
+                    'account_id' => $student->id,
+                    'training_place_id' => $trainingPlace->id,
+                ]);
 
                 continue;
             }
@@ -58,6 +65,14 @@ class TrainingPlaceService
                 'changed_by' => $student->id,
                 'date_changed' => now(),
             ]);
+
+            Log::info('CTS position validation granted', [
+                'account_id' => $student->id,
+                'member_id' => $student->member->id,
+                'position_id' => $ctsPositionModel->id,
+                'callsign' => $ctsPosition,
+                'training_place_id' => $trainingPlace->id,
+            ]);
         }
     }
 
@@ -66,7 +81,10 @@ class TrainingPlaceService
         $student = $trainingPlace->account;
 
         if (! $student->member) {
-            Log::error('Student does not have a CTS member model attached');
+            Log::error('Student does not have a CTS member model attached', [
+                'account_id' => $student->id,
+                'training_place_id' => $trainingPlace->id,
+            ]);
 
             return;
         }
@@ -77,7 +95,11 @@ class TrainingPlaceService
             $ctsPositionModel = Position::where('callsign', $ctsPosition)->first();
 
             if (! $ctsPositionModel) {
-                Log::error("CTS position with callsign {$ctsPosition} not found");
+                Log::error('CTS position not found', [
+                    'callsign' => $ctsPosition,
+                    'account_id' => $student->id,
+                    'training_place_id' => $trainingPlace->id,
+                ]);
 
                 continue;
             }
@@ -86,6 +108,14 @@ class TrainingPlaceService
                 ->where('position_id', $ctsPositionModel->id)
                 ->where('status', PositionValidationStatusEnum::Student->value)
                 ->delete();
+
+            Log::info('CTS position validation revoked', [
+                'account_id' => $student->id,
+                'member_id' => $student->member->id,
+                'position_id' => $ctsPositionModel->id,
+                'callsign' => $ctsPosition,
+                'training_place_id' => $trainingPlace->id,
+            ]);
         }
     }
 
@@ -96,7 +126,10 @@ class TrainingPlaceService
         $student = $trainingPlace->account;
 
         if (! $student->member) {
-            Log::error('Student does not have a CTS member model attached');
+            Log::error('Student does not have a CTS member model attached', [
+                'account_id' => $student->id,
+                'training_place_id' => $trainingPlace->id,
+            ]);
 
             return;
         }
@@ -113,7 +146,11 @@ class TrainingPlaceService
             $ctsPositionModel = Position::where('callsign', $ctsPositionCallsign)->first();
 
             if (! $ctsPositionModel) {
-                Log::error("CTS position with callsign {$ctsPositionCallsign} not found");
+                Log::error('CTS position not found', [
+                    'callsign' => $ctsPositionCallsign,
+                    'account_id' => $student->id,
+                    'training_place_id' => $trainingPlace->id,
+                ]);
 
                 continue;
             }
@@ -134,6 +171,13 @@ class TrainingPlaceService
             ->whereIn('rts_id', array_keys($rtsIds))
             ->whereIn('type', ['H', 'V'])
             ->delete();
+
+        Log::info('CTS membership revoked', [
+            'account_id' => $student->id,
+            'member_id' => $student->member->id,
+            'rts_ids' => array_keys($rtsIds),
+            'training_place_id' => $trainingPlace->id,
+        ]);
     }
 
     public function createManualTrainingPlace(WaitingListAccount $waitingListAccount, TrainingPosition|Qualification $trainable): TrainingPlace
@@ -141,6 +185,14 @@ class TrainingPlaceService
         $trainingPlace = TrainingPlace::create([
             'waiting_list_account_id' => $waitingListAccount->id,
             'account_id' => $waitingListAccount->account_id,
+            'trainable_type' => $trainable->getMorphClass(),
+            'trainable_id' => $trainable->getKey(),
+        ]);
+
+        Log::info('Manual training place created', [
+            'account_id' => $waitingListAccount->account_id,
+            'training_place_id' => $trainingPlace->id,
+            'waiting_list_account_id' => $waitingListAccount->id,
             'trainable_type' => $trainable->getMorphClass(),
             'trainable_id' => $trainable->getKey(),
         ]);
@@ -165,6 +217,15 @@ class TrainingPlaceService
             'trainable_type' => $trainable->getMorphClass(),
             'trainable_id' => $trainable->getKey(),
             'waiting_list_account_id' => null,
+        ]);
+
+        Log::info('Adhoc training place created', [
+            'account_id' => $account->id,
+            'training_place_id' => $trainingPlace->id,
+            'trainable_type' => $trainable->getMorphClass(),
+            'trainable_id' => $trainable->getKey(),
+            'actor_id' => $actor->id,
+            'reason' => $reason,
         ]);
 
         $account->addNote(
@@ -192,7 +253,10 @@ class TrainingPlaceService
         $student = $trainingPlace->account;
 
         if (! $student->member) {
-            Log::error('Student does not have a CTS member model attached');
+            Log::error('Student does not have a CTS member model attached', [
+                'account_id' => $student->id,
+                'training_place_id' => $trainingPlace->id,
+            ]);
 
             return false;
         }
@@ -201,7 +265,10 @@ class TrainingPlaceService
         $trainingPosition = $trainingPlace->trainingPosition;
 
         if (! $trainingPosition) {
-            Log::error('Training position not found');
+            Log::error('Training position not found', [
+                'account_id' => $student->id,
+                'training_place_id' => $trainingPlace->id,
+            ]);
 
             return false;
         }
@@ -213,7 +280,11 @@ class TrainingPlaceService
             ?? null;
 
         if (! $examPosition) {
-            Log::error('Exam position not found');
+            Log::error('Exam position not found', [
+                'account_id' => $student->id,
+                'training_place_id' => $trainingPlace->id,
+                'training_position_id' => $trainingPosition->id,
+            ]);
 
             return false;
         }

--- a/app/Services/Training/WaitingListRetentionChecks.php
+++ b/app/Services/Training/WaitingListRetentionChecks.php
@@ -18,7 +18,7 @@ class WaitingListRetentionChecks
 
     public static function createRetentionCheckRecord(WaitingListAccount $waitingListAccount): WaitingListRetentionCheckModel
     {
-        Log::info('Creating retention check record for account: '.$waitingListAccount->account->id);
+        Log::info('Creating retention check record for account', ['account_id' => $waitingListAccount->account->id]);
 
         return $waitingListAccount->retentionChecks()->create([
             'waiting_list_account_id' => $waitingListAccount->id,

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -226,10 +226,8 @@ if (! function_exists('audit')) {
     function audit(string $message, array $context = []): void
     {
         if ($user = auth()->user()) {
-            $context += [
-                'actor_id' => $user->getAuthIdentifier(),
-                'actor_name' => (string) $user->name,
-            ];
+            $context['actor_id'] = $user->getAuthIdentifier();
+            $context['actor_name'] = (string) $user->name;
         }
 
         Illuminate\Support\Facades\Log::channel('audit')->info($message, $context);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -217,3 +217,21 @@ if (! function_exists('str_contains')) {
         return Illuminate\Support\Str::contains($haystack, $needle);
     }
 }
+
+if (! function_exists('audit')) {
+    /**
+     * Write an actor-attributed record to the audit channel.
+     * For "who did what to whom" staff/member state changes only - never errors.
+     */
+    function audit(string $message, array $context = []): void
+    {
+        if ($user = auth()->user()) {
+            $context += [
+                'actor_id' => $user->getAuthIdentifier(),
+                'actor_name' => (string) $user->name,
+            ];
+        }
+
+        Illuminate\Support\Facades\Log::channel('audit')->info($message, $context);
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -52,7 +52,7 @@ return [
             'path' => storage_path('logs/audit.log'),
             'level' => env('AUDIT_LOG_LEVEL', 'info'),
             'days' => (int) env('AUDIT_LOG_DAYS', 365),
-            'replace_placeholders' => true,
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'single' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -47,6 +47,14 @@ return [
             'days' => 14,
         ],
 
+        'audit' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/audit.log'),
+            'level' => env('AUDIT_LOG_LEVEL', 'info'),
+            'days' => (int) env('AUDIT_LOG_DAYS', 365),
+            'replace_placeholders' => true,
+        ],
+
         'single' => [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
@@ -113,6 +121,7 @@ return [
 
         'bugsnag' => [
             'driver' => 'bugsnag',
+            'level' => env('BUGSNAG_LOG_LEVEL', 'error'),
         ],
 
         'betterstack' => [

--- a/tests/Feature/Jobs/SyncJobLoggingTest.php
+++ b/tests/Feature/Jobs/SyncJobLoggingTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\Mship\SyncToCTS;
+use App\Models\Mship\Account;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SyncJobLoggingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function a_failed_sync_job_logs_a_single_error_with_account_context()
+    {
+        $account = Account::factory()->create();
+
+        Log::shouldReceive('error')->once()->withArgs(fn ($msg, $ctx) => $msg === 'Job failed'
+            && $ctx['account_id'] === $account->id
+            && $ctx['job'] === SyncToCTS::class
+            && isset($ctx['exception'])
+        );
+
+        $job = new SyncToCTS($account);
+
+        $job->failed(new \RuntimeException('boom'));
+    }
+
+    /**
+     * NOTE: The success-path 'Member sync completed' info log (added to each
+     * of the four sync jobs' handle() methods) is not exercised here because
+     * handle() calls the real external sync method (syncToCTS/syncToHelpdesk/
+     * syncUserToMoodle/syncToDiscord), which would perform live HTTP calls to
+     * external services. That path is covered by manual/maintainer testing.
+     */
+}

--- a/tests/Feature/Training/WaitingListAuditLogTest.php
+++ b/tests/Feature/Training/WaitingListAuditLogTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Training;
+
+use App\Events\Training\AccountAddedToWaitingList;
+use App\Listeners\Training\WaitingList\LogAccountAdded;
+use App\Models\Mship\Account;
+use App\Models\Training\WaitingList;
+use App\Models\Training\WaitingList\WaitingListAccount;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class WaitingListAuditLogTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function adding_an_account_writes_a_single_audit_record()
+    {
+        $this->actingAs($this->privacc);
+
+        $waitingList = WaitingList::factory()->create();
+        $account = Account::factory()->create();
+
+        // Build the WaitingListAccount directly (bypassing capacity/endorsement
+        // checks in WaitingList::addToWaitingList()) since this test only needs
+        // to exercise the listener, not the full enrolment flow.
+        $waitingListAccount = new WaitingListAccount(['added_by' => $this->privacc->id]);
+        $waitingListAccount->account_id = $account->id;
+        $waitingList->waitingListAccounts()->save($waitingListAccount);
+
+        Log::shouldReceive('channel')->with('audit')->andReturnSelf();
+        Log::shouldReceive('info')->once()->withArgs(fn ($msg, $ctx) => $msg === 'Account added to waiting list'
+            && isset($ctx['account_id'], $ctx['waiting_list_id'])
+            && $ctx['account_id'] === $account->id
+            && $ctx['waiting_list_id'] === $waitingList->id
+            && $ctx['actor_id'] === $this->privacc->id
+        );
+
+        $event = new AccountAddedToWaitingList($account, $waitingList, $this->privacc, $waitingListAccount);
+
+        (new LogAccountAdded)->handle($event);
+    }
+
+    /**
+     * NOTE: WaitingListEventSubscriber (promoted/demoted/status-change) is not
+     * registered anywhere in the app (see EventServiceProvider), so those
+     * waiting-list transitions are NOT currently written to the audit log.
+     * This is tracked as a FIXME on the subscriber itself and is out of scope
+     * for this change - no test is written against it because there is no
+     * live code path to assert against.
+     */
+    #[Test]
+    public function status_change_events_are_not_audited_due_to_unregistered_subscriber()
+    {
+        $this->assertTrue(true, 'Documented gap: see FIXME in WaitingListEventSubscriber.php');
+    }
+}

--- a/tests/Feature/Training/WaitingListAuditLogTest.php
+++ b/tests/Feature/Training/WaitingListAuditLogTest.php
@@ -6,6 +6,7 @@ use App\Events\Training\AccountAddedToWaitingList;
 use App\Listeners\Training\WaitingList\LogAccountAdded;
 use App\Models\Mship\Account;
 use App\Models\Training\WaitingList;
+use App\Models\Training\WaitingList\WaitingListAccount;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\Test;
@@ -25,6 +26,10 @@ class WaitingListAuditLogTest extends TestCase
         $account = Account::factory()->create();
         $staffAccount = Account::factory()->create();
 
+        $waitingListAccount = new WaitingListAccount(['added_by' => $staffAccount->id]);
+        $waitingListAccount->account_id = $account->id;
+        $waitingList->waitingListAccounts()->save($waitingListAccount);
+
         Log::shouldReceive('channel')->with('audit')->andReturnSelf();
         Log::shouldReceive('info')->once()->withArgs(fn ($msg, $ctx) => $msg === 'Account added to waiting list'
             && isset($ctx['account_id'], $ctx['waiting_list_id'])
@@ -33,7 +38,7 @@ class WaitingListAuditLogTest extends TestCase
             && $ctx['actor_id'] === $authUser->id
         );
 
-        $event = new AccountAddedToWaitingList($account, $waitingList, $staffAccount, null);
+        $event = new AccountAddedToWaitingList($account, $waitingList, $staffAccount, $waitingListAccount);
 
         (new LogAccountAdded)->handle($event);
     }

--- a/tests/Feature/Training/WaitingListAuditLogTest.php
+++ b/tests/Feature/Training/WaitingListAuditLogTest.php
@@ -32,9 +32,10 @@ class WaitingListAuditLogTest extends TestCase
 
         Log::shouldReceive('channel')->with('audit')->andReturnSelf();
         Log::shouldReceive('info')->once()->withArgs(fn ($msg, $ctx) => $msg === 'Account added to waiting list'
-            && isset($ctx['account_id'], $ctx['waiting_list_id'])
+            && isset($ctx['account_id'], $ctx['waiting_list_id'], $ctx['staff_id'])
             && $ctx['account_id'] === $account->id
             && $ctx['waiting_list_id'] === $waitingList->id
+            && $ctx['staff_id'] === $staffAccount->id
             && $ctx['actor_id'] === $authUser->id
         );
 

--- a/tests/Feature/Training/WaitingListAuditLogTest.php
+++ b/tests/Feature/Training/WaitingListAuditLogTest.php
@@ -6,7 +6,6 @@ use App\Events\Training\AccountAddedToWaitingList;
 use App\Listeners\Training\WaitingList\LogAccountAdded;
 use App\Models\Mship\Account;
 use App\Models\Training\WaitingList;
-use App\Models\Training\WaitingList\WaitingListAccount;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\Test;
@@ -19,27 +18,22 @@ class WaitingListAuditLogTest extends TestCase
     #[Test]
     public function adding_an_account_writes_a_single_audit_record()
     {
-        $this->actingAs($this->privacc);
+        $authUser = Account::factory()->create();
+        $this->actingAs($authUser);
 
         $waitingList = WaitingList::factory()->create();
         $account = Account::factory()->create();
-
-        // Build the WaitingListAccount directly (bypassing capacity/endorsement
-        // checks in WaitingList::addToWaitingList()) since this test only needs
-        // to exercise the listener, not the full enrolment flow.
-        $waitingListAccount = new WaitingListAccount(['added_by' => $this->privacc->id]);
-        $waitingListAccount->account_id = $account->id;
-        $waitingList->waitingListAccounts()->save($waitingListAccount);
+        $staffAccount = Account::factory()->create();
 
         Log::shouldReceive('channel')->with('audit')->andReturnSelf();
         Log::shouldReceive('info')->once()->withArgs(fn ($msg, $ctx) => $msg === 'Account added to waiting list'
             && isset($ctx['account_id'], $ctx['waiting_list_id'])
             && $ctx['account_id'] === $account->id
             && $ctx['waiting_list_id'] === $waitingList->id
-            && $ctx['actor_id'] === $this->privacc->id
+            && $ctx['actor_id'] === $authUser->id
         );
 
-        $event = new AccountAddedToWaitingList($account, $waitingList, $this->privacc, $waitingListAccount);
+        $event = new AccountAddedToWaitingList($account, $waitingList, $staffAccount, null);
 
         (new LogAccountAdded)->handle($event);
     }
@@ -55,6 +49,6 @@ class WaitingListAuditLogTest extends TestCase
     #[Test]
     public function status_change_events_are_not_audited_due_to_unregistered_subscriber()
     {
-        $this->assertTrue(true, 'Documented gap: see FIXME in WaitingListEventSubscriber.php');
+        $this->markTestSkipped('Documented gap: see FIXME in WaitingListEventSubscriber.php');
     }
 }

--- a/tests/Unit/Jobs/LogsJobLifecycleTest.php
+++ b/tests/Unit/Jobs/LogsJobLifecycleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\Concerns\LogsJobLifecycle;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Tests\TestCase;
+
+class LogsJobLifecycleTest extends TestCase
+{
+    /** @test */
+    public function failed_logs_an_error_with_job_context()
+    {
+        $job = new class
+        {
+            use LogsJobLifecycle;
+
+            protected function logJobContext(): array
+            {
+                return ['account_id' => 42];
+            }
+        };
+
+        Log::shouldReceive('error')->once()->withArgs(fn ($msg, $ctx) => $msg === 'Job failed' && $ctx['account_id'] === 42 && isset($ctx['exception'])
+        );
+
+        $job->failed(new RuntimeException('boom'));
+    }
+}

--- a/tests/Unit/Jobs/LogsJobLifecycleTest.php
+++ b/tests/Unit/Jobs/LogsJobLifecycleTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Jobs;
 
-use App\Jobs\Concerns\LogsJobLifecycle;
+use App\Jobs\Concerns\LogsJobFailure;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
 use Tests\TestCase;
@@ -14,7 +14,7 @@ class LogsJobLifecycleTest extends TestCase
     {
         $job = new class
         {
-            use LogsJobLifecycle;
+            use LogsJobFailure;
 
             protected function logJobContext(): array
             {

--- a/tests/Unit/Jobs/LogsJobLifecycleTest.php
+++ b/tests/Unit/Jobs/LogsJobLifecycleTest.php
@@ -4,12 +4,13 @@ namespace Tests\Unit\Jobs;
 
 use App\Jobs\Concerns\LogsJobFailure;
 use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
 use Tests\TestCase;
 
 class LogsJobLifecycleTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function failed_logs_an_error_with_job_context()
     {
         $job = new class

--- a/tests/Unit/Support/AuditHelperTest.php
+++ b/tests/Unit/Support/AuditHelperTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class AuditHelperTest extends TestCase
+{
+    /** @test */
+    public function it_writes_to_the_audit_channel_with_actor_context()
+    {
+        $actor = $this->user; // member-role account helper from TestCase
+        $this->actingAs($actor);
+
+        Log::shouldReceive('channel')->with('audit')->andReturnSelf();
+        Log::shouldReceive('info')->once()->withArgs(function ($message, $context) use ($actor) {
+            return $message === 'Test audit event'
+                && $context['account_id'] === 123
+                && $context['actor_id'] === $actor->id;
+        });
+
+        audit('Test audit event', ['account_id' => 123]);
+    }
+}

--- a/tests/Unit/Support/AuditHelperTest.php
+++ b/tests/Unit/Support/AuditHelperTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Unit\Support;
 
 use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class AuditHelperTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_writes_to_the_audit_channel_with_actor_context()
     {
         $actor = $this->user; // member-role account helper from TestCase

--- a/tests/Unit/Training/WaitingList/WaitingListRetentionChecks/WaitingListRetentionChecksNotificationsTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListRetentionChecks/WaitingListRetentionChecksNotificationsTest.php
@@ -187,10 +187,12 @@ class WaitingListRetentionChecksNotificationsTest extends TestCase
         // Assert that the error was logged correctly
         Log::shouldHaveReceived('error')
             ->once()
-            ->withArgs(function ($message) use ($account) {
-                return str_contains($message, "Failed to notify account {$account->id}") &&
-                       str_contains($message, 'of retention check') &&
-                       str_contains($message, 'Notification failed');
+            ->withArgs(function ($message, $context) use ($account) {
+                return $message === 'Failed to notify account of retention check'
+                    && ($context['account_id'] ?? null) === $account->id
+                    && isset($context['exception'])
+                    && $context['exception'] instanceof \Throwable
+                    && $context['exception']->getMessage() === 'Notification failed';
             });
     }
 


### PR DESCRIPTION
Standardises all logging across the codebase to structured context format:

- `Log` facade, static message + context array, no interpolation
- Exception logging uses `['exception' => $e]` before swallowing/rethrowing
- `Log::debug`/`info` for expected conditions, `notice`+ for human investigation
- New `audit()` helper (`app/helpers.php`) writes actor-attributed state changes
- New `LogsJobFailure` trait for consistent job failure logging
- New `audit` logging channel (365-day retention)
- Filament page/relation access logging via `LogPageAccess`/`LogRelationAccess` traits