### PR TITLE
Allow a waiting list to be linked to a pilot qualification

### DIFF
--- a/app/Filament/Training/Resources/WaitingLists/RelationManagers/AccountsRelationManager.php
+++ b/app/Filament/Training/Resources/WaitingLists/RelationManagers/AccountsRelationManager.php
@@ -6,6 +6,8 @@ use App\Enums\TrainingPlaceOfferStatus;
 use App\Filament\Support\NameColumn;
 use App\Filament\Training\Pages\TrainingPlace\ViewTrainingPlace;
 use App\Models\Mship\Feedback\Feedback;
+use App\Models\Mship\Qualification;
+use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
 use App\Models\Training\WaitingList\Removal;
 use App\Models\Training\WaitingList\RemovalReason;
@@ -33,6 +35,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
 
 /**
  * @property WaitingList $ownerRecord
@@ -157,28 +160,21 @@ class AccountsRelationManager extends RelationManager
                                         ->content('No feedback on record for this member.'),
                                 ])
                                 ->collapsible()
-                                ->columns(3),
+                                ->columns(3)
+                                ->visible(fn () => $record->waitingList->isAtcList()),
 
-                            Select::make('training_position_id')
-                                ->label('Training Position')
-                                ->options(function ($livewire) {
-                                    return $livewire->ownerRecord->trainingPositions
-                                        ->mapWithKeys(fn ($tp) => [$tp->id => $tp->position?->callsign ?? "Position #{$tp->id}"])
-                                        ->toArray();
-                                })
-                                ->required()
-                                ->helperText('Select the training position to offer to this member.'),
+                            $this->trainableSelect('offer to this member'),
                         ];
                     })
-                    ->action(function (WaitingListAccount $record, array $data, $livewire) {
-                        $trainingPosition = $livewire->ownerRecord->trainingPositions()->findOrFail($data['training_position_id']);
+                    ->action(function (WaitingListAccount $record, array $data) {
+                        $trainable = $this->resolveAttachedTrainable($data['trainable']);
 
                         $service = app(TrainingPlaceOfferService::class);
-                        $service->offerTrainingPlace($record, $trainingPosition);
+                        $service->offerTrainingPlace($record, $trainable);
                     })
                     ->successNotificationTitle('Training place offered successfully')
                     ->modalHeading('Offer Training Place')
-                    ->modalDescription('Select a training position to offer this member.')
+                    ->modalDescription(fn (): string => $this->selectTrainableDescription('offer this member'))
                     ->modalSubmitActionLabel('Offer Training Place')
                     ->modalCancelActionLabel('Cancel')
                     ->color('success'),
@@ -371,21 +367,13 @@ class AccountsRelationManager extends RelationManager
                         ->icon('heroicon-o-academic-cap')
                         ->visible(fn ($record) => $this->can('trainingPlacesManualSetup', $record->waitingList))
                         ->schema([
-                            Select::make('training_position_id')
-                                ->label('Training Position')
-                                ->options(function ($livewire) {
-                                    return $livewire->ownerRecord->trainingPositions
-                                        ->mapWithKeys(fn ($tp) => [$tp->id => $tp->position?->callsign ?? "Position #{$tp->id}"])
-                                        ->toArray();
-                                })
-                                ->required()
-                                ->helperText('Select the training position to offer to this user.'),
+                            $this->trainableSelect('set up for this user'),
                         ])
                         ->action(function (WaitingListAccount $record, array $data, $livewire) {
-                            $trainingPosition = $livewire->ownerRecord->trainingPositions()->findOrFail($data['training_position_id']);
+                            $trainable = $this->resolveAttachedTrainable($data['trainable']);
 
                             $service = app(TrainingPlaceService::class);
-                            $trainingPlace = $service->createManualTrainingPlace($record, $trainingPosition);
+                            $trainingPlace = $service->createManualTrainingPlace($record, $trainable);
 
                             Notification::make()
                                 ->title('Training place offered successfully')
@@ -402,7 +390,7 @@ class AccountsRelationManager extends RelationManager
                         })
                         ->successNotificationTitle('Training place offered successfully')
                         ->modalHeading('Manual Setup Training Place')
-                        ->modalDescription('Select a training position to manually setup a training place for this user.')
+                        ->modalDescription(fn (): string => $this->selectTrainableDescription('manually set up a training place for this user'))
                         ->modalSubmitActionLabel('Setup Training Place')
                         ->modalCancelActionLabel('Cancel'),
                 ]),
@@ -446,6 +434,75 @@ class AccountsRelationManager extends RelationManager
     public static function removalReasonOptions(): array
     {
         return RemovalReason::formOptions();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function trainableOptions(): array
+    {
+        return $this->ownerRecord->trainables
+            ->mapWithKeys(function (Model $trainable): array {
+                $key = $trainable->getMorphClass().'|'.$trainable->getKey();
+
+                $label = match (true) {
+                    $trainable instanceof Qualification => "{$trainable->name_long} ({$trainable->code})",
+                    $trainable instanceof TrainingPosition => $trainable->position?->callsign ?? "Position #{$trainable->id}",
+                    default => (string) $trainable->getKey(),
+                };
+
+                return [$key => $label];
+            })
+            ->all();
+    }
+
+    protected function trainableNoun(): string
+    {
+        return $this->ownerRecord->isPilotList() ? 'pilot qualification' : 'training position';
+    }
+
+    protected function trainableSelect(string $purpose): Select
+    {
+        $noun = $this->trainableNoun();
+
+        return Select::make('trainable')
+            ->label(ucwords($noun))
+            ->options(fn (): array => $this->trainableOptions())
+            ->required()
+            ->helperText("Select the {$noun} to {$purpose}.");
+    }
+
+    protected function selectTrainableDescription(string $purpose): string
+    {
+        return "Select a {$this->trainableNoun()} to {$purpose}.";
+    }
+
+    /**
+     * Resolve a composite "{morphClass}|{id}" key to a trainable still attached to this waiting list.
+     *
+     * @return TrainingPosition|Qualification
+     */
+    protected function resolveAttachedTrainable(string $compositeKey): Model
+    {
+        [$type, $id] = array_pad(explode('|', $compositeKey, 2), 2, null);
+
+        if (! filled($type) || ! filled($id)) {
+            throw ValidationException::withMessages([
+                'trainable' => 'Invalid training selection.',
+            ]);
+        }
+
+        $trainable = $this->ownerRecord->trainables->first(
+            fn (Model $model): bool => $model->getMorphClass() === $type && (string) $model->getKey() === (string) $id
+        );
+
+        if (! $trainable) {
+            throw ValidationException::withMessages([
+                'trainable' => 'The selected option is not linked to this waiting list.',
+            ]);
+        }
+
+        return $trainable;
     }
 
     // Display All Manual Flags where display option is enabled

--- a/app/Filament/Training/Resources/WaitingLists/WaitingListResource.php
+++ b/app/Filament/Training/Resources/WaitingLists/WaitingListResource.php
@@ -2,11 +2,13 @@
 
 namespace App\Filament\Training\Resources\WaitingLists;
 
+use App\Enums\QualificationTypeEnum;
 use App\Filament\Training\Resources\WaitingLists\Pages\CreateWaitingList;
 use App\Filament\Training\Resources\WaitingLists\Pages\EditWaitingList;
 use App\Filament\Training\Resources\WaitingLists\Pages\ListWaitingLists;
 use App\Filament\Training\Resources\WaitingLists\Pages\ViewWaitingList;
 use App\Filament\Training\Resources\WaitingLists\RelationManagers\AccountsRelationManager;
+use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
 use Filament\Actions\ViewAction;
@@ -19,6 +21,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 class WaitingListResource extends Resource
@@ -42,7 +45,7 @@ class WaitingListResource extends Resource
                 Select::make('department')->options([
                     'atc' => 'ATC Training',
                     'pilot' => 'Pilot Training',
-                ])->disabledOn('edit')->required(),
+                ])->disabledOn('edit')->required()->live(),
 
                 Section::make('Additional Settings')
                     ->columnSpanFull()
@@ -53,7 +56,22 @@ class WaitingListResource extends Resource
                             ->relationship('trainingPositions')
                             ->multiple()
                             ->preload()
-                            ->getOptionLabelFromRecordUsing(fn (TrainingPosition $record) => $record->position?->callsign ?? "Position #{$record->id}"),
+                            ->getOptionLabelFromRecordUsing(fn (TrainingPosition $record) => $record->position?->callsign ?? "Position #{$record->id}")
+                            ->visible(fn ($get) => $get('department') === WaitingList::ATC_DEPARTMENT),
+
+                        Select::make('qualifications')
+                            ->label('Pilot Qualifications')
+                            ->helperText('Link this waiting list to one or more pilot qualifications.')
+                            ->relationship(
+                                'qualifications',
+                                modifyQueryUsing: fn (Builder $query) => $query
+                                    ->ofType(QualificationTypeEnum::Pilot->value)
+                                    ->orderBy('vatsim'),
+                            )
+                            ->multiple()
+                            ->preload()
+                            ->getOptionLabelFromRecordUsing(fn (Qualification $record) => "{$record->name_long} ({$record->code})")
+                            ->visible(fn ($get) => $get('department') === WaitingList::PILOT_DEPARTMENT),
 
                         Toggle::make('feature_toggles.check_atc_hours')
                             ->label('Check ATC Hours')

--- a/app/Models/Training/TrainingPlace/TrainingPlace.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlace.php
@@ -7,6 +7,7 @@ use App\Models\Cts\Session as CtsSession;
 use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Models\Training\WaitingList;
 use App\Models\Training\WaitingList\WaitingListAccount;
 use App\Observers\Training\TrainingPlaceObserver;
 use App\Services\Training\MentorPermissionService;
@@ -89,6 +90,15 @@ class TrainingPlace extends Model
 
             return 'Unknown';
         });
+    }
+
+    protected function department(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): string => $this->trainable instanceof Qualification
+                ? WaitingList::PILOT_DEPARTMENT
+                : WaitingList::ATC_DEPARTMENT
+        );
     }
 
     /**

--- a/app/Models/Training/TrainingPlace/TrainingPlaceOffer.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlaceOffer.php
@@ -5,6 +5,7 @@ namespace App\Models\Training\TrainingPlace;
 use App\Enums\TrainingPlaceOfferStatus;
 use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Models\Training\WaitingList;
 use App\Models\Training\WaitingList\WaitingListAccount;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -77,6 +78,15 @@ class TrainingPlaceOffer extends Model
 
             return 'Unknown';
         });
+    }
+
+    protected function department(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): string => $this->trainable instanceof Qualification
+                ? WaitingList::PILOT_DEPARTMENT
+                : WaitingList::ATC_DEPARTMENT
+        );
     }
 
     protected function statusLabel(): Attribute

--- a/tests/Feature/TrainingPanel/WaitingLists/Pages/ManualTrainingPlaceCreationFromWaitingListTest.php
+++ b/tests/Feature/TrainingPanel/WaitingLists/Pages/ManualTrainingPlaceCreationFromWaitingListTest.php
@@ -51,7 +51,7 @@ class ManualTrainingPlaceCreationFromWaitingListTest extends BaseTrainingPanelTe
                 'pageClass' => ViewRecord::class,
             ])
             ->callTableAction('manualSetupTrainingPlace', $waitingListAccount, [
-                'training_position_id' => $trainingPosition->id,
+                'trainable' => TrainingPosition::class.'|'.$trainingPosition->id,
             ])
             ->assertHasNoTableActionErrors();
 
@@ -93,7 +93,7 @@ class ManualTrainingPlaceCreationFromWaitingListTest extends BaseTrainingPanelTe
                 'pageClass' => ViewRecord::class,
             ])
             ->callTableAction('manualSetupTrainingPlace', $waitingListAccount1, [
-                'training_position_id' => $position1->id,
+                'trainable' => TrainingPosition::class.'|'.$position1->id,
             ])
             ->assertHasNoTableActionErrors();
 
@@ -104,7 +104,7 @@ class ManualTrainingPlaceCreationFromWaitingListTest extends BaseTrainingPanelTe
                 'pageClass' => ViewRecord::class,
             ])
             ->callTableAction('manualSetupTrainingPlace', $waitingListAccount2, [
-                'training_position_id' => $position2->id,
+                'trainable' => TrainingPosition::class.'|'.$position2->id,
             ])
             ->assertHasNoTableActionErrors();
 
@@ -123,7 +123,7 @@ class ManualTrainingPlaceCreationFromWaitingListTest extends BaseTrainingPanelTe
     }
 
     #[Test]
-    public function it_requires_training_position_to_be_selected()
+    public function it_requires_trainable_to_be_selected()
     {
         // Arrange
         $trainingPosition = TrainingPosition::factory()->create();
@@ -142,9 +142,9 @@ class ManualTrainingPlaceCreationFromWaitingListTest extends BaseTrainingPanelTe
                 'pageClass' => ViewRecord::class,
             ])
             ->callTableAction('manualSetupTrainingPlace', $waitingListAccount, [
-                'training_position_id' => null,
+                'trainable' => null,
             ])
-            ->assertHasTableActionErrors(['training_position_id' => 'required']);
+            ->assertHasTableActionErrors(['trainable' => 'required']);
     }
 
     #[Test]
@@ -197,7 +197,7 @@ class ManualTrainingPlaceCreationFromWaitingListTest extends BaseTrainingPanelTe
                 'pageClass' => ViewRecord::class,
             ])
             ->callTableAction('manualSetupTrainingPlace', $waitingListAccount, [
-                'training_position_id' => $trainingPosition->id,
+                'trainable' => TrainingPosition::class.'|'.$trainingPosition->id,
             ])
             ->assertNotified();
     }

--- a/tests/Feature/TrainingPanel/WaitingLists/Pages/QualificationTrainingPlaceFromWaitingListTest.php
+++ b/tests/Feature/TrainingPanel/WaitingLists/Pages/QualificationTrainingPlaceFromWaitingListTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\TrainingPanel\WaitingLists\Pages;
+
+use App\Enums\TrainingPlaceOfferStatus;
+use App\Filament\Training\Resources\WaitingLists\RelationManagers\AccountsRelationManager;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Models\Training\WaitingList;
+use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class QualificationTrainingPlaceFromWaitingListTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    private function pilotQualification(): Qualification
+    {
+        return Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+    }
+
+    private function pilotWaitingListWithQualification(Qualification $qualification): WaitingList
+    {
+        $waitingList = WaitingList::factory()->create([
+            'department' => WaitingList::PILOT_DEPARTMENT,
+        ]);
+        $waitingList->qualifications()->attach($qualification);
+
+        return $waitingList;
+    }
+
+    #[Test]
+    public function it_can_offer_a_qualification_backed_training_place_from_a_pilot_list(): void
+    {
+        Notification::fake();
+
+        $qualification = $this->pilotQualification();
+        $waitingList = $this->pilotWaitingListWithQualification($qualification);
+
+        $student = Account::factory()->create();
+        Member::factory()->create(['cid' => $student->id]);
+        $waitingListAccount = $waitingList->addToWaitingList($student, $this->privacc);
+
+        Livewire::actingAs($this->privacc)
+            ->test(AccountsRelationManager::class, [
+                'ownerRecord' => $waitingList,
+                'pageClass' => ViewRecord::class,
+            ])
+            ->callTableAction('offerTrainingPlace', $waitingListAccount, [
+                'trainable' => Qualification::class.'|'.$qualification->id,
+            ])
+            ->assertHasNoTableActionErrors();
+
+        $this->assertDatabaseHas('training_place_offers', [
+            'waiting_list_account_id' => $waitingListAccount->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+            'status' => TrainingPlaceOfferStatus::Pending->value,
+        ]);
+
+        $offer = $waitingListAccount->trainingPlaceOffers()->latest()->first();
+        $this->assertNotNull($offer);
+        $this->assertSame(WaitingList::PILOT_DEPARTMENT, $offer->department);
+    }
+
+    #[Test]
+    public function it_can_manual_setup_a_qualification_backed_training_place_from_a_pilot_list(): void
+    {
+        $qualification = $this->pilotQualification();
+        $waitingList = $this->pilotWaitingListWithQualification($qualification);
+
+        $student = Account::factory()->create();
+        Member::factory()->create(['cid' => $student->id]);
+        $waitingListAccount = $waitingList->addToWaitingList($student, $this->privacc);
+
+        Livewire::actingAs($this->privacc)
+            ->test(AccountsRelationManager::class, [
+                'ownerRecord' => $waitingList,
+                'pageClass' => ViewRecord::class,
+            ])
+            ->callTableAction('manualSetupTrainingPlace', $waitingListAccount, [
+                'trainable' => Qualification::class.'|'.$qualification->id,
+            ])
+            ->assertHasNoTableActionErrors();
+
+        $this->assertDatabaseHas('training_places', [
+            'waiting_list_account_id' => $waitingListAccount->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+        ]);
+
+        $trainingPlace = TrainingPlace::query()
+            ->where('waiting_list_account_id', $waitingListAccount->id)
+            ->first();
+
+        $this->assertNotNull($trainingPlace);
+        $this->assertSame(WaitingList::PILOT_DEPARTMENT, $trainingPlace->department);
+        $this->assertNotNull($waitingListAccount->fresh()->deleted_at);
+    }
+
+    #[Test]
+    public function it_rejects_a_trainable_that_is_not_attached_to_the_waiting_list(): void
+    {
+        $attachedQualification = $this->pilotQualification();
+        $unattachedQualification = Qualification::firstWhere('code', 'IR')
+            ?? Qualification::factory()->create(['code' => 'IR', 'type' => 'pilot']);
+
+        $waitingList = $this->pilotWaitingListWithQualification($attachedQualification);
+
+        $student = Account::factory()->create();
+        Member::factory()->create(['cid' => $student->id]);
+        $waitingListAccount = $waitingList->addToWaitingList($student, $this->privacc);
+
+        Livewire::actingAs($this->privacc)
+            ->test(AccountsRelationManager::class, [
+                'ownerRecord' => $waitingList,
+                'pageClass' => ViewRecord::class,
+            ])
+            ->callTableAction('manualSetupTrainingPlace', $waitingListAccount, [
+                'trainable' => Qualification::class.'|'.$unattachedQualification->id,
+            ])
+            ->assertHasTableActionErrors(['trainable']);
+
+        $this->assertDatabaseMissing('training_places', [
+            'waiting_list_account_id' => $waitingListAccount->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_rejects_an_unattached_training_position_on_offer(): void
+    {
+        Notification::fake();
+
+        $trainingPosition = TrainingPosition::factory()->create();
+        $waitingList = WaitingList::factory()->create();
+        // Position deliberately not attached to the list
+
+        $student = Account::factory()->create();
+        Member::factory()->create(['cid' => $student->id]);
+        $waitingListAccount = $waitingList->addToWaitingList($student, $this->privacc);
+
+        Livewire::actingAs($this->privacc)
+            ->test(AccountsRelationManager::class, [
+                'ownerRecord' => $waitingList,
+                'pageClass' => ViewRecord::class,
+            ])
+            ->callTableAction('offerTrainingPlace', $waitingListAccount, [
+                'trainable' => TrainingPosition::class.'|'.$trainingPosition->id,
+            ])
+            ->assertHasTableActionErrors(['trainable']);
+
+        $this->assertDatabaseMissing('training_place_offers', [
+            'waiting_list_account_id' => $waitingListAccount->id,
+        ]);
+    }
+}

--- a/tests/Feature/TrainingPanel/WaitingLists/Pages/QualificationTrainingPlaceFromWaitingListTest.php
+++ b/tests/Feature/TrainingPanel/WaitingLists/Pages/QualificationTrainingPlaceFromWaitingListTest.php
@@ -107,7 +107,7 @@ class QualificationTrainingPlaceFromWaitingListTest extends BaseTrainingPanelTes
     }
 
     #[Test]
-    public function it_rejects_a_trainable_that_is_not_attached_to_the_waiting_list(): void
+    public function it_rejects_a_trainable_that_is_not_attached_to_the_waiting_list_on_manual_setup(): void
     {
         $attachedQualification = $this->pilotQualification();
         $unattachedQualification = Qualification::firstWhere('code', 'IR')
@@ -130,6 +130,36 @@ class QualificationTrainingPlaceFromWaitingListTest extends BaseTrainingPanelTes
             ->assertHasTableActionErrors(['trainable']);
 
         $this->assertDatabaseMissing('training_places', [
+            'waiting_list_account_id' => $waitingListAccount->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_rejects_an_unattached_qualification_on_offer(): void
+    {
+        Notification::fake();
+
+        $attachedQualification = $this->pilotQualification();
+        $unattachedQualification = Qualification::firstWhere('code', 'IR')
+            ?? Qualification::factory()->create(['code' => 'IR', 'type' => 'pilot']);
+
+        $waitingList = $this->pilotWaitingListWithQualification($attachedQualification);
+
+        $student = Account::factory()->create();
+        Member::factory()->create(['cid' => $student->id]);
+        $waitingListAccount = $waitingList->addToWaitingList($student, $this->privacc);
+
+        Livewire::actingAs($this->privacc)
+            ->test(AccountsRelationManager::class, [
+                'ownerRecord' => $waitingList,
+                'pageClass' => ViewRecord::class,
+            ])
+            ->callTableAction('offerTrainingPlace', $waitingListAccount, [
+                'trainable' => Qualification::class.'|'.$unattachedQualification->id,
+            ])
+            ->assertHasTableActionErrors(['trainable']);
+
+        $this->assertDatabaseMissing('training_place_offers', [
             'waiting_list_account_id' => $waitingListAccount->id,
         ]);
     }


### PR DESCRIPTION
## Summary
- Gate waiting-list Training Positions to ATC lists and add a Pilot Qualifications multi-select for pilot lists.
- Replace offer/manual `training_position_id` selects with a shared composite `trainable` picker (position or qualification), including department-aware copy and attachment validation.
- Add a `department` accessor on `TrainingPlace` / `TrainingPlaceOffer` for PR 3/4 reuse.

Part of TECH-699. Depends on #5033 (TECH-712).

## Known follow-up
Offering a **pilot** training place still uses the ATC offer email template, which errors on `$position->name`. That is intentionally deferred to TECH-715 (PR 4). Manual setup of qualification-backed places works end-to-end. Offer creation for qualifications is covered in tests with `Notification::fake()`.

## Test plan
- [ ] Edit an ATC waiting list: Training Positions select visible; Pilot Qualifications hidden
- [ ] Edit a pilot waiting list: Pilot Qualifications select visible; Training Positions hidden
- [ ] Offer / manual-setup on an ATC list still works with a linked training position
- [ ] Manual-setup on a pilot list with a linked qualification creates a qualification-backed place
- [ ] Offering on a pilot list shows the expected UI error until TECH-715 (or succeeds once that lands)
- [ ] Forged/unattached trainable values are rejected


Made with [Cursor](https://cursor.com)