### PR TITLE
fix: align heading on upcoming mentoring session

### DIFF
--- a/resources/views/filament/widgets/upcoming-training-session-widget.blade.php
+++ b/resources/views/filament/widgets/upcoming-training-session-widget.blade.php
@@ -2,7 +2,7 @@
 	@if ($session && $startsAt && $endsAt)
 		<x-filament::callout icon="heroicon-o-academic-cap" color="primary">
 			<x-slot name="heading">
-				<div class="flex items-center justify-between gap-4">
+				<div class="flex items-center justify-between gap-4 -mt-1">
 					<div>
 						Upcoming session:
 						<span class="font-bold">


### PR DESCRIPTION
# Summary of changes
- align heading on upcoming mentoring session

# Screenshots (if necessary)
Before:
<img width="1280" height="143" alt="image" src="https://github.com/user-attachments/assets/1fadeaf3-7bdc-4eec-8196-e774b6d82b29" />

After:
<img width="1277" height="128" alt="image" src="https://github.com/user-attachments/assets/dc9cb004-a7f7-4c1c-831c-33bedba62a0b" />
