### PR TITLE
fix: use highest endorsement held to determine which progress bars are shown

### DIFF
--- a/app/Http/Controllers/Site/ATCPagesController.php
+++ b/app/Http/Controllers/Site/ATCPagesController.php
@@ -64,16 +64,31 @@ class ATCPagesController extends \App\Http\Controllers\BaseController
 
             $gndPgId = $heathrowPositionGroups->get('Heathrow (GND)')?->id;
             $twrPgId = $heathrowPositionGroups->get('Heathrow (TWR)')?->id;
+            $appPgId = $heathrowPositionGroups->get('Heathrow (APP)')?->id;
 
-            $hasGndEndorsement = $gndPgId && in_array($gndPgId, $existingEndorsements);
-            $hasTwrEndorsement = $twrPgId && in_array($twrPgId, $existingEndorsements);
+            $holdsGnd = $gndPgId && in_array($gndPgId, $existingEndorsements);
+            $holdsTwr = $twrPgId && in_array($twrPgId, $existingEndorsements);
+            $holdsApp = $appPgId && in_array($appPgId, $existingEndorsements);
+
+            $hasGndEndorsement = $holdsGnd || $holdsTwr || $holdsApp;
+            $hasTwrEndorsement = $holdsTwr || $holdsApp;
 
             $endorsementProgress = [];
             $endorsementChain = ['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)'];
 
             foreach ($endorsementChain as $pgName) {
                 $pg = $heathrowPositionGroups->get($pgName);
-                if (! $pg || in_array($pg->id, $existingEndorsements)) {
+                if (! $pg) {
+                    continue;
+                }
+
+                $alreadyHeldOrSuperseded = match ($pgName) {
+                    'Heathrow (GND)' => $holdsGnd || $holdsTwr || $holdsApp,
+                    'Heathrow (TWR)' => $holdsTwr || $holdsApp,
+                    'Heathrow (APP)' => $holdsApp,
+                };
+
+                if ($alreadyHeldOrSuperseded) {
                     continue;
                 }
 

--- a/tests/Feature/Site/HeathrowEndorsementProgressTest.php
+++ b/tests/Feature/Site/HeathrowEndorsementProgressTest.php
@@ -932,6 +932,39 @@ class HeathrowEndorsementProgressTest extends TestCase
             ->assertSee('0 / 10 Hrs');
     }
 
+    #[Test]
+    public function test_s3_user_holding_only_twr_endorsement_sees_app_bars_not_gnd()
+    {
+        $account = $this->createAccountWithQualification('S3');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)', 'Heathrow (APP)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+
+        $s3Qual = Qualification::code('S3')->firstOrFail();
+        $this->seedAppSessions($account, $s3Qual);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertSee('Your Progress')
+            ->assertSee('Heathrow APP (S3+)')
+            ->assertSee('Total UK APP')
+            ->assertDontSee('Total UK DEL/GND/TWR')
+            ->assertDontSee('Total UK TWR');
+    }
+
+    #[Test]
+    public function test_s2_user_holding_only_twr_endorsement_sees_no_progress()
+    {
+        $account = $this->createAccountWithQualification('S2');
+        $positionGroups = $this->createPositionGroups(['Heathrow (GND)', 'Heathrow (TWR)']);
+        $this->createEndorsement($account, $positionGroups['Heathrow (TWR)']);
+
+        $this->actingAs($account)
+            ->get(route(self::ROUTE))
+            ->assertOk()
+            ->assertDontSee('Your Progress');
+    }
+
     private function createAccountWithQualification(string $code): Account
     {
         $account = Account::factory()->create();


### PR DESCRIPTION
# Summary of changes
- If a user holds a TWR only and not a GND endorsement. Ensure APP is shown not GND.

# Screenshots (if necessary)
