### PR TITLE
Add availability log logic

### DIFF
--- a/app/Enums/AvailabilityLogEvent.php
+++ b/app/Enums/AvailabilityLogEvent.php
@@ -14,7 +14,7 @@ enum AvailabilityLogEvent: string
     {
         return match ($this) {
             self::Added => 'Added',
-            self::Merged => 'Merged',
+            self::Merged => 'Extended',
             self::Edited => 'Edited',
         };
     }

--- a/app/Filament/Training/Pages/MyTraining/MyAvailability.php
+++ b/app/Filament/Training/Pages/MyTraining/MyAvailability.php
@@ -8,6 +8,7 @@ use App\Models\Cts\Member;
 use App\Models\Cts\Position;
 use App\Models\Cts\PositionValidation;
 use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Services\Training\AvailabilityLogService;
 use App\Services\Training\AvailabilityService;
 use Carbon\Carbon;
 use CodeWithKyrian\FilamentDateRange\Forms\Components\DateRangePicker;
@@ -269,11 +270,20 @@ class MyAvailability extends Page implements HasForms, HasTable
                             return;
                         }
 
+                        $oldFrom = Carbon::parse($record->date->format('Y-m-d').' '.$record->from->format('H:i:s'), 'UTC');
+                        $oldTo = Carbon::parse($record->date->format('Y-m-d').' '.$record->to->format('H:i:s'), 'UTC');
+
                         $record->update([
                             'date' => $startUtc->toDateString(),
                             'from' => $startUtc->format('H:i:s'),
                             'to' => $endUtc->format('H:i:s'),
                         ]);
+
+                        $service = app(AvailabilityLogService::class);
+                        $service->recordEdited(
+                            $service->activeTrainingPlacesForAccount(auth()->id()),
+                            $oldFrom, $oldTo, $startUtc, $endUtc,
+                        );
 
                         Notification::make()->title('Availability updated')->success()->send();
                     }),
@@ -282,10 +292,33 @@ class MyAvailability extends Page implements HasForms, HasTable
                     ->color('danger')
                     ->iconButton()
                     ->requiresConfirmation(false)
-                    ->action(fn ($record) => $record->delete()),
+                    ->action(function (Availability $record): void {
+                        $from = Carbon::parse($record->date->format('Y-m-d').' '.$record->from->format('H:i:s'), 'UTC');
+                        $to = Carbon::parse($record->date->format('Y-m-d').' '.$record->to->format('H:i:s'), 'UTC');
+
+                        $record->delete();
+
+                        $service = app(AvailabilityLogService::class);
+                        $service->recordRemoved($service->activeTrainingPlacesForAccount(auth()->id()), $from, $to);
+                    }),
             ])
             ->bulkActions([
-                DeleteBulkAction::make(),
+                DeleteBulkAction::make()
+                    ->after(function (\Illuminate\Support\Collection $records): void {
+                        $service = app(AvailabilityLogService::class);
+                        $places = $service->activeTrainingPlacesForAccount(auth()->id());
+
+                        foreach ($records as $record) {
+                            if ($record->exists()) {
+                                continue;
+                            }
+
+                            $from = Carbon::parse($record->date->format('Y-m-d').' '.$record->from->format('H:i:s'), 'UTC');
+                            $to = Carbon::parse($record->date->format('Y-m-d').' '.$record->to->format('H:i:s'), 'UTC');
+
+                            $service->recordRemoved($places, $from, $to);
+                        }
+                    }),
             ])
             ->emptyStateHeading('No availability added yet')
             ->emptyStateDescription('Use the form to add your availability slots.')

--- a/app/Livewire/Training/AvailabilityLogReview.php
+++ b/app/Livewire/Training/AvailabilityLogReview.php
@@ -32,6 +32,10 @@ class AvailabilityLogReview extends Component implements HasActions, HasForms, H
 
     public function mount(): void
     {
+        if (! auth()->user()?->can('training-places.view.*')) {
+            abort(403);
+        }
+
         $this->form->fill([
             'asOf' => now()->format('Y-m-d H:i'),
         ]);
@@ -57,7 +61,11 @@ class AvailabilityLogReview extends Component implements HasActions, HasForms, H
             return null;
         }
 
-        $asOf = Carbon::parse($this->data['asOf']);
+        try {
+            $asOf = Carbon::parse($this->data['asOf']);
+        } catch (\Throwable) {
+            return null;
+        }
 
         return $asOf->isAfter(now()) ? now() : $asOf;
     }

--- a/app/Livewire/Training/AvailabilityLogReview.php
+++ b/app/Livewire/Training/AvailabilityLogReview.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Training;
+
+use App\Models\Training\TrainingPlace\AvailabilityLogEntry;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use Carbon\Carbon;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Component;
+
+class AvailabilityLogReview extends Component implements HasActions, HasForms, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+    use InteractsWithTable;
+
+    public TrainingPlace $trainingPlace;
+
+    public array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'asOf' => now()->format('Y-m-d H:i'),
+        ]);
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form->schema([
+            DateTimePicker::make('asOf')
+                ->label('Availability as of')
+                ->timezone('UTC')
+                ->seconds(false)
+                ->native(false)
+                ->displayFormat('d.m.Y H:i')
+                ->live()
+                ->maxDate(now()),
+        ])->statePath('data');
+    }
+
+    public function asOfCarbon(): ?Carbon
+    {
+        if (blank($this->data['asOf'] ?? null)) {
+            return null;
+        }
+
+        $asOf = Carbon::parse($this->data['asOf']);
+
+        return $asOf->isAfter(now()) ? now() : $asOf;
+    }
+
+    public function setAsOfToNow(): void
+    {
+        $this->data['asOf'] = now()->format('Y-m-d H:i');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->queryStringIdentifier('availability-log-snapshot')
+            ->query(function (): Builder {
+                $asOf = $this->asOfCarbon();
+
+                if (! $asOf) {
+                    return AvailabilityLogEntry::query()->whereRaw('1 = 0');
+                }
+
+                return AvailabilityLogEntry::query()
+                    ->where('training_place_id', $this->trainingPlace->id)
+                    ->where('created_at', '<=', $asOf)
+                    ->where(function (Builder $query) use ($asOf) {
+                        $query->whereNull('superseded_at')
+                            ->orWhere('superseded_at', '>', $asOf);
+                    })
+                    ->orderBy('slot_from');
+            })
+            ->paginated(false)
+            ->columns([
+                TextColumn::make('day')
+                    ->label('Day')
+                    ->state(fn (AvailabilityLogEntry $record) => $record->slot_from->format('d.m.Y')),
+
+                TextColumn::make('time')
+                    ->label('Time (Zulu)')
+                    ->fontFamily('mono')
+                    ->state(fn (AvailabilityLogEntry $record) => $record->slot_from->format('H:i').' - '.$record->slot_to->format('H:i')),
+
+                TextColumn::make('duration')
+                    ->label('Duration')
+                    ->state(fn (AvailabilityLogEntry $record) => $this->slotDuration($record)),
+            ])
+            ->emptyStateHeading('No availability at this time');
+    }
+
+    private function slotDuration(AvailabilityLogEntry $entry): string
+    {
+        $minutes = (int) $entry->slot_from->diffInMinutes($entry->slot_to);
+
+        if ($minutes < 60) {
+            return "{$minutes}m";
+        }
+
+        $hours = intdiv($minutes, 60);
+        $remaining = $minutes % 60;
+
+        return $remaining === 0 ? "{$hours}h" : "{$hours}h {$remaining}m";
+    }
+
+    public function render()
+    {
+        return view('livewire.training.availability-log-review');
+    }
+}

--- a/app/Livewire/Training/AvailabilityLogTable.php
+++ b/app/Livewire/Training/AvailabilityLogTable.php
@@ -15,6 +15,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
+use Illuminate\Support\Collection;
 use Livewire\Component;
 
 class AvailabilityLogTable extends Component implements HasActions, HasSchemas, HasTable
@@ -24,6 +25,15 @@ class AvailabilityLogTable extends Component implements HasActions, HasSchemas, 
     use InteractsWithTable;
 
     public TrainingPlace $trainingPlace;
+
+    private ?Collection $successorCreatedAts = null;
+
+    public function mount(): void
+    {
+        if (! auth()->user()?->can('training-places.view.*')) {
+            abort(403);
+        }
+    }
 
     public function table(Table $table): Table
     {
@@ -70,7 +80,19 @@ class AvailabilityLogTable extends Component implements HasActions, HasSchemas, 
             ->emptyStateHeading('No availability logged yet');
     }
 
-    private function logEntryStatus(AvailabilityLogEntry $entry): string
+    /**
+     * The created_at timestamps of merged/edited successors for this training place,
+     * memoized so the status column does not query once per row.
+     */
+    private function successorCreatedAts(): Collection
+    {
+        return $this->successorCreatedAts ??= AvailabilityLogEntry::query()
+            ->where('training_place_id', $this->trainingPlace->id)
+            ->whereIn('event', [AvailabilityLogEvent::Merged, AvailabilityLogEvent::Edited])
+            ->pluck('created_at');
+    }
+
+    public function logEntryStatus(AvailabilityLogEntry $entry): string
     {
         if ($entry->superseded_at === null) {
             return 'Current';
@@ -80,13 +102,9 @@ class AvailabilityLogTable extends Component implements HasActions, HasSchemas, 
         // version's superseded_at (the write-wiring stamps both with one shared now()).
         // This match is unambiguous because the UI serializes a student's actions - two
         // mutations to one training place within the same wall-clock second do not occur.
-        $hasSuccessor = AvailabilityLogEntry::query()
-            ->where('training_place_id', $entry->training_place_id)
-            ->where('created_at', $entry->superseded_at)
-            ->whereIn('event', [AvailabilityLogEvent::Merged, AvailabilityLogEvent::Edited])
-            ->exists();
-
-        return $hasSuccessor ? 'Changed' : 'Removed';
+        return $this->successorCreatedAts()->contains($entry->superseded_at->format('Y-m-d H:i:s'))
+            ? 'Changed'
+            : 'Removed';
     }
 
     public function render()

--- a/app/Livewire/Training/AvailabilityLogTable.php
+++ b/app/Livewire/Training/AvailabilityLogTable.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Training;
+
+use App\Enums\AvailabilityLogEvent;
+use App\Models\Training\TrainingPlace\AvailabilityLogEntry;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Livewire\Component;
+
+class AvailabilityLogTable extends Component implements HasActions, HasSchemas, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use InteractsWithTable;
+
+    public TrainingPlace $trainingPlace;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->queryStringIdentifier('availability-log')
+            ->query(
+                AvailabilityLogEntry::query()
+                    ->where('training_place_id', $this->trainingPlace->id)
+                    ->orderBy('created_at', 'desc')
+            )
+            ->paginated([10, 25, 50])
+            ->defaultPaginationPageOption(10)
+            ->columns([
+                TextColumn::make('created_at')
+                    ->label('When')
+                    ->dateTime('d.m.Y H:i'),
+
+                TextColumn::make('event')
+                    ->label('Event')
+                    ->badge()
+                    ->formatStateUsing(fn (AvailabilityLogEntry $record) => $record->event->label())
+                    ->color(fn (AvailabilityLogEntry $record) => match ($record->event) {
+                        AvailabilityLogEvent::Added => 'success',
+                        AvailabilityLogEvent::Merged => 'warning',
+                        AvailabilityLogEvent::Edited => 'info',
+                        default => 'gray',
+                    }),
+
+                TextColumn::make('slot')
+                    ->label('Slot')
+                    ->state(fn (AvailabilityLogEntry $record) => $record->slot_from->format('d.m.Y H:i').' - '.$record->slot_to->format('H:i')),
+
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->state(fn (AvailabilityLogEntry $record) => $this->logEntryStatus($record))
+                    ->color(fn (string $state) => match ($state) {
+                        'Current' => 'success',
+                        'Changed' => 'info',
+                        'Removed' => 'danger',
+                        default => 'gray',
+                    }),
+            ])
+            ->emptyStateHeading('No availability logged yet');
+    }
+
+    private function logEntryStatus(AvailabilityLogEntry $entry): string
+    {
+        if ($entry->superseded_at === null) {
+            return 'Current';
+        }
+
+        // A successor is the next version of the same slot, so its created_at equals this
+        // version's superseded_at (the write-wiring stamps both with one shared now()).
+        // This match is unambiguous because the UI serializes a student's actions - two
+        // mutations to one training place within the same wall-clock second do not occur.
+        $hasSuccessor = AvailabilityLogEntry::query()
+            ->where('training_place_id', $entry->training_place_id)
+            ->where('created_at', $entry->superseded_at)
+            ->whereIn('event', [AvailabilityLogEvent::Merged, AvailabilityLogEvent::Edited])
+            ->exists();
+
+        return $hasSuccessor ? 'Changed' : 'Removed';
+    }
+
+    public function render()
+    {
+        return view('livewire.training.availability-log-table');
+    }
+}

--- a/app/Services/Training/AvailabilityLogService.php
+++ b/app/Services/Training/AvailabilityLogService.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Training;
+
+use App\Enums\AvailabilityLogEvent;
+use App\Models\Training\TrainingPlace\AvailabilityLogEntry;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use Carbon\Carbon;
+use Closure;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class AvailabilityLogService
+{
+    /**
+     * @return Collection<int, TrainingPlace>
+     */
+    public function activeTrainingPlacesForAccount(int $cid): Collection
+    {
+        return TrainingPlace::query()
+            ->where('account_id', $cid)
+            ->whereNull('deleted_at')
+            ->get();
+    }
+
+    /**
+     * @param  Collection<int, TrainingPlace>  $places
+     */
+    public function recordAdded(Collection $places, Carbon $from, Carbon $to): void
+    {
+        foreach ($places as $place) {
+            $this->write(fn () => AvailabilityLogEntry::create([
+                'training_place_id' => $place->id,
+                'event' => AvailabilityLogEvent::Added,
+                'slot_from' => $from,
+                'slot_to' => $to,
+                'created_at' => now(),
+            ]));
+        }
+    }
+
+    /**
+     * @param  Collection<int, TrainingPlace>  $places
+     */
+    public function recordMerged(Collection $places, Carbon $oldFrom, Carbon $oldTo, Carbon $newFrom, Carbon $newTo): void
+    {
+        $now = now();
+
+        foreach ($places as $place) {
+            $this->write(function () use ($place, $now, $oldFrom, $oldTo, $newFrom, $newTo): void {
+                DB::transaction(function () use ($place, $now, $oldFrom, $oldTo, $newFrom, $newTo): void {
+                    $this->supersedeMatching($place, $oldFrom, $oldTo, $now);
+
+                    AvailabilityLogEntry::create([
+                        'training_place_id' => $place->id,
+                        'event' => AvailabilityLogEvent::Merged,
+                        'slot_from' => $newFrom,
+                        'slot_to' => $newTo,
+                        'created_at' => $now,
+                    ]);
+                });
+            });
+        }
+    }
+
+    /**
+     * @param  Collection<int, TrainingPlace>  $places
+     */
+    public function recordEdited(Collection $places, Carbon $oldFrom, Carbon $oldTo, Carbon $newFrom, Carbon $newTo): void
+    {
+        $now = now();
+
+        foreach ($places as $place) {
+            $this->write(function () use ($place, $now, $oldFrom, $oldTo, $newFrom, $newTo): void {
+                DB::transaction(function () use ($place, $now, $oldFrom, $oldTo, $newFrom, $newTo): void {
+                    $this->supersedeMatching($place, $oldFrom, $oldTo, $now);
+
+                    AvailabilityLogEntry::create([
+                        'training_place_id' => $place->id,
+                        'event' => AvailabilityLogEvent::Edited,
+                        'slot_from' => $newFrom,
+                        'slot_to' => $newTo,
+                        'created_at' => $now,
+                    ]);
+                });
+            });
+        }
+    }
+
+    /**
+     * @param  Collection<int, TrainingPlace>  $places
+     */
+    public function recordRemoved(Collection $places, Carbon $from, Carbon $to): void
+    {
+        $now = now();
+
+        foreach ($places as $place) {
+            $this->write(fn () => DB::transaction(
+                fn () => $this->supersedeMatching($place, $from, $to, $now)
+            ));
+        }
+    }
+
+    private function currentVersion(TrainingPlace $place, Carbon $from, Carbon $to): ?AvailabilityLogEntry
+    {
+        return AvailabilityLogEntry::query()
+            ->where('training_place_id', $place->id)
+            ->whereNull('superseded_at')
+            ->where('slot_from', $from)
+            ->where('slot_to', $to)
+            ->first();
+    }
+
+    private function supersedeMatching(TrainingPlace $place, Carbon $from, Carbon $to, Carbon $now): void
+    {
+        $current = $this->currentVersion($place, $from, $to);
+
+        if ($current) {
+            $current->update(['superseded_at' => $now]);
+        }
+    }
+
+    private function write(Closure $operation): void
+    {
+        try {
+            $operation();
+        } catch (Throwable $exception) {
+            Log::warning('Failed to write availability log entry', ['exception' => $exception]);
+        }
+    }
+}

--- a/app/Services/Training/AvailabilityService.php
+++ b/app/Services/Training/AvailabilityService.php
@@ -119,6 +119,8 @@ class AvailabilityService
                 'to' => $mergedEnd->format('H:i:s'),
             ]);
 
+            $this->logAvailabilityMutation($studentId, 'merged', $existingStart, $existingEnd, $mergedStart, $mergedEnd);
+
             return 'merged';
         }
 
@@ -130,6 +132,30 @@ class AvailabilityService
             'to' => $endUtc->format('H:i:s'),
         ]);
 
+        $this->logAvailabilityMutation($studentId, 'added', null, null, $startUtc, $endUtc);
+
         return 'added';
+    }
+
+    private function logAvailabilityMutation(int $studentId, string $type, ?Carbon $oldFrom, ?Carbon $oldTo, Carbon $newFrom, Carbon $newTo): void
+    {
+        $cid = Member::where('id', $studentId)->value('cid');
+
+        if (! $cid) {
+            return;
+        }
+
+        $service = app(AvailabilityLogService::class);
+        $places = $service->activeTrainingPlacesForAccount($cid);
+
+        if ($places->isEmpty()) {
+            return;
+        }
+
+        match ($type) {
+            'added' => $service->recordAdded($places, $newFrom, $newTo),
+            'merged' => $service->recordMerged($places, $oldFrom, $oldTo, $newFrom, $newTo),
+            default => null,
+        };
     }
 }

--- a/resources/views/filament/training/pages/view-training-place.blade.php
+++ b/resources/views/filament/training/pages/view-training-place.blade.php
@@ -9,6 +9,15 @@
 
 	@livewire(\App\Livewire\Training\AvailabilityWarningsTable::class, ['trainingPlace' => $this->trainingPlace], key('availability-warnings-table'))
 
+	<x-filament::section collapsible>
+		<x-slot name="heading">Availability log</x-slot>
+		<x-slot name="description">
+			Every change the student made to their availability is listed here, newest first. A slot can appear more than once if
+			it was later changed or extended.
+		</x-slot>
+		@livewire(\App\Livewire\Training\AvailabilityLogReview::class, ['trainingPlace' => $this->trainingPlace], key('availability-log-review'))
+	</x-filament::section>
+
 	@if (
 		$this->trainingPlace->trainingPosition &&
 			($this->trainingPlace->trainingPosition->should_show_solo_endorsement ?? true))

--- a/resources/views/livewire/training/availability-log-review.blade.php
+++ b/resources/views/livewire/training/availability-log-review.blade.php
@@ -1,0 +1,20 @@
+<div>
+	<div class="mb-4 flex items-end gap-2">
+		<div class="flex-1">
+			{{ $this->form }}
+		</div>
+		<x-filament::button wire:click="setAsOfToNow" icon="heroicon-m-clock">
+			Now
+		</x-filament::button>
+	</div>
+	<p class="mb-4 mt-1 text-xs text-gray-400">All times are in Zulu.</p>
+
+	{{ $this->table }}
+
+	<div class="mt-4">
+		<x-filament::section collapsible collapsed>
+			<x-slot name="heading">Log history</x-slot>
+			@livewire(\App\Livewire\Training\AvailabilityLogTable::class, ['trainingPlace' => $this->trainingPlace], key('availability-log-table'))
+		</x-filament::section>
+	</div>
+</div>

--- a/resources/views/livewire/training/availability-log-table.blade.php
+++ b/resources/views/livewire/training/availability-log-table.blade.php
@@ -1,0 +1,3 @@
+<div>
+	{{ $this->table }}
+</div>

--- a/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityLogWiringTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityLogWiringTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\MyTraining;
+
+use App\Filament\Training\Pages\MyTraining\MyAvailability;
+use App\Models\Cts\Availability;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\AvailabilityLogEntry;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class MyAvailabilityLogWiringTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    protected Account $studentAccount;
+
+    protected Member $studentMember;
+
+    protected TrainingPlace $place;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->travelTo(Carbon::create(2026, 5, 10, 12, 0, 0));
+
+        $this->studentAccount = Account::factory()->create();
+        $this->studentMember = Member::factory()->forAccount($this->studentAccount)->create();
+        $this->studentAccount->givePermissionTo('training.access');
+
+        $this->place = TrainingPlace::factory()->createQuietly([
+            'account_id' => $this->studentAccount->id,
+        ]);
+    }
+
+    #[Test]
+    public function adding_availability_writes_an_added_version(): void
+    {
+        $tomorrow = now()->addDay()->toDateString();
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAvailability::class)
+            ->set('data.date_range', ['start' => $tomorrow, 'end' => $tomorrow])
+            ->set('data.from', '18:00')
+            ->set('data.to', '21:00')
+            ->call('create');
+
+        $entry = AvailabilityLogEntry::where('training_place_id', $this->place->id)->sole();
+
+        $this->assertSame('added', $entry->event->value);
+        $this->assertSame("{$tomorrow} 18:00:00", $entry->slot_from->format('Y-m-d H:i:s'));
+        $this->assertSame("{$tomorrow} 21:00:00", $entry->slot_to->format('Y-m-d H:i:s'));
+        $this->assertNull($entry->superseded_at);
+    }
+
+    #[Test]
+    public function adding_availability_logs_to_every_active_training_place(): void
+    {
+        $secondPlace = TrainingPlace::factory()->createQuietly([
+            'account_id' => $this->studentAccount->id,
+        ]);
+
+        $tomorrow = now()->addDay()->toDateString();
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAvailability::class)
+            ->set('data.date_range', ['start' => $tomorrow, 'end' => $tomorrow])
+            ->set('data.from', '18:00')
+            ->set('data.to', '21:00')
+            ->call('create');
+
+        $this->assertSame(2, AvailabilityLogEntry::where('slot_from', "{$tomorrow} 18:00:00")->count());
+        $this->assertSame(1, AvailabilityLogEntry::where('training_place_id', $secondPlace->id)->count());
+    }
+
+    #[Test]
+    public function merging_availability_writes_a_merged_version_and_supersedes_the_current_one(): void
+    {
+        $date = now()->addDay()->toDateString();
+
+        Availability::factory()->forStudent($this->studentMember->id)->create([
+            'date' => $date,
+            'from' => '18:00:00',
+            'to' => '20:00:00',
+            'type' => 'S',
+        ]);
+
+        $added = AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'added',
+            'slot_from' => "{$date} 18:00:00",
+            'slot_to' => "{$date} 20:00:00",
+            'created_at' => now()->subDay(),
+            'superseded_at' => null,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAvailability::class)
+            ->set('data.date_range', ['start' => $date, 'end' => $date])
+            ->set('data.from', '19:00')
+            ->set('data.to', '21:00')
+            ->call('create');
+
+        $merged = AvailabilityLogEntry::where('training_place_id', $this->place->id)
+            ->where('event', 'merged')
+            ->sole();
+
+        $this->assertNotNull($added->fresh()->superseded_at);
+        $this->assertSame("{$date} 18:00:00", $merged->slot_from->format('Y-m-d H:i:s'));
+        $this->assertSame("{$date} 21:00:00", $merged->slot_to->format('Y-m-d H:i:s'));
+        $this->assertSame(
+            $added->fresh()->superseded_at->format('Y-m-d H:i:s'),
+            $merged->created_at->format('Y-m-d H:i:s'),
+            'Shared timestamp invariant broken.',
+        );
+    }
+
+    #[Test]
+    public function editing_availability_writes_an_edited_version(): void
+    {
+        $date = now()->addDay()->toDateString();
+
+        $slot = Availability::factory()->forStudent($this->studentMember->id)->create([
+            'date' => $date,
+            'from' => '18:00:00',
+            'to' => '21:00:00',
+            'type' => 'S',
+        ]);
+
+        $added = AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'added',
+            'slot_from' => "{$date} 18:00:00",
+            'slot_to' => "{$date} 21:00:00",
+            'created_at' => now()->subDay(),
+            'superseded_at' => null,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAvailability::class)
+            ->callTableAction('edit', $slot)
+            ->fillTableActionForm([
+                'date' => $date,
+                'from' => '17:00',
+                'to' => '20:00',
+            ])
+            ->callMountedTableAction();
+
+        $edited = AvailabilityLogEntry::where('training_place_id', $this->place->id)
+            ->where('event', 'edited')
+            ->sole();
+
+        $this->assertNotNull($added->fresh()->superseded_at, 'Editing must supersede the previous version.');
+        $this->assertSame("{$date} 17:00:00", $edited->slot_from->format('Y-m-d H:i:s'));
+        $this->assertSame("{$date} 20:00:00", $edited->slot_to->format('Y-m-d H:i:s'));
+    }
+
+    #[Test]
+    public function deleting_availability_writes_a_removed_version(): void
+    {
+        $date = now()->addDay()->toDateString();
+
+        $slot = Availability::factory()->forStudent($this->studentMember->id)->create([
+            'date' => $date,
+            'from' => '18:00:00',
+            'to' => '21:00:00',
+            'type' => 'S',
+        ]);
+
+        $current = AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'added',
+            'slot_from' => "{$date} 18:00:00",
+            'slot_to' => "{$date} 21:00:00",
+            'created_at' => now()->subDay(),
+            'superseded_at' => null,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAvailability::class)
+            ->callTableAction('delete', $slot);
+
+        $this->assertNotNull($current->fresh()->superseded_at);
+        $this->assertSame(1, AvailabilityLogEntry::where('training_place_id', $this->place->id)->count());
+    }
+
+    #[Test]
+    public function bulk_deleting_writes_a_removed_version_per_slot(): void
+    {
+        $date = now()->addDay()->toDateString();
+
+        $slotA = Availability::factory()->forStudent($this->studentMember->id)->create([
+            'date' => $date,
+            'from' => '18:00:00',
+            'to' => '19:00:00',
+            'type' => 'S',
+        ]);
+
+        $slotB = Availability::factory()->forStudent($this->studentMember->id)->create([
+            'date' => $date,
+            'from' => '20:00:00',
+            'to' => '21:00:00',
+            'type' => 'S',
+        ]);
+
+        $entryA = AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'added',
+            'slot_from' => "{$date} 18:00:00",
+            'slot_to' => "{$date} 19:00:00",
+            'created_at' => now()->subDay(),
+            'superseded_at' => null,
+        ]);
+
+        $entryB = AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'added',
+            'slot_from' => "{$date} 20:00:00",
+            'slot_to' => "{$date} 21:00:00",
+            'created_at' => now()->subDay(),
+            'superseded_at' => null,
+        ]);
+
+        Livewire::actingAs($this->studentAccount)
+            ->test(MyAvailability::class)
+            ->callTableBulkAction('delete', [$slotA->id, $slotB->id]);
+
+        $this->assertNotNull($entryA->fresh()->superseded_at);
+        $this->assertNotNull($entryB->fresh()->superseded_at);
+    }
+}

--- a/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityLogWiringTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityLogWiringTest.php
@@ -146,13 +146,11 @@ class MyAvailabilityLogWiringTest extends BaseTrainingPanelTestCase
 
         Livewire::actingAs($this->studentAccount)
             ->test(MyAvailability::class)
-            ->callTableAction('edit', $slot)
-            ->fillTableActionForm([
+            ->callTableAction('edit', $slot, [
                 'date' => $date,
                 'from' => '17:00',
                 'to' => '20:00',
-            ])
-            ->callMountedTableAction();
+            ]);
 
         $edited = AvailabilityLogEntry::where('training_place_id', $this->place->id)
             ->where('event', 'edited')

--- a/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityLogWiringTest.php
+++ b/tests/Feature/TrainingPanel/MyTraining/MyAvailabilityLogWiringTest.php
@@ -164,7 +164,7 @@ class MyAvailabilityLogWiringTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
-    public function deleting_availability_writes_a_removed_version(): void
+    public function deleting_availability_supersedes_the_current_version_without_a_removed_event(): void
     {
         $date = now()->addDay()->toDateString();
 
@@ -193,7 +193,7 @@ class MyAvailabilityLogWiringTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
-    public function bulk_deleting_writes_a_removed_version_per_slot(): void
+    public function bulk_deleting_supersedes_each_current_version_without_removed_events(): void
     {
         $date = now()->addDay()->toDateString();
 

--- a/tests/Feature/TrainingPanel/TrainingPlace/AvailabilityLogReviewTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/AvailabilityLogReviewTest.php
@@ -115,7 +115,7 @@ class AvailabilityLogReviewTest extends BaseTrainingPanelTestCase
         $component = Livewire::actingAs($this->panelUser)
             ->test(AvailabilityLogTable::class, ['trainingPlace' => $this->place]);
 
-        $statuses = collect($component->instance()->getTable()->getRecords())
+        $statuses = $this->tableRecords($component)
             ->mapWithKeys(fn (AvailabilityLogEntry $entry) => [$entry->event->value => $entry]);
 
         $this->assertSame('Changed', $component->instance()->logEntryStatus($statuses['added']));
@@ -130,9 +130,19 @@ class AvailabilityLogReviewTest extends BaseTrainingPanelTestCase
         $component = Livewire::actingAs($this->panelUser)
             ->test(AvailabilityLogTable::class, ['trainingPlace' => $this->place]);
 
-        $events = collect($component->instance()->getTable()->getRecords())
-            ->pluck('event.value');
+        $events = $this->tableRecords($component)->pluck('event.value');
 
         $this->assertSame(['edited', 'added'], $events->all());
+    }
+
+    private function tableRecords($component): \Illuminate\Support\Collection
+    {
+        $records = $component->instance()->getTable()->getRecords();
+
+        if ($records instanceof \Illuminate\Contracts\Pagination\Paginator) {
+            return $records->getCollection();
+        }
+
+        return collect($records);
     }
 }

--- a/tests/Feature/TrainingPanel/TrainingPlace/AvailabilityLogReviewTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/AvailabilityLogReviewTest.php
@@ -23,6 +23,8 @@ class AvailabilityLogReviewTest extends BaseTrainingPanelTestCase
     {
         parent::setUp();
 
+        $this->panelUser->givePermissionTo('training-places.view.*');
+
         $this->place = TrainingPlace::factory()->createQuietly();
     }
 
@@ -116,8 +118,8 @@ class AvailabilityLogReviewTest extends BaseTrainingPanelTestCase
         $statuses = collect($component->instance()->getTable()->getRecords())
             ->mapWithKeys(fn (AvailabilityLogEntry $entry) => [$entry->event->value => $entry]);
 
-        $this->assertSame('Changed', $this->invokeStatus($component, $statuses['added']));
-        $this->assertSame('Removed', $this->invokeStatus($component, $statuses['edited']));
+        $this->assertSame('Changed', $component->instance()->logEntryStatus($statuses['added']));
+        $this->assertSame('Removed', $component->instance()->logEntryStatus($statuses['edited']));
     }
 
     #[Test]
@@ -132,12 +134,5 @@ class AvailabilityLogReviewTest extends BaseTrainingPanelTestCase
             ->pluck('event.value');
 
         $this->assertSame(['edited', 'added'], $events->all());
-    }
-
-    private function invokeStatus($component, AvailabilityLogEntry $entry): string
-    {
-        $reflection = new \ReflectionMethod($component->instance(), 'logEntryStatus');
-
-        return $reflection->invoke($component->instance(), $entry);
     }
 }

--- a/tests/Feature/TrainingPanel/TrainingPlace/AvailabilityLogReviewTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/AvailabilityLogReviewTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TrainingPanel\TrainingPlace;
+
+use App\Livewire\Training\AvailabilityLogReview;
+use App\Livewire\Training\AvailabilityLogTable;
+use App\Models\Training\TrainingPlace\AvailabilityLogEntry;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class AvailabilityLogReviewTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    protected TrainingPlace $place;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->place = TrainingPlace::factory()->createQuietly();
+    }
+
+    private function seedChain(): void
+    {
+        $added = AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'added',
+            'slot_from' => '2026-05-15 18:00:00',
+            'slot_to' => '2026-05-15 21:00:00',
+            'created_at' => '2026-05-14 09:00:00',
+            'superseded_at' => null,
+        ]);
+
+        $edited = AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'edited',
+            'slot_from' => '2026-05-15 18:00:00',
+            'slot_to' => '2026-05-15 22:00:00',
+            'created_at' => '2026-05-16 10:00:00',
+            'superseded_at' => null,
+        ]);
+
+        $added->update(['superseded_at' => '2026-05-16 10:00:00']);
+        $edited->update(['superseded_at' => '2026-05-18 12:00:00']);
+    }
+
+    #[Test]
+    public function snapshot_is_empty_when_no_entries_exist_before_the_as_of_time(): void
+    {
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(AvailabilityLogReview::class, ['trainingPlace' => $this->place])
+            ->set('data.asOf', '2026-05-13 12:00');
+
+        $this->assertCount(0, $component->instance()->getTable()->getRecords());
+    }
+
+    #[Test]
+    public function snapshot_reconstructs_the_active_slot_at_each_point_in_time(): void
+    {
+        $this->seedChain();
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(AvailabilityLogReview::class, ['trainingPlace' => $this->place]);
+
+        $component->set('data.asOf', '2026-05-15 12:00');
+        $records = $component->instance()->getTable()->getRecords();
+        $this->assertCount(1, $records);
+        $this->assertSame('2026-05-15 21:00:00', $records->first()->slot_to->format('Y-m-d H:i:s'));
+
+        $component->set('data.asOf', '2026-05-17 12:00');
+        $records = $component->instance()->getTable()->getRecords();
+        $this->assertCount(1, $records);
+        $this->assertSame('2026-05-15 22:00:00', $records->first()->slot_to->format('Y-m-d H:i:s'));
+
+        $component->set('data.asOf', '2026-05-19 12:00');
+        $this->assertCount(0, $component->instance()->getTable()->getRecords());
+    }
+
+    #[Test]
+    public function snapshot_at_the_exact_shared_timestamp_shows_only_the_successor(): void
+    {
+        $this->seedChain();
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(AvailabilityLogReview::class, ['trainingPlace' => $this->place])
+            ->set('data.asOf', '2026-05-16 10:00');
+
+        $records = $component->instance()->getTable()->getRecords();
+
+        $this->assertCount(1, $records, 'At the shared timestamp exactly one version must be active (no double count).');
+        $this->assertSame('edited', $records->first()->event->value);
+    }
+
+    #[Test]
+    public function it_renders_successfully_with_an_empty_log(): void
+    {
+        Livewire::actingAs($this->panelUser)
+            ->test(AvailabilityLogReview::class, ['trainingPlace' => $this->place])
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function narrative_table_marks_the_removed_version(): void
+    {
+        $this->seedChain();
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(AvailabilityLogTable::class, ['trainingPlace' => $this->place]);
+
+        $statuses = collect($component->instance()->getTable()->getRecords())
+            ->mapWithKeys(fn (AvailabilityLogEntry $entry) => [$entry->event->value => $entry]);
+
+        $this->assertSame('Changed', $this->invokeStatus($component, $statuses['added']));
+        $this->assertSame('Removed', $this->invokeStatus($component, $statuses['edited']));
+    }
+
+    #[Test]
+    public function narrative_table_lists_all_versions_newest_first(): void
+    {
+        $this->seedChain();
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(AvailabilityLogTable::class, ['trainingPlace' => $this->place]);
+
+        $events = collect($component->instance()->getTable()->getRecords())
+            ->pluck('event.value');
+
+        $this->assertSame(['edited', 'added'], $events->all());
+    }
+
+    private function invokeStatus($component, AvailabilityLogEntry $entry): string
+    {
+        $reflection = new \ReflectionMethod($component->instance(), 'logEntryStatus');
+
+        return $reflection->invoke($component->instance(), $entry);
+    }
+}

--- a/tests/Unit/Services/Training/AvailabilityLogServiceTest.php
+++ b/tests/Unit/Services/Training/AvailabilityLogServiceTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Training;
+
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\AvailabilityLogEntry;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Services\Training\AvailabilityLogService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AvailabilityLogServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected AvailabilityLogService $service;
+
+    protected Account $account;
+
+    protected Member $member;
+
+    protected TrainingPlace $place;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->travelTo(Carbon::create(2026, 5, 10, 12, 0, 0));
+
+        $this->service = new AvailabilityLogService;
+        $this->account = Account::factory()->create();
+        $this->member = Member::factory()->forAccount($this->account)->create();
+        $this->place = TrainingPlace::factory()->createQuietly([
+            'account_id' => $this->account->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_returns_only_active_training_places_for_the_account(): void
+    {
+        TrainingPlace::factory()->createQuietly([
+            'account_id' => $this->account->id,
+        ]);
+
+        $trashed = TrainingPlace::factory()->createQuietly([
+            'account_id' => $this->account->id,
+        ]);
+        $trashed->delete();
+
+        $places = $this->service->activeTrainingPlacesForAccount($this->account->id);
+
+        $this->assertCount(2, $places);
+        $this->assertTrue($places->contains('id', $this->place->id));
+        $this->assertFalse($places->contains('id', $trashed->id));
+    }
+
+    #[Test]
+    public function record_added_inserts_an_added_version_per_place(): void
+    {
+        $places = $this->service->activeTrainingPlacesForAccount($this->account->id);
+
+        $this->service->recordAdded($places, Carbon::parse('2026-05-15 18:00:00'), Carbon::parse('2026-05-15 21:00:00'));
+
+        $entry = AvailabilityLogEntry::where('training_place_id', $this->place->id)->sole();
+
+        $this->assertSame('added', $entry->event->value);
+        $this->assertSame('2026-05-15 18:00:00', $entry->slot_from->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-05-15 21:00:00', $entry->slot_to->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-05-10 12:00:00', $entry->created_at->format('Y-m-d H:i:s'));
+        $this->assertNull($entry->superseded_at);
+    }
+
+    #[Test]
+    public function record_removed_supersedes_the_current_version_without_a_successor(): void
+    {
+        $places = $this->service->activeTrainingPlacesForAccount($this->account->id);
+        $current = AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'added',
+            'slot_from' => '2026-05-15 18:00:00',
+            'slot_to' => '2026-05-15 21:00:00',
+            'created_at' => '2026-05-08 09:00:00',
+            'superseded_at' => null,
+        ]);
+
+        $this->service->recordRemoved($places, Carbon::parse('2026-05-15 18:00:00'), Carbon::parse('2026-05-15 21:00:00'));
+
+        $this->assertSame('2026-05-10 12:00:00', $current->fresh()->superseded_at->format('Y-m-d H:i:s'));
+        $this->assertSame(1, AvailabilityLogEntry::where('training_place_id', $this->place->id)->count());
+    }
+
+    #[Test]
+    public function record_merged_supersedes_the_old_version_and_inserts_a_merged_version_with_a_shared_timestamp(): void
+    {
+        $places = $this->service->activeTrainingPlacesForAccount($this->account->id);
+        $old = AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'added',
+            'slot_from' => '2026-05-15 18:00:00',
+            'slot_to' => '2026-05-15 20:00:00',
+            'created_at' => '2026-05-08 09:00:00',
+            'superseded_at' => null,
+        ]);
+
+        $this->service->recordMerged(
+            $places,
+            Carbon::parse('2026-05-15 18:00:00'),
+            Carbon::parse('2026-05-15 20:00:00'),
+            Carbon::parse('2026-05-15 18:00:00'),
+            Carbon::parse('2026-05-15 21:00:00'),
+        );
+
+        $merged = AvailabilityLogEntry::where('training_place_id', $this->place->id)
+            ->where('event', 'merged')
+            ->sole();
+
+        $this->assertSame('2026-05-10 12:00:00', $old->fresh()->superseded_at->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-05-10 12:00:00', $merged->created_at->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-05-15 18:00:00', $merged->slot_from->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-05-15 21:00:00', $merged->slot_to->format('Y-m-d H:i:s'));
+        $this->assertNull($merged->superseded_at);
+        $this->assertSame(
+            $old->fresh()->superseded_at->format('Y-m-d H:i:s'),
+            $merged->created_at->format('Y-m-d H:i:s'),
+            'Successor created_at must equal predecessor superseded_at (shared timestamp).',
+        );
+    }
+
+    #[Test]
+    public function record_edited_supersedes_and_inserts_an_edited_version(): void
+    {
+        $places = $this->service->activeTrainingPlacesForAccount($this->account->id);
+        AvailabilityLogEntry::factory()->create([
+            'training_place_id' => $this->place->id,
+            'event' => 'added',
+            'slot_from' => '2026-05-15 18:00:00',
+            'slot_to' => '2026-05-15 21:00:00',
+            'created_at' => '2026-05-08 09:00:00',
+            'superseded_at' => null,
+        ]);
+
+        $this->service->recordEdited(
+            $places,
+            Carbon::parse('2026-05-15 18:00:00'),
+            Carbon::parse('2026-05-15 21:00:00'),
+            Carbon::parse('2026-05-16 17:00:00'),
+            Carbon::parse('2026-05-16 20:00:00'),
+        );
+
+        $edited = AvailabilityLogEntry::where('training_place_id', $this->place->id)
+            ->where('event', 'edited')
+            ->sole();
+
+        $this->assertSame('2026-05-16 17:00:00', $edited->slot_from->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-05-16 20:00:00', $edited->slot_to->format('Y-m-d H:i:s'));
+        $this->assertSame(2, AvailabilityLogEntry::where('training_place_id', $this->place->id)->count());
+    }
+
+    #[Test]
+    public function record_merged_without_a_matching_current_version_still_inserts(): void
+    {
+        $places = $this->service->activeTrainingPlacesForAccount($this->account->id);
+
+        $this->service->recordMerged(
+            $places,
+            Carbon::parse('2026-05-15 18:00:00'),
+            Carbon::parse('2026-05-15 20:00:00'),
+            Carbon::parse('2026-05-15 18:00:00'),
+            Carbon::parse('2026-05-15 21:00:00'),
+        );
+
+        $this->assertSame(1, AvailabilityLogEntry::where('training_place_id', $this->place->id)->count());
+        $this->assertSame('merged', AvailabilityLogEntry::where('training_place_id', $this->place->id)->sole()->event->value);
+    }
+
+    #[Test]
+    public function record_removed_without_a_matching_current_version_is_a_no_op(): void
+    {
+        $places = $this->service->activeTrainingPlacesForAccount($this->account->id);
+
+        $this->service->recordRemoved($places, Carbon::parse('2026-05-15 18:00:00'), Carbon::parse('2026-05-15 21:00:00'));
+
+        $this->assertSame(0, AvailabilityLogEntry::where('training_place_id', $this->place->id)->count());
+    }
+
+    #[Test]
+    public function a_log_write_failure_never_throws(): void
+    {
+        Log::shouldReceive('warning')->once();
+
+        $ghost = TrainingPlace::factory()->make();
+        $ghost->id = str()->ulid(); // id that does not exist in DB -> FK violation on insert
+
+        $this->service->recordAdded(collect([$ghost]), Carbon::parse('2026-05-15 18:00:00'), Carbon::parse('2026-05-15 21:00:00'));
+
+        $this->assertSame(0, AvailabilityLogEntry::where('training_place_id', $ghost->id)->count());
+    }
+}


### PR DESCRIPTION
Allows admin to see both update logs and availability as it was in the system at any point in the past.
Wires only into the training panel, CTS will have to be turned off (https://github.com/VATSIM-UK/cts/pull/38/changes)

<img width="1237" height="900" alt="image" src="https://github.com/user-attachments/assets/812ca523-970b-4eff-a5a7-5f5a5be846c9" />
