### PR TITLE
Show weekday name on the bookings calendar date

### DIFF
--- a/resources/views/livewire/bookings/calendar.blade.php
+++ b/resources/views/livewire/bookings/calendar.blade.php
@@ -34,8 +34,8 @@
 						title="Previous day" wire:navigate>
 						<i class="fa fa-chevron-left text-[10px]" aria-hidden="true"></i>
 					</a>
-					<span class="text-sm font-medium text-white/90 min-w-[140px] text-center tabular-nums">
-						{{ $selectedDate->format('d. m. Y') }}
+					<span class="text-sm font-medium text-white/90 min-w-[200px] text-center whitespace-nowrap">
+						{{ $selectedDate->format('l, d. m. Y') }}
 						@if ($selectedDate->isToday())
 							<span class="text-brand/90 text-xs font-normal">· today</span>
 						@endif

--- a/tests/Feature/Bookings/CalendarTest.php
+++ b/tests/Feature/Bookings/CalendarTest.php
@@ -44,6 +44,13 @@ class CalendarTest extends TestCase
     }
 
     #[Test]
+    public function it_shows_the_weekday_before_the_selected_date(): void
+    {
+        Livewire::test(Calendar::class, ['year' => 2026, 'month' => 7])
+            ->assertSee('Wednesday, 01. 07. 2026', false);
+    }
+
+    #[Test]
     public function it_shows_error_when_not_authenticated(): void
     {
         Livewire::test(Calendar::class)


### PR DESCRIPTION
## Summary
- Prefixed the selected date in the bookings calendar header with the weekday (e.g. `Saturday, 08. 08. 2026`)
- Widened the date label slightly so the longer text does not wrap

## Test plan
- [ ] Open the bookings calendar and confirm the header shows the weekday before the numerical date
- [ ] Step previous/next day and confirm the weekday updates correctly
- [ ] Confirm “· today” still appears when viewing today


Made with [Cursor](https://cursor.com)