### PR TITLE
chore: show PHP notice details in test output

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" displayDetailsOnAllIssues="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage/>
   <testsuites>
     <testsuite name="Feature">

--- a/tests/Unit/TeamSpeak/AtcServerGroupTest.php
+++ b/tests/Unit/TeamSpeak/AtcServerGroupTest.php
@@ -31,15 +31,13 @@ class AtcServerGroupTest extends TestCase
         parent::setUp();
 
         $this->service = new AtcServerGroupService;
-        $this->server = $this->createMock(Server::class);
+        $this->server = $this->createStub(Server::class);
         $this->account = Account::factory()->create();
     }
 
     private function makeReply(): Reply
     {
-        return $this->getMockBuilder(Reply::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createStub(Reply::class);
     }
 
     private function giveAccountTsRegistration(Account $account, int $dbid = 12345): void
@@ -53,9 +51,7 @@ class AtcServerGroupTest extends TestCase
 
     private function makeTsServerGroup(int $sgid = 100): TsServerGroup
     {
-        $node = $this->getMockBuilder(TsServerGroup::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $node = $this->createStub(TsServerGroup::class);
         $node->method('getId')->willReturn($sgid);
 
         return $node;
@@ -100,16 +96,17 @@ class AtcServerGroupTest extends TestCase
 
     public function test_assign_creates_new_ts_server_group_when_none_exists()
     {
+        $server = $this->createMock(Server::class);
         $this->giveAccountTsRegistration($this->account);
-        $this->server->method('serverGroupGetByName')
+        $server->method('serverGroupGetByName')
             ->willThrowException(new ServerQueryException('group not found', 0));
-        $this->server->expects($this->once())
+        $server->expects($this->once())
             ->method('serverGroupCreate')
             ->with('EGKK_TWR')
             ->willReturn(100);
-        $this->server->method('request')->willReturn($this->makeReply());
+        $server->method('request')->willReturn($this->makeReply());
 
-        $this->service->assign($this->account, 'EGKK_TWR', $this->server);
+        $this->service->assign($this->account, 'EGKK_TWR', $server);
 
         $this->assertDatabaseHas('teamspeak_atc_server_groups', [
             'callsign' => 'EGKK_TWR',
@@ -140,14 +137,15 @@ class AtcServerGroupTest extends TestCase
 
     public function test_assign_reuses_existing_db_record_without_ts_lookup()
     {
+        $server = $this->createMock(Server::class);
         $this->giveAccountTsRegistration($this->account);
         $this->makeServerGroup('EGKK_TWR', 100);
 
-        $this->server->expects($this->never())->method('serverGroupGetByName');
-        $this->server->expects($this->never())->method('serverGroupCreate');
-        $this->server->method('request')->willReturn($this->makeReply());
+        $server->expects($this->never())->method('serverGroupGetByName');
+        $server->expects($this->never())->method('serverGroupCreate');
+        $server->method('request')->willReturn($this->makeReply());
 
-        $this->service->assign($this->account, 'EGKK_TWR', $this->server);
+        $this->service->assign($this->account, 'EGKK_TWR', $server);
 
         $this->assertEquals(1, AtcServerGroup::where('callsign', 'EGKK_TWR')->count());
     }
@@ -187,9 +185,10 @@ class AtcServerGroupTest extends TestCase
 
     public function test_assign_skips_ts_calls_when_account_has_no_registration()
     {
-        $this->server->expects($this->never())->method('request');
+        $server = $this->createMock(Server::class);
+        $server->expects($this->never())->method('request');
 
-        $this->service->assign($this->account, 'EGKK_TWR', $this->server);
+        $this->service->assign($this->account, 'EGKK_TWR', $server);
 
         $this->assertDatabaseMissing('teamspeak_atc_group_assignments', [
             'account_id' => $this->account->id,
@@ -347,12 +346,13 @@ class AtcServerGroupTest extends TestCase
 
     public function test_prune_empty_groups_skips_groups_with_assignments()
     {
+        $server = $this->createMock(Server::class);
         $group = $this->makeServerGroup();
         $this->makeAssignment($this->account, $group);
 
-        $this->server->expects($this->never())->method('request');
+        $server->expects($this->never())->method('request');
 
-        $count = $this->service->pruneEmptyGroups($this->server);
+        $count = $this->service->pruneEmptyGroups($server);
 
         $this->assertEquals(0, $count);
         $this->assertDatabaseHas('teamspeak_atc_server_groups', ['id' => $group->id]);

--- a/tests/Unit/Training/Mentoring/MentoringAnnouncementServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringAnnouncementServiceTest.php
@@ -17,7 +17,7 @@ class MentoringAnnouncementServiceTest extends TestCase
 
     private function makeService(?MentorPermissionService $permissionService = null): MentoringAnnouncementService
     {
-        return new MentoringAnnouncementService(new Discord, $permissionService ?? $this->createMock(MentorPermissionService::class));
+        return new MentoringAnnouncementService(new Discord, $permissionService ?? $this->createStub(MentorPermissionService::class));
     }
 
     private function makeSession(array $attributes = []): Session
@@ -34,10 +34,10 @@ class MentoringAnnouncementServiceTest extends TestCase
 
     private function makeAtcPermissionService(string $category = 'S2 Training'): MentorPermissionService
     {
-        $mock = $this->createMock(MentorPermissionService::class);
-        $mock->method('resolveCategoryForCtsCallsign')->willReturn($category);
+        $stub = $this->createStub(MentorPermissionService::class);
+        $stub->method('resolveCategoryForCtsCallsign')->willReturn($category);
 
-        return $mock;
+        return $stub;
     }
 
     #[Test]
@@ -116,12 +116,12 @@ class MentoringAnnouncementServiceTest extends TestCase
     #[Test]
     public function it_builds_pilot_message_for_pilot_category_sessions(): void
     {
-        $mock = $this->createMock(MentorPermissionService::class);
-        $mock->method('resolveCategoryForCtsCallsign')->willReturn('P1 Training');
+        $stub = $this->createStub(MentorPermissionService::class);
+        $stub->method('resolveCategoryForCtsCallsign')->willReturn('P1 Training');
 
         $session = $this->makeSession(['position' => 'P1_PPL(A)', 'taken_date' => '2026-01-11', 'taken_from' => '12:00:00']);
 
-        $message = $this->makeService($mock)->buildMessage($session, ['ping_pilot' => false, 'ping_controller' => false, 'notes' => '']);
+        $message = $this->makeService($stub)->buildMessage($session, ['ping_pilot' => false, 'ping_controller' => false, 'notes' => '']);
 
         $this->assertStringContainsString('Pilot Mentoring Session', $message);
         $this->assertStringNotContainsString('ATC Mentoring Session', $message);


### PR DESCRIPTION
## Show PHP notices and deprecations in test output

Right now our test output only gives us the count:

```
Tests: 1622, Assertions: 4231, Deprecations: 7, Notices: 2.
```

Seven deprecations — but *where*? No file, no message, so they get ignored until one becomes a real bug on a PHP upgrade.

This PR adds one attribute to `phpunit.xml`:

```diff
- <phpunit ... stopOnFailure="false" ...>
+ <phpunit ... stopOnFailure="false" displayDetailsOnAllIssues="true" ...>
```

Now we get file, line, and message for each one.

**We keep parallel runs.** That was the original worry, and it was unfounded — ParaTest collects issues from all workers and prints them in the final summary. Verified locally against our pinned ParaTest 7.20 / PHPUnit 12.5. The CI workflow is untouched: `phpunit.xml` is read by both PHPUnit and ParaTest, so this applies locally *and* in CI with no flags to keep in sync.

**Nothing new fails** — this only changes what gets printed. Expect a longer CI log on the first run; that's the existing backlog becoming visible. If vendor deprecations prove too noisy we can scope to first-party code later via `<source ignoreIndirectDeprecations>`.