### PR TITLE
feat: add mentor name to overlapping alerts

### DIFF
--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -308,7 +308,7 @@ class MentoringSessionsService
         $to = Carbon::parse($overlap->taken_to)->format('H:i');
         $staffName = $overlap instanceof Session ? $overlap->mentor?->name : $overlap->examiners?->primaryExaminer?->name;
 
-        return "There is already a {$type} booked on this position from {$from} to {$to} with {$staffName}.";
+        return "{$staffName} already has a {$type} booked on this position from {$from} to {$to}.";
     }
 
     private function validateSessionTimes(Availability $availability, string $takenFrom, string $takenTo): void

--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -306,8 +306,9 @@ class MentoringSessionsService
         $type = $overlap instanceof Session ? 'session' : 'exam';
         $from = Carbon::parse($overlap->taken_from)->format('H:i');
         $to = Carbon::parse($overlap->taken_to)->format('H:i');
+        $staffName = $overlap instanceof Session ? $overlap->mentor?->name : $overlap->examiners?->primaryExaminer?->name;
 
-        return "There is already a {$type} booked on this position from {$from} to {$to}.";
+        return "There is already a {$type} booked on this position from {$from} to {$to} with {$staffName}.";
     }
 
     private function validateSessionTimes(Availability $availability, string $takenFrom, string $takenTo): void

--- a/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
@@ -214,7 +214,7 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
 
         Livewire::actingAs($this->mentor)
             ->test(AcceptedMentoringSessionsTable::class)
-            ->assertSee('There is already a session booked on this position from 11:00 to 13:00.');
+            ->assertSee('already has a session booked on this position');
     }
 
     #[Test]
@@ -237,7 +237,7 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
 
         Livewire::actingAs($this->mentor)
             ->test(AcceptedMentoringSessionsTable::class)
-            ->assertDontSee('There is already a session booked on this position');
+            ->assertDontSee('already has a session booked on this position');
     }
 
     #[Test]


### PR DESCRIPTION
# Summary of changes
- Adds mentor/examiner name to overlapping alerts.

# Screenshots (if necessary)
<img width="469" height="158" alt="image" src="https://github.com/user-attachments/assets/ac2c226a-7048-4b21-90c5-8b11fa06de45" />
