### PR TITLE
Allow ad-hoc creation of waiting lists with per department permisisons

### DIFF
--- a/app/Filament/Training/Resources/TrainingPlaces/Pages/ListTrainingPlaces.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/Pages/ListTrainingPlaces.php
@@ -176,6 +176,12 @@ class ListTrainingPlaces extends ListRecords
             ]);
         }
 
+        if ($trainable instanceof Qualification && $trainable->type !== QualificationTypeEnum::Pilot->value) {
+            throw ValidationException::withMessages([
+                'trainable' => 'The selected qualification is not a pilot qualification.',
+            ]);
+        }
+
         return $trainable;
     }
 }

--- a/app/Filament/Training/Resources/TrainingPlaces/Pages/ListTrainingPlaces.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/Pages/ListTrainingPlaces.php
@@ -2,21 +2,26 @@
 
 namespace App\Filament\Training\Resources\TrainingPlaces\Pages;
 
+use App\Enums\QualificationTypeEnum;
 use App\Filament\Admin\Forms\Components\AccountSelect;
 use App\Filament\Training\Pages\TrainingPlace\ViewTrainingPlace;
 use App\Filament\Training\Resources\TrainingPlaces\TrainingPlaceResource;
 use App\Filament\Training\Resources\TrainingPlaces\Widgets\TrainingPlaceCategoryChart;
 use App\Filament\Training\Resources\TrainingPlaces\Widgets\TrainingPlaceOffersOverview;
 use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Models\Training\WaitingList;
 use App\Services\Training\TrainingPlaceService;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
 
 class ListTrainingPlaces extends ListRecords
 {
@@ -56,22 +61,12 @@ class ListTrainingPlaces extends ListRecords
                         ->label('Student')
                         ->required(),
 
-                    Select::make('training_position_id')
-                        ->label('Training Position')
+                    Select::make('trainable')
+                        ->label('Training')
                         ->required()
                         ->searchable()
                         ->preload()
-                        ->options(fn (): array => TrainingPosition::query()
-                            ->with('position')
-                            ->orderBy('id')
-                            ->get()
-                            ->mapWithKeys(function (TrainingPosition $trainingPosition): array {
-                                $label = $trainingPosition->position?->callsign
-                                    ?? collect($trainingPosition->cts_positions)->filter()->first();
-
-                                return [$trainingPosition->id => $label];
-                            })
-                            ->all()),
+                        ->options(fn (): array => $this->adhocTrainableOptions()),
 
                     Textarea::make('reason')
                         ->label('Reason')
@@ -87,16 +82,20 @@ class ListTrainingPlaces extends ListRecords
                     /** @var Account $actor */
                     $actor = Auth::user();
                     abort_unless($actor instanceof Account, 403);
-                    abort_unless($actor->can('createAdhoc', TrainingPlace::class), 403);
 
                     $student = Account::query()->findOrFail($data['account_id']);
-                    $trainingPosition = TrainingPosition::query()->with('position')->findOrFail($data['training_position_id']);
+                    $trainable = $this->resolveAdhocTrainable($data['trainable']);
+                    $department = $trainable instanceof Qualification
+                        ? WaitingList::PILOT_DEPARTMENT
+                        : WaitingList::ATC_DEPARTMENT;
+
+                    abort_unless($actor->can('createAdhoc', [TrainingPlace::class, $department]), 403);
 
                     $reason = trim((string) $data['reason']);
 
                     $trainingPlace = app(TrainingPlaceService::class)->createAdhocTrainingPlace(
                         $student,
-                        $trainingPosition,
+                        $trainable,
                         $reason,
                         $actor,
                     );
@@ -113,5 +112,70 @@ class ListTrainingPlaces extends ListRecords
                         ->send();
                 }),
         ];
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    protected function adhocTrainableOptions(): array
+    {
+        /** @var Account|null $user */
+        $user = Auth::user();
+        $options = [];
+
+        if ($user?->can('createAdhoc', [TrainingPlace::class, WaitingList::ATC_DEPARTMENT])) {
+            $options['Training Positions'] = TrainingPosition::query()
+                ->with('position')
+                ->orderBy('id')
+                ->get()
+                ->mapWithKeys(function (TrainingPosition $trainingPosition): array {
+                    $label = $trainingPosition->position?->callsign
+                        ?? collect($trainingPosition->cts_positions)->filter()->first()
+                        ?? "Position #{$trainingPosition->id}";
+
+                    return [TrainingPosition::class.'|'.$trainingPosition->id => $label];
+                })
+                ->all();
+        }
+
+        if ($user?->can('createAdhoc', [TrainingPlace::class, WaitingList::PILOT_DEPARTMENT])) {
+            $options['Pilot Qualifications'] = Qualification::ofType(QualificationTypeEnum::Pilot->value)
+                ->orderBy('vatsim')
+                ->get()
+                ->mapWithKeys(fn (Qualification $qualification): array => [
+                    Qualification::class.'|'.$qualification->id => "{$qualification->name_long} ({$qualification->code})",
+                ])
+                ->all();
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return TrainingPosition|Qualification
+     */
+    protected function resolveAdhocTrainable(string $compositeKey): Model
+    {
+        [$type, $id] = array_pad(explode('|', $compositeKey, 2), 2, null);
+
+        if (! filled($type) || ! filled($id)) {
+            throw ValidationException::withMessages([
+                'trainable' => 'Invalid training selection.',
+            ]);
+        }
+
+        $trainable = match ($type) {
+            TrainingPosition::class => TrainingPosition::query()->with('position')->find($id),
+            Qualification::class => Qualification::query()->find($id),
+            default => null,
+        };
+
+        if (! $trainable) {
+            throw ValidationException::withMessages([
+                'trainable' => 'The selected training option could not be found.',
+            ]);
+        }
+
+        return $trainable;
     }
 }

--- a/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
@@ -4,8 +4,10 @@ namespace App\Filament\Training\Resources\TrainingPlaces;
 
 use App\Filament\Training\Pages\TrainingPlace\ViewTrainingPlace;
 use App\Filament\Training\Resources\TrainingPlaces\Pages\ListTrainingPlaces;
+use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\MentorPermissionService;
 use Filament\Actions\RestoreAction;
 use Filament\Actions\ViewAction;
 use Filament\Resources\Resource;
@@ -42,37 +44,78 @@ class TrainingPlaceResource extends Resource
             ->titlePrefixedWithLabel(false)
             ->collapsible()
             ->getTitleFromRecordUsing(
-                fn (TrainingPlace $record): string => filled($record->trainingPosition?->category)
-                    ? $record->trainingPosition->category
+                fn (TrainingPlace $record): string => filled($record->category)
+                    ? $record->category
                     : 'Uncategorised'
             )
             ->getKeyFromRecordUsing(
-                fn (TrainingPlace $record): string => filled($record->trainingPosition?->category)
-                    ? $record->trainingPosition->category
+                fn (TrainingPlace $record): string => filled($record->category)
+                    ? $record->category
                     : '__uncategorised__'
             )
-            ->orderQueryUsing(fn (Builder $query, string $direction): Builder => $query
-                ->orderBy(
-                    TrainingPosition::query()
-                        ->select('category')
-                        ->whereColumn('training_positions.id', 'training_places.trainable_id')
-                        ->where('training_places.trainable_type', TrainingPosition::class),
-                    $direction,
-                )
-                ->orderByDesc('training_places.created_at')
-            )
+            ->orderQueryUsing(function (Builder $query, string $direction): Builder {
+                $direction = strtolower($direction) === 'desc' ? 'desc' : 'asc';
+
+                $qualificationCases = collect(MentorPermissionService::PILOT_CATEGORY_QUALIFICATION_MAP)
+                    ->map(fn (): string => 'WHEN ? THEN ?')
+                    ->implode(' ');
+
+                $bindings = [TrainingPosition::class];
+                foreach (MentorPermissionService::PILOT_CATEGORY_QUALIFICATION_MAP as $category => $code) {
+                    $bindings[] = $code;
+                    $bindings[] = $category;
+                }
+                $bindings[] = Qualification::class;
+
+                return $query
+                    ->orderByRaw(
+                        "COALESCE(
+                            (
+                                SELECT category FROM training_positions
+                                WHERE training_positions.id = training_places.trainable_id
+                                AND training_places.trainable_type = ?
+                            ),
+                            (
+                                SELECT CASE code {$qualificationCases} END
+                                FROM mship_qualification
+                                WHERE mship_qualification.id = training_places.trainable_id
+                                AND training_places.trainable_type = ?
+                            )
+                        ) {$direction}",
+                        $bindings
+                    )
+                    ->orderByDesc('training_places.created_at');
+            })
             ->scopeQueryByKeyUsing(function (Builder $query, string $key): Builder {
                 if ($key === '__uncategorised__') {
-                    return $query->where(function (Builder $query) {
+                    $mappedCodes = array_values(MentorPermissionService::PILOT_CATEGORY_QUALIFICATION_MAP);
+
+                    return $query->where(function (Builder $query) use ($mappedCodes) {
                         $query->whereHasMorph('trainable', [TrainingPosition::class], function (Builder $query) {
                             $query->whereNull('category')->orWhere('category', '');
                         })
-                            ->orWhere('trainable_type', '!=', TrainingPosition::class)
+                            ->orWhereHasMorph('trainable', [Qualification::class], function (Builder $query) use ($mappedCodes) {
+                                $query->whereNotIn('code', $mappedCodes);
+                            })
                             ->orWhereNull('trainable_type');
                     });
                 }
 
-                return $query->whereHasMorph('trainable', [TrainingPosition::class], fn (Builder $query) => $query->where('category', $key));
+                if (in_array($key, MentorPermissionService::pilotCategories(), true)) {
+                    $code = MentorPermissionService::PILOT_CATEGORY_QUALIFICATION_MAP[$key] ?? null;
+
+                    return $query->whereHasMorph(
+                        'trainable',
+                        [Qualification::class],
+                        fn (Builder $query) => $query->where('code', $code)
+                    );
+                }
+
+                return $query->whereHasMorph(
+                    'trainable',
+                    [TrainingPosition::class],
+                    fn (Builder $query) => $query->where('category', $key)
+                );
             });
 
         return $table
@@ -130,11 +173,22 @@ class TrainingPlaceResource extends Resource
                 TextColumn::make('display_name')
                     ->label('Position')
                     ->state(fn (TrainingPlace $record): string => $record->display_name)
-                    ->searchable(query: fn (Builder $query, string $search): Builder => $query->whereHasMorph(
-                        'trainable',
-                        [TrainingPosition::class],
-                        fn (Builder $query) => $query->whereHas('position', fn (Builder $query) => $query->where('callsign', 'like', "%{$search}%"))
-                    )),
+                    ->searchable(query: fn (Builder $query, string $search): Builder => $query->where(function (Builder $query) use ($search) {
+                        $query->whereHasMorph(
+                            'trainable',
+                            [TrainingPosition::class],
+                            fn (Builder $query) => $query->whereHas(
+                                'position',
+                                fn (Builder $query) => $query->where('callsign', 'like', "%{$search}%")
+                            )
+                        )->orWhereHasMorph(
+                            'trainable',
+                            [Qualification::class],
+                            fn (Builder $query) => $query
+                                ->where('code', 'like', "%{$search}%")
+                                ->orWhere('name_long', 'like', "%{$search}%")
+                        );
+                    })),
 
                 TextColumn::make('status')
                     ->label('Status')
@@ -147,12 +201,32 @@ class TrainingPlaceResource extends Resource
             ->filters([
                 SelectFilter::make('category')
                     ->label('Category')
-                    ->options(TrainingPosition::all()->pluck('category', 'category')->map(fn ($category) => Str::title($category ?? 'Uncategorised')))
+                    ->options(fn (): array => self::categoryFilterOptions())
                     ->preload()
                     ->searchable()
-                    ->query(fn (Builder $query, array $data): Builder => filled($data['value'] ?? null)
-                        ? $query->whereHasMorph('trainable', [TrainingPosition::class], fn (Builder $q): Builder => $q->where('category', $data['value']))
-                        : $query),
+                    ->query(function (Builder $query, array $data): Builder {
+                        $value = $data['value'] ?? null;
+
+                        if (! filled($value)) {
+                            return $query;
+                        }
+
+                        if (in_array($value, MentorPermissionService::pilotCategories(), true)) {
+                            $code = MentorPermissionService::PILOT_CATEGORY_QUALIFICATION_MAP[$value] ?? null;
+
+                            return $query->whereHasMorph(
+                                'trainable',
+                                [Qualification::class],
+                                fn (Builder $query): Builder => $query->where('code', $code)
+                            );
+                        }
+
+                        return $query->whereHasMorph(
+                            'trainable',
+                            [TrainingPosition::class],
+                            fn (Builder $query): Builder => $query->where('category', $value)
+                        );
+                    }),
 
                 TrashedFilter::make()
                     ->label('Training Place Status')
@@ -171,6 +245,27 @@ class TrainingPlaceResource extends Resource
             ->persistColumnSearchesInSession()
             ->paginated(['25', '50', '100'])
             ->defaultPaginationPageOption(25);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function categoryFilterOptions(): array
+    {
+        $positionCategories = TrainingPosition::query()
+            ->whereNotNull('category')
+            ->where('category', '!=', '')
+            ->distinct()
+            ->orderBy('category')
+            ->pluck('category', 'category');
+
+        $pilotCategories = collect(MentorPermissionService::pilotCategories())
+            ->mapWithKeys(fn (string $category): array => [$category => $category]);
+
+        return $positionCategories
+            ->union($pilotCategories)
+            ->map(fn (string $category): string => Str::title($category))
+            ->all();
     }
 
     public static function getPages(): array
@@ -202,6 +297,6 @@ class TrainingPlaceResource extends Resource
 
     public static function getGlobalSearchResultDetails(Model $record): array
     {
-        return [$record->trainingPosition?->position?->name];
+        return [$record->display_name];
     }
 }

--- a/app/Filament/Training/Resources/TrainingPlaces/Widgets/TrainingPlaceCategoryChart.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/Widgets/TrainingPlaceCategoryChart.php
@@ -45,8 +45,8 @@ class TrainingPlaceCategoryChart extends ChartWidget
     {
         $counts = TrainingPlace::with('trainable')
             ->get()
-            ->groupBy(fn (TrainingPlace $place): string => filled($place->trainingPosition?->category)
-                ? $place->trainingPosition->category
+            ->groupBy(fn (TrainingPlace $place): string => filled($place->category)
+                ? $place->category
                 : 'Uncategorised')
             ->map->count()
             ->sortDesc();

--- a/app/Models/Training/TrainingPlace/TrainingPlace.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlace.php
@@ -101,6 +101,21 @@ class TrainingPlace extends Model
         );
     }
 
+    protected function category(): Attribute
+    {
+        return Attribute::make(get: function (): ?string {
+            if (filled($this->trainingPosition?->category)) {
+                return $this->trainingPosition->category;
+            }
+
+            $code = $this->qualification?->code;
+
+            return $code
+                ? MentorPermissionService::categoryForQualificationCode($code)
+                : null;
+        });
+    }
+
     /**
      * The CTS position callsigns associated with this training place's trainable.
      *

--- a/app/Policies/Training/WaitingListPolicy.php
+++ b/app/Policies/Training/WaitingListPolicy.php
@@ -85,7 +85,8 @@ class WaitingListPolicy
 
     public function trainingPlacesManualSetup(Account $account, WaitingList $waitingList)
     {
-        return $account->hasAnyPermission('training-places.manual-setup');
+        return $this->checkHasPermissionForList($account, $waitingList, 'training-places.manual-setup.%s')
+            || $account->hasPermissionTo('training-places.manual-setup');
     }
 
     /**

--- a/app/Policies/TrainingPlacePolicy.php
+++ b/app/Policies/TrainingPlacePolicy.php
@@ -55,9 +55,20 @@ class TrainingPlacePolicy
         return $account->hasPermissionTo('training-places.restore.*');
     }
 
-    public function createAdhoc(Account $account): bool
+    public function createAdhoc(Account $account, ?string $department = null): bool
     {
-        return $account->hasPermissionTo('training-places.create-adhoc');
+        if ($department !== null) {
+            return $account->hasAnyPermission([
+                'training-places.create-adhoc',
+                sprintf('training-places.create-adhoc.%s', $department),
+            ]);
+        }
+
+        return $account->hasAnyPermission([
+            'training-places.create-adhoc',
+            'training-places.create-adhoc.atc',
+            'training-places.create-adhoc.pilot',
+        ]);
     }
 
     /**

--- a/app/Services/Training/MentorPermissionService.php
+++ b/app/Services/Training/MentorPermissionService.php
@@ -90,6 +90,11 @@ class MentorPermissionService
         return array_keys(self::PILOT_CATEGORY_ROLE_MAP);
     }
 
+    public static function categoryForQualificationCode(string $code): ?string
+    {
+        return array_flip(self::PILOT_CATEGORY_QUALIFICATION_MAP)[$code] ?? null;
+    }
+
     public static function categoryType(string $category): string
     {
         return in_array($category, self::atcCategories(), true) ? 'atc' : 'pilot';

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -181,7 +181,11 @@ class RolesAndPermissionsSeeder extends Seeder
             // Training Places Permissions
             'training-places.view.*',
             'training-places.manual-setup',
+            'training-places.manual-setup.atc',
+            'training-places.manual-setup.pilot',
             'training-places.create-adhoc',
+            'training-places.create-adhoc.atc',
+            'training-places.create-adhoc.pilot',
             'training-places.revoke.*',
             'training-places.restore.*',
             'training-places.loas.create.*',

--- a/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
@@ -6,6 +6,7 @@ use App\Filament\Training\Resources\TrainingPlaces\Pages\ListTrainingPlaces;
 use App\Models\Cts\Member;
 use App\Models\Cts\Position as CtsPosition;
 use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
@@ -63,7 +64,7 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
             ->test(ListTrainingPlaces::class)
             ->callAction('createAdhocTrainingPlace', data: [
                 'account_id' => $student->id,
-                'training_position_id' => $trainingPosition->id,
+                'trainable' => TrainingPosition::class.'|'.$trainingPosition->id,
                 'reason' => $reason,
             ])
             ->assertNotified();
@@ -80,6 +81,111 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
             'writer_id' => $this->panelUser->id,
             'content' => "Ad-hoc training place created on {$ctsPosition->callsign} outside the usual waiting list flow. Reason: {$reason}",
         ]);
+    }
+
+    #[Test]
+    public function it_can_create_an_adhoc_qualification_training_place_from_the_list_page()
+    {
+        $this->panelUser->givePermissionTo('training-places.view.*');
+        $this->panelUser->givePermissionTo('training-places.create-adhoc.pilot');
+
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $student = Account::factory()->create();
+        Member::factory()->create([
+            'cid' => $student->id,
+            'name' => 'Pilot Student',
+        ]);
+
+        $reason = 'This is a valid reason for creating an ad-hoc pilot training place.';
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ListTrainingPlaces::class)
+            ->callAction('createAdhocTrainingPlace', data: [
+                'account_id' => $student->id,
+                'trainable' => Qualification::class.'|'.$qualification->id,
+                'reason' => $reason,
+            ])
+            ->assertNotified();
+
+        $this->assertDatabaseHas('training_places', [
+            'account_id' => $student->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+            'waiting_list_account_id' => null,
+        ]);
+    }
+
+    #[Test]
+    public function it_rejects_adhoc_qualification_creation_with_only_atc_permission()
+    {
+        $this->panelUser->givePermissionTo('training-places.view.*');
+        $this->panelUser->givePermissionTo('training-places.create-adhoc.atc');
+
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $student = Account::factory()->create();
+        Member::factory()->create(['cid' => $student->id]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ListTrainingPlaces::class)
+            ->callAction('createAdhocTrainingPlace', data: [
+                'account_id' => $student->id,
+                'trainable' => Qualification::class.'|'.$qualification->id,
+                'reason' => 'This is a valid reason for creating an ad-hoc training place.',
+            ])
+            ->assertHasActionErrors(['trainable']);
+
+        $this->assertDatabaseMissing('training_places', [
+            'account_id' => $student->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_groups_and_filters_qualification_places_under_p1_training()
+    {
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $ctsPosition = CtsPosition::factory()->create(['callsign' => 'EGLL_APP']);
+        $trainingPosition = TrainingPosition::factory()
+            ->withCtsPositions([$ctsPosition->callsign])
+            ->create(['category' => 'approach']);
+
+        $waitingList = WaitingList::factory()->create();
+        $pilotStudent = Account::factory()->create();
+        $atcStudent = Account::factory()->create();
+        Member::factory()->create(['cid' => $pilotStudent->id]);
+        Member::factory()->create(['cid' => $atcStudent->id]);
+
+        $pilotWaitingListAccount = $waitingList->addToWaitingList($pilotStudent, $this->privacc);
+        $atcWaitingListAccount = $waitingList->addToWaitingList($atcStudent, $this->privacc);
+
+        $qualificationPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::create([
+            'waiting_list_account_id' => $pilotWaitingListAccount->id,
+            'account_id' => $pilotStudent->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+        ]));
+
+        $positionPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::create([
+            'waiting_list_account_id' => $atcWaitingListAccount->id,
+            'account_id' => $atcStudent->id,
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
+        ]));
+
+        $this->assertSame('P1 Training', $qualificationPlace->fresh(['trainable'])->category);
+
+        Livewire::actingAs($this->privacc)
+            ->test(ListTrainingPlaces::class)
+            ->filterTable('category', 'P1 Training')
+            ->assertCanSeeTableRecords([$qualificationPlace])
+            ->assertCanNotSeeTableRecords([$positionPlace]);
     }
 
     #[Test]

--- a/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
@@ -12,6 +12,7 @@ use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Carbon;
+use Illuminate\Validation\ValidationException;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
@@ -143,6 +144,56 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
             'trainable_type' => Qualification::class,
             'trainable_id' => $qualification->id,
         ]);
+    }
+
+    #[Test]
+    public function it_rejects_adhoc_creation_for_non_pilot_qualifications()
+    {
+        $this->panelUser->givePermissionTo('training-places.view.*');
+        $this->panelUser->givePermissionTo('training-places.create-adhoc');
+
+        $qualification = Qualification::factory()->atc()->create();
+
+        $student = Account::factory()->create();
+        Member::factory()->create(['cid' => $student->id]);
+
+        Livewire::actingAs($this->panelUser)
+            ->test(ListTrainingPlaces::class)
+            ->callAction('createAdhocTrainingPlace', data: [
+                'account_id' => $student->id,
+                'trainable' => Qualification::class.'|'.$qualification->id,
+                'reason' => 'This is a valid reason for creating an ad-hoc training place.',
+            ])
+            ->assertHasActionErrors(['trainable']);
+
+        $this->assertDatabaseMissing('training_places', [
+            'account_id' => $student->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_rejects_non_pilot_qualifications_when_resolving_adhoc_trainable()
+    {
+        $this->panelUser->givePermissionTo('training-places.view.*');
+
+        $qualification = Qualification::factory()->atc()->create();
+
+        $component = Livewire::actingAs($this->panelUser)
+            ->test(ListTrainingPlaces::class)
+            ->instance();
+
+        $this->assertInstanceOf(ListTrainingPlaces::class, $component);
+
+        $method = new \ReflectionMethod(ListTrainingPlaces::class, 'resolveAdhocTrainable');
+
+        try {
+            $method->invoke($component, Qualification::class.'|'.$qualification->id);
+            $this->fail('Expected ValidationException was not thrown.');
+        } catch (ValidationException $exception) {
+            $this->assertArrayHasKey('trainable', $exception->errors());
+        }
     }
 
     #[Test]

--- a/tests/Unit/Policies/TrainingPlacePolicyTest.php
+++ b/tests/Unit/Policies/TrainingPlacePolicyTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit\Policies;
+
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\WaitingList;
+use App\Policies\TrainingPlacePolicy;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TrainingPlacePolicyTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private TrainingPlacePolicy $policy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->policy = app(TrainingPlacePolicy::class);
+    }
+
+    #[Test]
+    public function create_adhoc_with_atc_permission_allows_atc_department_via_gate(): void
+    {
+        $account = Account::factory()->create();
+        $account->givePermissionTo('training-places.create-adhoc.atc');
+
+        $this->assertTrue($account->can('createAdhoc', [TrainingPlace::class, WaitingList::ATC_DEPARTMENT]));
+        $this->assertFalse($account->can('createAdhoc', [TrainingPlace::class, WaitingList::PILOT_DEPARTMENT]));
+    }
+
+    #[Test]
+    public function create_adhoc_with_pilot_permission_allows_pilot_department_via_gate(): void
+    {
+        $account = Account::factory()->create();
+        $account->givePermissionTo('training-places.create-adhoc.pilot');
+
+        $this->assertTrue($account->can('createAdhoc', [TrainingPlace::class, WaitingList::PILOT_DEPARTMENT]));
+        $this->assertFalse($account->can('createAdhoc', [TrainingPlace::class, WaitingList::ATC_DEPARTMENT]));
+    }
+
+    #[Test]
+    public function create_adhoc_with_bare_permission_allows_either_department(): void
+    {
+        $account = Account::factory()->create();
+        $account->givePermissionTo('training-places.create-adhoc');
+
+        $this->assertTrue($account->can('createAdhoc', [TrainingPlace::class, WaitingList::ATC_DEPARTMENT]));
+        $this->assertTrue($account->can('createAdhoc', [TrainingPlace::class, WaitingList::PILOT_DEPARTMENT]));
+        $this->assertTrue($this->policy->createAdhoc($account));
+    }
+
+    #[Test]
+    public function create_adhoc_without_permission_denies(): void
+    {
+        $account = Account::factory()->create();
+
+        $this->assertFalse($account->can('createAdhoc', [TrainingPlace::class, WaitingList::ATC_DEPARTMENT]));
+        $this->assertFalse($account->can('createAdhoc', TrainingPlace::class));
+    }
+}


### PR DESCRIPTION
## Summary
- Seed and enforce department-split `training-places.manual-setup.atc/.pilot` and `create-adhoc.atc/.pilot` (bare permissions retained for existing roles).
- Replace ad-hoc creation’s position-only select with a composite `trainable` picker grouped into Training Positions and Pilot Qualifications, gated by department permission.
- Categorise qualification-backed places (e.g. PPL → P1 Training) across the list group/filter/search and category chart.

Part of TECH-699. Builds on #5102 (TECH-713).

## Test plan
- [ ] User with only `create-adhoc.atc` sees Training Positions options, not Pilot Qualifications
- [ ] User with only `create-adhoc.pilot` can create a qualification-backed ad-hoc place
- [ ] User with bare `create-adhoc` can still create either type
- [ ] Manual setup on a pilot waiting list respects `manual-setup.pilot` (bare still works)
- [ ] Qualification places appear under `P1 Training` / `P2 Training` / `P3 Training` rather than Uncategorised
- [ ] Category filter for `P1 Training` shows PPL places and hides ATC position places
- [ ] Searching by qualification code / name_long finds the place


Made with [Cursor](https://cursor.com)