### PR TITLE
feat: show overlapping sessions warning on Accepted Mentoring sessions table

### DIFF
--- a/app/Livewire/Training/AcceptedMentoringSessionsTable.php
+++ b/app/Livewire/Training/AcceptedMentoringSessionsTable.php
@@ -28,6 +28,7 @@ use Filament\Schemas\Components\Callout;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
+use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
@@ -93,6 +94,22 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
                         ->orderBy('taken_date', $direction)
                         ->orderBy('taken_from', $direction)
                     ),
+
+                IconColumn::make('overlap_warning')
+                    ->label('')
+                    ->grow(false)
+                    ->getStateUsing(fn (Session $record) => $this->overlapForRecord($record) !== null)
+                    ->icon(fn (Session $record) => $this->overlapForRecord($record) ? 'heroicon-o-exclamation-triangle' : null)
+                    ->color('warning')
+                    ->tooltip(function (Session $record) {
+                        $overlap = $this->overlapForRecord($record);
+
+                        if (! $overlap) {
+                            return null;
+                        }
+
+                        return app(MentoringSessionsService::class)->overlapDescription($overlap);
+                    }),
             ])
             ->actions([
                 Action::make('conduct')
@@ -142,6 +159,11 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
             $takenTo,
             $session->id
         );
+    }
+
+    private function overlapForRecord(Session $record): Session|ExamBooking|null
+    {
+        return app(MentoringSessionsService::class)->findOverlappingBookingForSession($record);
     }
 
     protected function generateTimeOptions(?string $minTime = null, ?string $maxTime = null): array
@@ -393,7 +415,7 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
                             return '';
                         }
 
-                        return $overlap instanceof Session ? 'Overlapping Session Detected' : 'Overlapping Exam Detected';
+                        return app(MentoringSessionsService::class)->overlapHeading($overlap);
                     })
                     ->description(function (Get $get) use ($record) {
                         $overlap = $this->getOverlappingBooking($get, $record);
@@ -402,11 +424,7 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
                             return '';
                         }
 
-                        $type = $overlap instanceof Session ? 'session' : 'exam';
-                        $from = $overlap->taken_from;
-                        $to = $overlap->taken_to;
-
-                        return "There is already a {$type} booked on this position from {$from} to {$to}.";
+                        return app(MentoringSessionsService::class)->overlapDescription($overlap);
                     })
                     ->danger()
                     ->visible(function (Get $get) use ($record) {

--- a/app/Livewire/Training/AvailabilityGantt.php
+++ b/app/Livewire/Training/AvailabilityGantt.php
@@ -357,7 +357,7 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
                                 return '';
                             }
 
-                            return $overlap instanceof Session ? 'Overlapping Session Detected' : 'Overlapping Exam Detected';
+                            return app(MentoringSessionsService::class)->overlapHeading($overlap);
                         })
                         ->description(function (Get $get) use ($availability, $pendingSession) {
                             $overlap = $this->getOverlappingBooking($get, $availability, $pendingSession);
@@ -366,11 +366,7 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
                                 return '';
                             }
 
-                            $type = $overlap instanceof Session ? 'session' : 'exam';
-                            $from = $overlap->taken_from;
-                            $to = $overlap->taken_to;
-
-                            return "There is already a {$type} booked on this position from {$from} to {$to}.";
+                            return app(MentoringSessionsService::class)->overlapDescription($overlap);
                         })
                         ->danger()
                         ->visible(function (Get $get) use ($availability, $pendingSession) {

--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -280,6 +280,35 @@ class MentoringSessionsService
             ->first();
     }
 
+    public function findOverlappingBookingForSession(Session $session): Session|ExamBooking|null
+    {
+        if (! $session->taken_date || ! $session->taken_from || ! $session->taken_to) {
+            return null;
+        }
+
+        return $this->checkForOverlappingBookings(
+            $session->position,
+            $session->taken_date,
+            $session->taken_from,
+            $session->taken_to,
+            $session->id
+        );
+    }
+
+    public function overlapHeading(Session|ExamBooking $overlap): string
+    {
+        return $overlap instanceof Session ? 'Overlapping Session Detected' : 'Overlapping Exam Detected';
+    }
+
+    public function overlapDescription(Session|ExamBooking $overlap): string
+    {
+        $type = $overlap instanceof Session ? 'session' : 'exam';
+        $from = Carbon::parse($overlap->taken_from)->format('H:i');
+        $to = Carbon::parse($overlap->taken_to)->format('H:i');
+
+        return "There is already a {$type} booked on this position from {$from} to {$to}.";
+    }
+
     private function validateSessionTimes(Availability $availability, string $takenFrom, string $takenTo): void
     {
         $sessionStart = Carbon::parse($availability->date)->setTimeFromTimeString($takenFrom);

--- a/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
@@ -214,7 +214,7 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
 
         Livewire::actingAs($this->mentor)
             ->test(AcceptedMentoringSessionsTable::class)
-            ->assertSee('There is already a session booked on this position from 11:00:00 to 13:00:00.');
+            ->assertSee('There is already a session booked on this position from 11:00 to 13:00.');
     }
 
     #[Test]

--- a/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
@@ -181,6 +181,66 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
+    public function accepted_sessions_table_shows_warning_when_an_overlapping_booking_exists(): void
+    {
+        $student = Member::factory()->create();
+        $otherMentor = Member::factory()->create();
+
+        Session::factory()->create([
+            'mentor_id' => $this->mentorMember->id,
+            'student_id' => $student->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+            'noShow' => 0,
+        ]);
+
+        Session::factory()->create([
+            'mentor_id' => $otherMentor->id,
+            'student_id' => $student->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '11:00:00',
+            'taken_to' => '13:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+            'noShow' => 0,
+        ]);
+
+        Livewire::actingAs($this->mentor)
+            ->test(AcceptedMentoringSessionsTable::class)
+            ->assertSee('There is already a session booked on this position from 11:00:00 to 13:00:00.');
+    }
+
+    #[Test]
+    public function accepted_sessions_table_does_not_show_warning_when_no_overlapping_booking_exists(): void
+    {
+        $student = Member::factory()->create();
+
+        Session::factory()->create([
+            'mentor_id' => $this->mentorMember->id,
+            'student_id' => $student->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+            'noShow' => 0,
+        ]);
+
+        Livewire::actingAs($this->mentor)
+            ->test(AcceptedMentoringSessionsTable::class)
+            ->assertDontSee('There is already a session booked on this position');
+    }
+
+    #[Test]
     public function availability_gantt_renders_successfully(): void
     {
         Livewire::actingAs($this->mentor)

--- a/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
@@ -1007,4 +1007,80 @@ class MentoringSessionsServiceTest extends TestCase
 
         $this->assertInstanceOf(Session::class, $result);
     }
+
+    #[Test]
+    public function find_overlapping_booking_for_session_returns_null_when_no_overlap(): void
+    {
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+        ]);
+
+        $result = $this->service->findOverlappingBookingForSession($session);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function find_overlapping_booking_for_session_returns_overlapping_session(): void
+    {
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+        ]);
+
+        Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '11:00:00',
+            'taken_to' => '13:00:00',
+            'cancelled_datetime' => null,
+        ]);
+
+        $result = $this->service->findOverlappingBookingForSession($session);
+
+        $this->assertInstanceOf(Session::class, $result);
+        $this->assertSame('11:00:00', $result->taken_from);
+        $this->assertSame('13:00:00', $result->taken_to);
+    }
+
+    #[Test]
+    public function find_overlapping_booking_for_session_returns_overlapping_exam(): void
+    {
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+        ]);
+
+        ExamBooking::factory()->create([
+            'position_1' => 'EGLL_APP',
+            'taken' => 1,
+            'finished' => ExamBooking::NOT_FINISHED_FLAG,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '11:00:00',
+            'taken_to' => '13:00:00',
+        ]);
+
+        $result = $this->service->findOverlappingBookingForSession($session);
+
+        $this->assertInstanceOf(ExamBooking::class, $result);
+    }
 }


### PR DESCRIPTION
# Summary of changes
- show overlapping sessions warning on Accepted Mentoring sessions table

# Screenshots (if necessary)
<img width="961" height="790" alt="image" src="https://github.com/user-attachments/assets/2571207e-443b-40b9-84f3-f09154cfe216" />
