### PR TITLE
Ensure new mentor is sent in session reallocation properly

### DIFF
--- a/app/Notifications/Training/Mentoring/MentoringSessionReallocatedStudentNotification.php
+++ b/app/Notifications/Training/Mentoring/MentoringSessionReallocatedStudentNotification.php
@@ -15,7 +15,7 @@ class MentoringSessionReallocatedStudentNotification extends Notification implem
 
     public function __construct(
         private Session $session,
-        private string $oldMentorName,
+        private string $newMentorName,
     ) {}
 
     public function getEmailType(): EmailType
@@ -40,7 +40,7 @@ class MentoringSessionReallocatedStudentNotification extends Notification implem
                 'session' => $session,
                 'position' => $session->position,
                 'sessionDateTime' => $session->formattedSessionDateTime(),
-                'newMentorName' => $session->mentor?->account?->name ?? 'TBD',
+                'newMentorName' => $this->newMentorName,
             ]);
     }
 }

--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -236,13 +236,13 @@ class MentoringSessionsService
                 $newMentorAccount = $data['newMentorAccount'];
                 $reason = $data['reason'];
                 $oldMentorName = $oldMentorAccount?->name ?? 'Unknown';
+                $newMentorName = $newMentorAccount->name ?? 'Unknown';
 
                 if ($studentAccount) {
-                    $studentAccount->notify(new MentoringSessionReallocatedStudentNotification($session, $oldMentorName));
+                    $studentAccount->notify(new MentoringSessionReallocatedStudentNotification($session, $newMentorName));
                 }
 
                 if ($oldMentorAccount) {
-                    $newMentorName = $newMentorAccount->name ?? 'Unknown';
                     $oldMentorAccount->notify(new MentoringSessionReallocatedOldMentorNotification($session, $reason, $newMentorName));
                 }
 

--- a/tests/Unit/Notifications/Training/Mentoring/MentoringSessionNotificationsTest.php
+++ b/tests/Unit/Notifications/Training/Mentoring/MentoringSessionNotificationsTest.php
@@ -227,9 +227,9 @@ class MentoringSessionNotificationsTest extends TestCase
     #[Test]
     public function reallocated_student_notification_uses_expected_subject_view_and_data(): void
     {
-        $oldMentorName = $this->mentorAccount->name;
+        $newMentorName = 'Sam Newmentor';
 
-        $notification = new MentoringSessionReallocatedStudentNotification($this->session, $oldMentorName);
+        $notification = new MentoringSessionReallocatedStudentNotification($this->session, $newMentorName);
         $mail = $notification->toMail($this->studentAccount);
 
         $this->assertContains('mail', $notification->via($this->studentAccount));
@@ -241,6 +241,7 @@ class MentoringSessionNotificationsTest extends TestCase
         );
         $this->assertSame($this->session->id, $mail->viewData['session']->id);
         $this->assertSame('EGLL_APP', $mail->viewData['position']);
+        $this->assertSame($newMentorName, $mail->viewData['newMentorName']);
 
         $html = View::make($mail->view, $mail->data())->render();
 
@@ -248,7 +249,7 @@ class MentoringSessionNotificationsTest extends TestCase
         $this->assertStringContainsString('re-allocated your mentoring session to another mentor', $html);
         $this->assertStringContainsString('EGLL_APP', $html);
         $this->assertStringContainsString($this->session->formattedSessionDateTime(), $html);
-        $this->assertStringContainsString('Jamie Mentor', $html);
+        $this->assertStringContainsString($newMentorName, $html);
     }
 
     #[Test]

--- a/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
@@ -31,6 +31,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\View;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -1044,6 +1045,72 @@ class MentoringSessionsServiceTest extends TestCase
         Notification::assertSentTo($this->studentAccount, MentoringSessionReallocatedStudentNotification::class);
         Notification::assertSentTo($this->mentorAccount, MentoringSessionReallocatedOldMentorNotification::class);
         Notification::assertSentTo($newMentorAccount, MentoringSessionReallocatedNewMentorNotification::class);
+    }
+
+    #[Test]
+    public function reallocate_session_sends_student_notification_with_new_mentor_name(): void
+    {
+        Notification::fake();
+
+        $oldMentorAccount = Account::factory()->create([
+            'name_first' => 'Jamie',
+            'name_last' => 'Mentor',
+        ]);
+        $oldMentorAccount->givePermissionTo('training.mentoring.view.*');
+
+        $oldMentorMember = Member::factory()->create([
+            'id' => $oldMentorAccount->generateCTSInternalID($oldMentorAccount->id),
+            'cid' => $oldMentorAccount->id,
+        ]);
+
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'mentor_id' => $oldMentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+        ]);
+
+        $newMentorAccount = Account::factory()->create([
+            'name_first' => 'Sam',
+            'name_last' => 'Newmentor',
+        ]);
+        Member::factory()->create([
+            'id' => $newMentorAccount->generateCTSInternalID($newMentorAccount->id),
+            'cid' => $newMentorAccount->id,
+        ]);
+
+        $trainingPosition = TrainingPosition::factory()->create([
+            'category' => 'S3 Training',
+            'cts_positions' => ['EGLL_APP'],
+        ]);
+
+        MentorTrainingPosition::create([
+            'account_id' => $newMentorAccount->id,
+            'mentorable_type' => TrainingPosition::class,
+            'mentorable_id' => $trainingPosition->id,
+            'created_by' => $newMentorAccount->id,
+        ]);
+
+        $this->service->reallocateSession(
+            $session->id,
+            $newMentorAccount->id,
+            $oldMentorAccount,
+            'Mentor is unavailable due to prior commitments.',
+        );
+
+        Notification::assertSentTo(
+            $this->studentAccount,
+            MentoringSessionReallocatedStudentNotification::class,
+            function (MentoringSessionReallocatedStudentNotification $notification): bool {
+                $mail = $notification->toMail($this->studentAccount);
+                $html = View::make($mail->view, $mail->data())->render();
+
+                return str_contains($html, 'Sam Newmentor') && ! str_contains($html, 'Jamie Mentor');
+            },
+        );
     }
 
     #[Test]


### PR DESCRIPTION
reallocateSession() cached the old mentor relation - that's why old mentor was always sent