### PR TITLE
Enforce 15-minute booking slots on the calendar

### DIFF
--- a/app/Livewire/Bookings/Calendar.php
+++ b/app/Livewire/Bookings/Calendar.php
@@ -640,8 +640,8 @@ class Calendar extends Component
                     return;
                 }
 
-                if ($startsAt->equalTo($endsAt)) {
-                    $this->dispatch('booking-error', message: 'Booking length cannot be zero minutes.');
+                if ($endsAt->lessThanOrEqualTo($startsAt)) {
+                    $this->dispatch('booking-error', message: 'End time must be after start time.');
 
                     return;
                 }

--- a/app/Livewire/Bookings/Calendar.php
+++ b/app/Livewire/Bookings/Calendar.php
@@ -588,6 +588,11 @@ class Calendar extends Component
         return (int) $parts[0] * 60 + (int) $parts[1];
     }
 
+    private function isOnFifteenMinuteBoundary(Carbon $time): bool
+    {
+        return $time->second === 0 && $time->minute % 15 === 0;
+    }
+
     public function createBooking(array $data): void
     {
         if (! auth()->check()) {
@@ -620,8 +625,20 @@ class Calendar extends Component
                 return;
             }
 
+            if (! $this->isOnFifteenMinuteBoundary($startsAt)) {
+                $this->dispatch('booking-error', message: 'Start and end times must be on 15-minute boundaries.');
+
+                return;
+            }
+
             if (! empty($data['ends_at'])) {
                 $endsAt = Carbon::parse($data['ends_at']);
+
+                if (! $this->isOnFifteenMinuteBoundary($endsAt)) {
+                    $this->dispatch('booking-error', message: 'Start and end times must be on 15-minute boundaries.');
+
+                    return;
+                }
 
                 if ($startsAt->equalTo($endsAt)) {
                     $this->dispatch('booking-error', message: 'Booking length cannot be zero minutes.');

--- a/app/Support/Bookings/BookingTimeSlots.php
+++ b/app/Support/Bookings/BookingTimeSlots.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Bookings;
+
+/**
+ * Quarter-hour booking slots used by the bookings calendar create modal.
+ *
+ * Mirrors the Alpine helpers in resources/views/livewire/bookings/_create-modal.blade.php
+ * so the "end must be after start" filtering can be unit-tested in PHP.
+ */
+final class BookingTimeSlots
+{
+    /**
+     * @return list<string> Times as H:i on 15-minute boundaries from 00:00 to 23:45.
+     */
+    public static function all(): array
+    {
+        $slots = [];
+
+        for ($hour = 0; $hour < 24; $hour++) {
+            foreach ([0, 15, 30, 45] as $minute) {
+                $slots[] = sprintf('%02d:%02d', $hour, $minute);
+            }
+        }
+
+        return $slots;
+    }
+
+    /**
+     * End times that are strictly later than the given start on the same day.
+     *
+     * @return list<string>
+     */
+    public static function validEndTimes(?string $startTime): array
+    {
+        $slots = self::all();
+
+        if ($startTime === null || $startTime === '') {
+            return $slots;
+        }
+
+        $startMinutes = self::toMinutes($startTime);
+
+        return array_values(array_filter(
+            $slots,
+            fn (string $slot): bool => self::toMinutes($slot) > $startMinutes
+        ));
+    }
+
+    /**
+     * Keep the current end when it is still valid; otherwise prefer start+1h, else the earliest valid slot.
+     */
+    public static function ensureValidEndTime(string $startTime, ?string $endTime): string
+    {
+        $valid = self::validEndTimes($startTime);
+
+        if ($endTime !== null && $endTime !== '' && in_array($endTime, $valid, true)) {
+            return $endTime;
+        }
+
+        $preferredMinutes = self::toMinutes($startTime) + 60;
+        $preferred = sprintf('%02d:%02d', intdiv($preferredMinutes, 60) % 24, $preferredMinutes % 60);
+
+        if (in_array($preferred, $valid, true)) {
+            return $preferred;
+        }
+
+        return $valid[0] ?? '';
+    }
+
+    public static function toMinutes(string $time): int
+    {
+        [$hour, $minute] = explode(':', $time);
+
+        return (int) $hour * 60 + (int) $minute;
+    }
+}

--- a/resources/assets/js/bookings-calendar.js
+++ b/resources/assets/js/bookings-calendar.js
@@ -177,7 +177,8 @@ document.addEventListener('alpine:init', () => {
             event.preventDefault();
             const bar = event.currentTarget;
             const pct = this.getPosFromEvent(event, bar);
-            const startMinutes = this.pctToMinutes(pct);
+            // Latest start that still leaves room for a 15-minute slot before midnight.
+            const startMinutes = Math.min(1425, this.pctToMinutes(pct));
             this.dragging = {
                 pos,
                 bar,
@@ -207,6 +208,10 @@ document.addEventListener('alpine:init', () => {
                     end = start + 15;
                 }
             }
+            // Clamp to the day and re-snap so the minimum-slot nudge cannot leave
+            // the selection off a 15-minute boundary or outside 00:00–24:00.
+            start = this.snapToSlot(Math.max(0, Math.min(1425, start)));
+            end = this.snapToSlot(Math.max(start + 15, Math.min(1440, end)));
             this.dragging.startMinutes = start;
             this.dragging.currentMinutes = end;
         },
@@ -236,7 +241,7 @@ document.addEventListener('alpine:init', () => {
             if (!this.isAuthenticated) return;
             const bar = event.currentTarget;
             const pct = this.getPosFromEvent(event, bar);
-            const startMinutes = this.pctToMinutes(pct);
+            const startMinutes = Math.min(1380, this.pctToMinutes(pct));
             const endMinutes = startMinutes + 60;
             const endDate = endMinutes >= 1440 ? this.addDay(this.selectedDate) : this.selectedDate;
 

--- a/resources/views/livewire/bookings/_create-modal.blade.php
+++ b/resources/views/livewire/bookings/_create-modal.blade.php
@@ -84,6 +84,16 @@
         const [h, m] = t.split(":").map(Number);
         return h * 60 + m;
     },
+    snapToTimeSlot(t) {
+        if (!t) return "";
+        if (this.timeSlots.includes(t)) return t;
+        const mins = this.timeMinutes(t);
+        if (Number.isNaN(mins)) return "";
+        const snapped = ((Math.round(mins / 15) * 15) % 1440 + 1440) % 1440;
+        const h = Math.floor(snapped / 60);
+        const m = snapped % 60;
+        return String(h).padStart(2, "0") + ":" + String(m).padStart(2, "0");
+    },
     validEndTimes() {
         if (!this.startTime) return this.timeSlots;
         const min = this.timeMinutes(this.startTime);
@@ -98,7 +108,9 @@
 		x-show="open" x-cloak
 		x-on:open-create-modal.window="
             const d = $event.detail || {};
-            date = d.startDate || ''; startTime = d.startTime || ''; endTime = d.endTime || '';
+            date = d.startDate || '';
+            startTime = snapToTimeSlot(d.startTime || '');
+            endTime = snapToTimeSlot(d.endTime || '');
             selectedPosition = d.prefillPositionId || '';
             selectedCallsign = d.prefillCallsign || '';
             resetPositionSearch();
@@ -150,6 +162,10 @@
                             errorMessage = 'End time must be after start time.';
                             submitting = false; return;
                         }
+                        if (timeMinutes(startTime) % 15 !== 0 || timeMinutes(endTime) % 15 !== 0) {
+                            errorMessage = 'Start and end times must be on 15-minute boundaries.';
+                            submitting = false; return;
+                        }
                         if (!selectedPosition) {
                             errorMessage = 'Please select a position.';
                             submitting = false; return;
@@ -161,6 +177,7 @@
 						<div class="mb-5">
 							<label class="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Date</label>
 							<input type="date" x-model="date" required
+								x-on:keydown="if (!['Tab', 'Escape', 'Enter'].includes($event.key)) $event.preventDefault()" x-on:paste.prevent
 								class="block w-full rounded-lg border-gray-300 bg-white shadow-sm focus:border-brand focus:ring-brand text-sm px-3 py-2.5">
 						</div>
 
@@ -172,6 +189,7 @@
 									<div class="text-[10px] text-gray-400 font-medium uppercase tracking-wide mb-1.5">Start</div>
 									<div class="relative">
 										<select x-model="startTime"
+											x-on:keydown="if (!['ArrowUp', 'ArrowDown', 'Enter', 'Escape', 'Tab'].includes($event.key)) $event.preventDefault()"
 											class="block w-full rounded-lg border-gray-300 bg-white shadow-sm focus:border-brand focus:ring-brand text-sm px-3 py-2.5 appearance-none pr-8">
 											@foreach ($timeSlots as $slot)
 												<option value="{{ $slot }}">{{ $slot }}</option>
@@ -186,6 +204,7 @@
 									<div class="text-[10px] text-gray-400 font-medium uppercase tracking-wide mb-1.5">End</div>
 									<div class="relative">
 										<select x-model="endTime"
+											x-on:keydown="if (!['ArrowUp', 'ArrowDown', 'Enter', 'Escape', 'Tab'].includes($event.key)) $event.preventDefault()"
 											class="block w-full rounded-lg border-gray-300 bg-white shadow-sm focus:border-brand focus:ring-brand text-sm px-3 py-2.5 appearance-none pr-8">
 											@foreach ($timeSlots as $slot)
 												<option value="{{ $slot }}">{{ $slot }}</option>

--- a/resources/views/livewire/bookings/_create-modal.blade.php
+++ b/resources/views/livewire/bookings/_create-modal.blade.php
@@ -1,11 +1,6 @@
 <template x-teleport="body">
 	@php
-		$timeSlots = [];
-		for ($h = 0; $h < 24; $h++) {
-		    foreach ([0, 15, 30, 45] as $m) {
-		        $timeSlots[] = sprintf('%02d:%02d', $h, $m);
-		    }
-		}
+		$timeSlots = \App\Support\Bookings\BookingTimeSlots::all();
 		$positionSearchMinLength = \App\Livewire\Bookings\Calendar::POSITION_SEARCH_MIN_LENGTH;
 	@endphp
 	<div
@@ -94,10 +89,19 @@
         const m = snapped % 60;
         return String(h).padStart(2, "0") + ":" + String(m).padStart(2, "0");
     },
-    validEndTimes() {
+    get validEndTimes() {
         if (!this.startTime) return this.timeSlots;
         const min = this.timeMinutes(this.startTime);
-        return this.timeSlots;
+        return this.timeSlots.filter((t) => this.timeMinutes(t) > min);
+    },
+    ensureValidEndTime() {
+        if (!this.startTime) return;
+        if (this.endTime && this.validEndTimes.includes(this.endTime)) return;
+        const preferred = this.timeMinutes(this.startTime) + 60;
+        const preferredSlot = this.timeSlots.find((t) => this.timeMinutes(t) === preferred);
+        this.endTime = preferredSlot && this.validEndTimes.includes(preferredSlot)
+            ? preferredSlot
+            : (this.validEndTimes[0] || "");
     },
     selectPosition(id, callsign) {
         this.selectedPosition = id;
@@ -111,6 +115,7 @@
             date = d.startDate || '';
             startTime = snapToTimeSlot(d.startTime || '');
             endTime = snapToTimeSlot(d.endTime || '');
+            ensureValidEndTime();
             selectedPosition = d.prefillPositionId || '';
             selectedCallsign = d.prefillCallsign || '';
             resetPositionSearch();
@@ -188,7 +193,7 @@
 								<div>
 									<div class="text-[10px] text-gray-400 font-medium uppercase tracking-wide mb-1.5">Start</div>
 									<div class="relative">
-										<select x-model="startTime"
+										<select x-model="startTime" x-on:change="ensureValidEndTime()"
 											x-on:keydown="if (!['ArrowUp', 'ArrowDown', 'Enter', 'Escape', 'Tab'].includes($event.key)) $event.preventDefault()"
 											class="block w-full rounded-lg border-gray-300 bg-white shadow-sm focus:border-brand focus:ring-brand text-sm px-3 py-2.5 appearance-none pr-8">
 											@foreach ($timeSlots as $slot)
@@ -206,9 +211,9 @@
 										<select x-model="endTime"
 											x-on:keydown="if (!['ArrowUp', 'ArrowDown', 'Enter', 'Escape', 'Tab'].includes($event.key)) $event.preventDefault()"
 											class="block w-full rounded-lg border-gray-300 bg-white shadow-sm focus:border-brand focus:ring-brand text-sm px-3 py-2.5 appearance-none pr-8">
-											@foreach ($timeSlots as $slot)
-												<option value="{{ $slot }}">{{ $slot }}</option>
-											@endforeach
+											<template x-for="slot in validEndTimes" :key="slot">
+												<option :value="slot" x-text="slot"></option>
+											</template>
 										</select>
 										<i
 											class="fa fa-chevron-down absolute right-2.5 top-1/2 -translate-y-1/2 text-[10px] text-gray-400 pointer-events-none"

--- a/tests/Feature/Bookings/CalendarTest.php
+++ b/tests/Feature/Bookings/CalendarTest.php
@@ -101,6 +101,25 @@ class CalendarTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_end_time_before_start_time(): void
+    {
+        $member = Account::factory()->withQualification()->create();
+        $this->placeOnRoster($member);
+        $position = Position::factory()->create(['type' => Position::TYPE_ENROUTE]);
+
+        Livewire::actingAs($member)
+            ->test(Calendar::class)
+            ->call('createBooking', [
+                'starts_at' => Carbon::tomorrow()->setTime(12, 0)->format('Y-m-d H:i:s'),
+                'ends_at' => Carbon::tomorrow()->setTime(10, 0)->format('Y-m-d H:i:s'),
+                'position_id' => (string) $position->id,
+            ])
+            ->assertDispatched('booking-error');
+
+        $this->assertDatabaseMissing('bookings', ['member_id' => $member->id]);
+    }
+
+    #[Test]
     public function it_rejects_times_not_on_fifteen_minute_boundaries(): void
     {
         $member = Account::factory()->withQualification()->create();

--- a/tests/Feature/Bookings/CalendarTest.php
+++ b/tests/Feature/Bookings/CalendarTest.php
@@ -101,6 +101,60 @@ class CalendarTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_times_not_on_fifteen_minute_boundaries(): void
+    {
+        $member = Account::factory()->withQualification()->create();
+        $this->placeOnRoster($member);
+        $position = Position::factory()->create(['type' => Position::TYPE_ENROUTE]);
+
+        Livewire::actingAs($member)
+            ->test(Calendar::class)
+            ->call('createBooking', [
+                'starts_at' => Carbon::tomorrow()->setTime(10, 7)->format('Y-m-d H:i:s'),
+                'ends_at' => Carbon::tomorrow()->setTime(12, 0)->format('Y-m-d H:i:s'),
+                'position_id' => (string) $position->id,
+            ])
+            ->assertDispatched('booking-error');
+
+        Livewire::actingAs($member)
+            ->test(Calendar::class)
+            ->call('createBooking', [
+                'starts_at' => Carbon::tomorrow()->setTime(10, 0)->format('Y-m-d H:i:s'),
+                'ends_at' => Carbon::tomorrow()->setTime(12, 10)->format('Y-m-d H:i:s'),
+                'position_id' => (string) $position->id,
+            ])
+            ->assertDispatched('booking-error');
+
+        $this->assertDatabaseMissing('bookings', ['member_id' => $member->id]);
+    }
+
+    #[Test]
+    public function it_accepts_times_on_fifteen_minute_boundaries(): void
+    {
+        $member = Account::factory()->withQualification()->create();
+        $qual = Qualification::factory()->atc()->create(['vatsim' => 5]);
+        $member->qualifications()->sync([$qual->id]);
+        $member = $member->fresh();
+        $this->placeOnRoster($member);
+
+        $position = Position::factory()->create(['type' => Position::TYPE_ENROUTE]);
+
+        Livewire::actingAs($member)
+            ->test(Calendar::class)
+            ->call('createBooking', [
+                'starts_at' => Carbon::tomorrow()->setTime(10, 15)->format('Y-m-d H:i:s'),
+                'ends_at' => Carbon::tomorrow()->setTime(11, 45)->format('Y-m-d H:i:s'),
+                'position_id' => (string) $position->id,
+            ])
+            ->assertDispatched('booking-created');
+
+        $this->assertDatabaseHas('bookings', [
+            'member_id' => $member->id,
+            'position_id' => $position->id,
+        ]);
+    }
+
+    #[Test]
     public function it_creates_a_booking_successfully(): void
     {
         $member = Account::factory()->withQualification()->create();

--- a/tests/Unit/Support/Bookings/BookingTimeSlotsTest.php
+++ b/tests/Unit/Support/Bookings/BookingTimeSlotsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Bookings;
+
+use App\Support\Bookings\BookingTimeSlots;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BookingTimeSlotsTest extends TestCase
+{
+    #[Test]
+    public function it_lists_all_quarter_hour_slots_for_a_day(): void
+    {
+        $slots = BookingTimeSlots::all();
+
+        $this->assertCount(96, $slots);
+        $this->assertSame('00:00', $slots[0]);
+        $this->assertSame('00:15', $slots[1]);
+        $this->assertSame('23:45', $slots[95]);
+        $this->assertNotContains('24:00', $slots);
+        $this->assertNotContains('10:07', $slots);
+    }
+
+    #[Test]
+    public function it_returns_all_slots_when_start_time_is_empty(): void
+    {
+        $this->assertSame(BookingTimeSlots::all(), BookingTimeSlots::validEndTimes(null));
+        $this->assertSame(BookingTimeSlots::all(), BookingTimeSlots::validEndTimes(''));
+    }
+
+    #[Test]
+    public function it_hides_end_times_earlier_than_or_equal_to_the_start(): void
+    {
+        $valid = BookingTimeSlots::validEndTimes('10:00');
+
+        $this->assertNotContains('09:45', $valid);
+        $this->assertNotContains('10:00', $valid);
+        $this->assertSame('10:15', $valid[0]);
+        $this->assertContains('11:00', $valid);
+        $this->assertContains('23:45', $valid);
+        $this->assertCount(55, $valid);
+    }
+
+    #[Test]
+    public function it_returns_no_end_times_when_start_is_the_last_slot(): void
+    {
+        $this->assertSame([], BookingTimeSlots::validEndTimes('23:45'));
+    }
+
+    #[Test]
+    #[DataProvider('ensureValidEndTimeProvider')]
+    public function it_ensures_the_end_time_stays_after_the_start(
+        string $startTime,
+        ?string $endTime,
+        string $expected,
+    ): void {
+        $this->assertSame($expected, BookingTimeSlots::ensureValidEndTime($startTime, $endTime));
+    }
+
+    public static function ensureValidEndTimeProvider(): array
+    {
+        return [
+            'keeps a later end time' => ['10:00', '12:00', '12:00'],
+            'replaces an earlier end with start plus one hour' => ['10:00', '09:00', '11:00'],
+            'replaces an equal end with start plus one hour' => ['10:00', '10:00', '11:00'],
+            'replaces a missing end with start plus one hour' => ['10:00', null, '11:00'],
+            'falls back to the next slot when plus one hour is unavailable' => ['23:00', '22:00', '23:15'],
+            'returns empty when no later slot exists' => ['23:45', '00:00', ''],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Reject booking start/end times that are not on 15-minute boundaries in `Calendar::createBooking`
- Keep timeline drag selection snapped/clamped to quarter-hour slots within the day
- Block free typing in the create modal date/time fields and snap any prefilled times onto valid slots

## Test plan
- [ ] Open `/atc/bookings/calendar` and create a booking via the Book button using only the select pickers
- [ ] Confirm date/time fields cannot be typed into (picker / arrow keys only)
- [ ] Drag a slot on a position row and confirm start/end stay on `:00` / `:15` / `:30` / `:45`
- [ ] Attempt to create a booking with off-boundary times via Livewire (or temporarily bypass UI) and confirm a booking-error is returned
- [ ] Run `php artisan test tests/Feature/Bookings/CalendarTest.php --filter=fifteen_minute`


Made with [Cursor](https://cursor.com)