### PR TITLE
PR dependency check workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,6 +54,10 @@ The workflow for submitting a new pull request is designed to be simple, but als
 
 **Please** keep your changes in a single PR as small as possible (relating to one issue) as this makes it easier to review and accept. Large PRs with a small error will prevent the entire PR from being accepted.
 
+## Marking PR dependencies
+
+If your PR depends on another open PR being merged first, include a line in your PR description such as `Depends on #123` or `Blocked by #123`. A "Check Dependencies" status check will flag the PR until the dependency is resolved.
+
 # Expectations
 
 As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting merge requests or patches, and other activities.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,8 @@
 Fixes #[issue_no]
 
+## Dependencies
+<!-- If this PR depends on another PR being merged first, note it here, e.g. "Depends on #123" -->
+
 # Summary of changes
 
 < Please provide a sensible summary of changes for this merge request, ensuring all changes are explained. >

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,6 @@
 Fixes #[issue_no]
 
-## Dependencies
-<!-- If this PR depends on another PR being merged first, note it here, e.g. "Depends on #123" -->
+Depends on #[issue_no]
 
 # Summary of changes
 

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Check Dependencies
     steps:
-      - uses: gregsdennis/dependencies-action@main
+      - uses: gregsdennis/dependencies-action@a8cccab69814b9b985496cf97cbfe154c96c03c7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,17 @@
+name: PR Dependency Check
+on:
+  pull_request_target:
+    types: [opened, edited, closed, reopened]
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+      - uses: gregsdennis/dependencies-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     types: [opened, edited, closed, reopened]
 
+concurrency:
+  group: dep-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   issues: read
   pull-requests: read


### PR DESCRIPTION
Adds a "Check Dependencies" status check to PRs using `gregsdennis/dependencies-action`.

If a PR description includes `Depends on #N` or `Blocked by #N`, the check will flag the PR until the referenced PR is merged. The check is advisory only - it does not block manual merge.

Also updates `CONTRIBUTING.md` and `PULL_REQUEST_TEMPLATE.md` to document the convention.