### PR TITLE
fix: ensure only "certified" members on gander roster are synced

### DIFF
--- a/app/Console/Commands/Roster/UpdateRosterGanderControllers.php
+++ b/app/Console/Commands/Roster/UpdateRosterGanderControllers.php
@@ -32,6 +32,7 @@ class UpdateRosterGanderControllers extends Command
         $ganderValidatedAccountIds = $ganderResponse
             ->collect()
             ->where('active', true)
+            ->where('certification', 'certified')
             ->pluck('cid');
 
         DB::transaction(function () use ($ganderValidatedAccountIds) {


### PR DESCRIPTION
# Summary of changes
- ensure only "certified" members on gander roster are synced

# Screenshots (if necessary)
