### PR TITLE
Add pilot training specific emails for training place offer flow & discord notifications

### DIFF
--- a/app/Jobs/Training/CheckAvailability.php
+++ b/app/Jobs/Training/CheckAvailability.php
@@ -125,7 +125,7 @@ class CheckAvailability implements ShouldQueue
                 'training_place_id' => $this->trainingPlace->id,
                 'availability_check_id' => $availabilityCheck->id,
                 'status' => 'pending',
-                'expires_at' => now()->addDays(5)->endOfDay(),
+                'expires_at' => now()->addDays($this->trainingPlace->availabilityWarningDays())->endOfDay(),
             ]);
             $account->notify(new AvailabilityWarningCreated($warning));
         });

--- a/app/Models/Training/TrainingPlace/TrainingPlace.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlace.php
@@ -101,6 +101,23 @@ class TrainingPlace extends Model
         );
     }
 
+    public function availabilityWarningDays(): int
+    {
+        return (int) config(
+            'training.availability_warning_days.'.$this->department,
+            config('training.availability_warning_days.atc', 5)
+        );
+    }
+
+    public function trainingTeamDiscordChannelId(): string
+    {
+        if ($this->department === WaitingList::PILOT_DEPARTMENT) {
+            return (string) config('training.discord.pilot_training_team_channel_id', '');
+        }
+
+        return (string) ($this->trainingPosition?->training_team_discord_channel_id ?? '');
+    }
+
     /**
      * The CTS position callsigns associated with this training place's trainable.
      *

--- a/app/Models/Training/TrainingPlace/TrainingPlaceOffer.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlaceOffer.php
@@ -89,6 +89,15 @@ class TrainingPlaceOffer extends Model
         );
     }
 
+    public function trainingTeamDiscordChannelId(): string
+    {
+        if ($this->department === WaitingList::PILOT_DEPARTMENT) {
+            return (string) config('training.discord.pilot_training_team_channel_id', '');
+        }
+
+        return (string) ($this->trainingPosition?->training_team_discord_channel_id ?? '');
+    }
+
     protected function statusLabel(): Attribute
     {
         return Attribute::make(get: fn () => $this->status->label());

--- a/app/Notifications/Training/AvailabilityWarningCreated.php
+++ b/app/Notifications/Training/AvailabilityWarningCreated.php
@@ -3,6 +3,7 @@
 namespace App\Notifications\Training;
 
 use App\Models\Training\TrainingPlace\AvailabilityWarning;
+use App\Models\Training\WaitingList;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -41,16 +42,25 @@ class AvailabilityWarningCreated extends Notification
     public function toMail($notifiable)
     {
         $expiresAt = $this->availabilityWarning->expires_at;
+        $trainingPlace = $this->availabilityWarning->trainingPlace;
+        $isPilot = $trainingPlace->department === WaitingList::PILOT_DEPARTMENT;
 
         $daysToExpire = (int) ceil(now()->diffInHours($expiresAt, false) / 24);
+        $warningDays = $trainingPlace->availabilityWarningDays();
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject('Action Required: Update Your Availability')
-            ->view('emails.training.availability_warning', [
-                'recipient' => $notifiable,
-                'expires_at' => $expiresAt,
-                'days_to_expire' => $daysToExpire.' '.Str::plural('day', $daysToExpire),
-            ]);
+            ->view(
+                $isPilot
+                    ? 'emails.training.availability_warning_pilot'
+                    : 'emails.training.availability_warning',
+                [
+                    'recipient' => $notifiable,
+                    'expires_at' => $expiresAt,
+                    'days_to_expire' => $daysToExpire.' '.Str::plural('day', $daysToExpire),
+                    'availability_window' => $warningDays.' '.Str::plural('day', $warningDays),
+                ]
+            );
     }
 }

--- a/app/Notifications/Training/TrainingPlaceOfferDeclined.php
+++ b/app/Notifications/Training/TrainingPlaceOfferDeclined.php
@@ -43,6 +43,6 @@ class TrainingPlaceOfferDeclined extends Notification implements DiscordNotifica
 
     public function getChannel(): string
     {
-        return $this->trainingPlaceOffer->trainingPosition?->training_team_discord_channel_id ?? '';
+        return $this->trainingPlaceOffer->trainingTeamDiscordChannelId();
     }
 }

--- a/app/Notifications/Training/TrainingPlaceOfferRescinded.php
+++ b/app/Notifications/Training/TrainingPlaceOfferRescinded.php
@@ -3,6 +3,7 @@
 namespace App\Notifications\Training;
 
 use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+use App\Models\Training\WaitingList;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
@@ -26,17 +27,30 @@ class TrainingPlaceOfferRescinded extends Notification
 
     public function toMail($notifiable): MailMessage
     {
-        $account = $this->trainingPlaceOffer->waitingListAccount->account;
-        $position = $this->trainingPlaceOffer->trainingPosition?->position;
+        $offer = $this->trainingPlaceOffer;
+        $account = $offer->waitingListAccount->account;
+        $isPilot = $offer->department === WaitingList::PILOT_DEPARTMENT;
+
+        $viewData = [
+            'recipient' => $notifiable,
+            'account' => $account,
+            'reason' => $this->reason,
+        ];
+
+        if ($isPilot) {
+            $viewData['course_name'] = $offer->display_name;
+        } else {
+            $viewData['position'] = $offer->trainingPosition?->position;
+        }
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject('UK Training Place Offer Rescinded')
-            ->view('emails.training.training_place_offer_rescinded', [
-                'recipient' => $notifiable,
-                'account' => $account,
-                'position' => $position,
-                'reason' => $this->reason,
-            ]);
+            ->view(
+                $isPilot
+                    ? 'emails.training.training_place_offer_rescinded_pilot'
+                    : 'emails.training.training_place_offer_rescinded',
+                $viewData
+            );
     }
 }

--- a/app/Notifications/Training/TrainingPlaceOfferRescindedAndRemoved.php
+++ b/app/Notifications/Training/TrainingPlaceOfferRescindedAndRemoved.php
@@ -3,12 +3,12 @@
 namespace App\Notifications\Training;
 
 use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+use App\Models\Training\WaitingList;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
 /**
  * Sent to a member when their training place offer is rescinded by staff and they are removed from the waiting list.
- * The member retains their waiting list position.
  */
 class TrainingPlaceOfferRescindedAndRemoved extends Notification
 {
@@ -26,16 +26,23 @@ class TrainingPlaceOfferRescindedAndRemoved extends Notification
 
     public function toMail($notifiable): MailMessage
     {
-        $account = $this->trainingPlaceOffer->waitingListAccount->account;
-        $waitingList = $this->trainingPlaceOffer->waitingListAccount->waitingList;
+        $offer = $this->trainingPlaceOffer;
+        $account = $offer->waitingListAccount->account;
+        $waitingList = $offer->waitingListAccount->waitingList;
+        $isPilot = $offer->department === WaitingList::PILOT_DEPARTMENT;
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject('UK Training Place Offer Rescinded')
-            ->view('emails.training.training_place_offer_rescinded_and_removed', [
-                'recipient' => $notifiable,
-                'account' => $account,
-                'waiting_list' => $waitingList,
-            ]);
+            ->view(
+                $isPilot
+                    ? 'emails.training.training_place_offer_rescinded_and_removed_pilot'
+                    : 'emails.training.training_place_offer_rescinded_and_removed',
+                [
+                    'recipient' => $notifiable,
+                    'account' => $account,
+                    'waiting_list' => $waitingList,
+                ]
+            );
     }
 }

--- a/app/Notifications/Training/TrainingPlaceOffered.php
+++ b/app/Notifications/Training/TrainingPlaceOffered.php
@@ -3,6 +3,7 @@
 namespace App\Notifications\Training;
 
 use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+use App\Models\Training\WaitingList;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
@@ -36,18 +37,30 @@ class TrainingPlaceOffered extends Notification
     {
         $offer = $this->trainingPlaceOffer;
         $account = $offer->waitingListAccount->account;
-        $position = $offer->trainingPosition?->position;
+        $isPilot = $offer->department === WaitingList::PILOT_DEPARTMENT;
+
+        $viewData = [
+            'recipient' => $notifiable,
+            'account' => $account,
+            'offer' => $offer,
+            'accept_url' => route('mship.waiting-lists.training-place-offer.accept', ['token' => $offer->token]),
+            'decline_url' => route('mship.waiting-lists.training-place-offer.decline', ['token' => $offer->token]),
+        ];
+
+        if ($isPilot) {
+            $viewData['course_name'] = $offer->display_name;
+        } else {
+            $viewData['position'] = $offer->trainingPosition?->position;
+        }
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject('UK Training Place Offer')
-            ->view('emails.training.training_place_offer', [
-                'recipient' => $notifiable,
-                'account' => $account,
-                'position' => $position,
-                'offer' => $offer,
-                'accept_url' => route('mship.waiting-lists.training-place-offer.accept', ['token' => $offer->token]),
-                'decline_url' => route('mship.waiting-lists.training-place-offer.decline', ['token' => $offer->token]),
-            ]);
+            ->view(
+                $isPilot
+                    ? 'emails.training.training_place_offer_pilot'
+                    : 'emails.training.training_place_offer',
+                $viewData
+            );
     }
 }

--- a/app/Notifications/Training/TrainingPlaceRemovedDueToExpiredAvailability.php
+++ b/app/Notifications/Training/TrainingPlaceRemovedDueToExpiredAvailability.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Notifications\Training;
 
 use App\Models\Training\TrainingPlace\AvailabilityWarning;
+use App\Models\Training\WaitingList;
 use App\Notifications\DiscordNotification;
 use App\Notifications\DiscordNotificationChannel;
 use App\Notifications\Notification;
@@ -45,21 +46,27 @@ class TrainingPlaceRemovedDueToExpiredAvailability extends Notification implemen
     {
         $trainingPlace = $this->availabilityWarning->trainingPlace;
         $removalDate = now()->format('d M Y');
+        $isPilot = $trainingPlace->department === WaitingList::PILOT_DEPARTMENT;
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject('Attention: Your Training Place Has Been Removed - Availability Check Expired')
-            ->view('emails.training.training_place_removed_expired_availability', [
-                'recipient' => $notifiable,
-                'training_place_position_name' => $trainingPlace->trainingPosition?->position?->name ?? $trainingPlace->display_name,
-                'removal_date' => $removalDate,
-            ]);
+            ->view(
+                $isPilot
+                    ? 'emails.training.training_place_removed_expired_availability_pilot'
+                    : 'emails.training.training_place_removed_expired_availability',
+                [
+                    'recipient' => $notifiable,
+                    'training_place_position_name' => $trainingPlace->trainingPosition?->position?->name ?? $trainingPlace->display_name,
+                    'removal_date' => $removalDate,
+                ]
+            );
     }
 
     public function toDiscord($notifiable)
     {
         $trainingPlace = $this->availabilityWarning->trainingPlace;
-        $positionLabel = $this->positionLabel($trainingPlace);
+        $positionLabel = $this->placeLabel($trainingPlace);
 
         return [
             'content' => null,
@@ -83,10 +90,10 @@ class TrainingPlaceRemovedDueToExpiredAvailability extends Notification implemen
 
     public function getChannel(): string
     {
-        return $this->availabilityWarning->trainingPlace->trainingPosition?->training_team_discord_channel_id ?? '';
+        return $this->availabilityWarning->trainingPlace->trainingTeamDiscordChannelId();
     }
 
-    private function positionLabel($trainingPlace): string
+    private function placeLabel($trainingPlace): string
     {
         $position = $trainingPlace->trainingPosition?->position;
 

--- a/app/Notifications/Training/TrainingPlaceRemovedDueToFourthAvailabilityFailure.php
+++ b/app/Notifications/Training/TrainingPlaceRemovedDueToFourthAvailabilityFailure.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Notifications\Training;
 
 use App\Models\Training\TrainingPlace\AvailabilityWarning;
+use App\Models\Training\WaitingList;
 use App\Notifications\DiscordNotification;
 use App\Notifications\DiscordNotificationChannel;
 use App\Notifications\Notification;
@@ -13,7 +14,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 /**
  * This notification is sent to an account when their training place is removed
  * because they have failed the availability check on four occasions (having
- * previously resolved three failed checks within the five-day window).
+ * previously resolved three failed checks within the warning window).
  */
 class TrainingPlaceRemovedDueToFourthAvailabilityFailure extends Notification implements DiscordNotification
 {
@@ -46,21 +47,27 @@ class TrainingPlaceRemovedDueToFourthAvailabilityFailure extends Notification im
     {
         $trainingPlace = $this->availabilityWarning->trainingPlace;
         $removalDate = now()->format('d M Y');
+        $isPilot = $trainingPlace->department === WaitingList::PILOT_DEPARTMENT;
 
         return (new MailMessage)
             ->from(config('mail.from.address'), 'VATSIM UK - Training Department')
             ->subject('Attention: Your Training Place Has Been Removed - Repeated Availability Check Failures')
-            ->view('emails.training.training_place_removed_fourth_availability_failure', [
-                'recipient' => $notifiable,
-                'training_place_position_name' => $trainingPlace->trainingPosition?->position?->name ?? $trainingPlace->display_name,
-                'removal_date' => $removalDate,
-            ]);
+            ->view(
+                $isPilot
+                    ? 'emails.training.training_place_removed_fourth_availability_failure_pilot'
+                    : 'emails.training.training_place_removed_fourth_availability_failure',
+                [
+                    'recipient' => $notifiable,
+                    'training_place_position_name' => $trainingPlace->trainingPosition?->position?->name ?? $trainingPlace->display_name,
+                    'removal_date' => $removalDate,
+                ]
+            );
     }
 
     public function toDiscord($notifiable)
     {
         $trainingPlace = $this->availabilityWarning->trainingPlace;
-        $positionLabel = $this->positionLabel($trainingPlace);
+        $positionLabel = $this->placeLabel($trainingPlace);
 
         $warningDates = $trainingPlace->availabilityWarnings()
             ->orderBy('created_at')
@@ -90,10 +97,10 @@ class TrainingPlaceRemovedDueToFourthAvailabilityFailure extends Notification im
 
     public function getChannel(): string
     {
-        return $this->availabilityWarning->trainingPlace->trainingPosition?->training_team_discord_channel_id ?? '';
+        return $this->availabilityWarning->trainingPlace->trainingTeamDiscordChannelId();
     }
 
-    private function positionLabel($trainingPlace): string
+    private function placeLabel($trainingPlace): string
     {
         $position = $trainingPlace->trainingPosition?->position;
 

--- a/config/training.php
+++ b/config/training.php
@@ -7,6 +7,26 @@ return [
         'short_notice_hours' => (int) env('TRAINING_MENTORING_SHORT_NOTICE_HOURS', 24),
     ],
 
+    'availability_warning_days' => [
+        'atc' => (int) env('TRAINING_AVAILABILITY_WARNING_DAYS_ATC', 5),
+        'pilot' => (int) env('TRAINING_AVAILABILITY_WARNING_DAYS_PILOT', 7),
+    ],
+
+    'pilot' => [
+        'handbook_url' => env(
+            'TRAINING_PILOT_HANDBOOK_URL',
+            'https://drive.google.com/file/d/1llKkmgdf1srYxjTkMhd8m4u-lJDxls_6/view?usp=drive_link'
+        ),
+        // Policy is published within the handbook until a separate policy page exists.
+        'policy_url' => env(
+            'TRAINING_PILOT_POLICY_URL',
+            'https://drive.google.com/file/d/1llKkmgdf1srYxjTkMhd8m4u-lJDxls_6/view?usp=drive_link'
+        ),
+        'helpdesk_url' => env('TRAINING_PILOT_HELPDESK_URL', 'https://helpdesk.vatsim.uk'),
+        'waiting_lists_url' => env('TRAINING_PILOT_WAITING_LISTS_URL', 'https://www.vatsim.uk/mship/waiting-lists'),
+        'cts_url' => env('TRAINING_PILOT_CTS_URL', 'https://cts.vatsim.uk'),
+    ],
+
     'discord' => [
         'exam_announce_channel_id' => env('DISCORD_EXAM_ANNOUNCE_CHANNEL_ID', '1086017278988013609'),
         'exam_pilot_role_id' => env('DISCORD_EXAM_PILOT_ROLE_ID', '1086016803047747675'),
@@ -16,6 +36,7 @@ return [
         'mentoring_pilot_role_id' => env('DISCORD_MENTORING_PILOT_ROLE_ID', '1086016916394606622'),
         'mentoring_controller_role_id' => env('DISCORD_MENTORING_CONTROLLER_ROLE_ID', '1086016985537716256'),
         'vatuk_emoji_name_and_id' => env('DISCORD_VATUK_EMOJI_NAME_AND_ID', 'vuktrail:740917513436790834'),
+        'pilot_training_team_channel_id' => env('DISCORD_PILOT_TRAINING_TEAM_CHANNEL_ID', '705818400462602283'),
     ],
 
 ];

--- a/resources/views/emails/training/availability_warning_pilot.blade.php
+++ b/resources/views/emails/training/availability_warning_pilot.blade.php
@@ -1,0 +1,24 @@
+@extends('emails.messages.post')
+
+@section('body')
+	<p>Please could you check that you have both a session request and up-to-date availability entered into the CT System?
+		Without both, mentors will be unable to accept your mentoring sessions.</p>
+
+	<p>To be fair to those students who are still waiting for training, if after three of these reminders, or after
+		{{ $availability_window }} of this email, you have no session request/availability in the CTS System, we will have to
+		reassign your training place to the next person on the waiting list.</p>
+
+	<p>To continue your training, please submit your availability in the CTS System as soon as possible.
+		You have <strong>{{ $days_to_expire }}</strong>
+		(until <strong>{{ $expires_at->format('d/m/Y H:i') }} Zulu</strong>) to submit your availability.</p>
+
+	<p>To submit your availability, please visit the Central Training System:
+		<a href="{{ config('training.pilot.cts_url') }}">{{ config('training.pilot.cts_url') }}</a>
+	</p>
+
+	<p>
+		If you don’t have the time/don’t wish to continue with your training for the time being, please let us know by
+		opening a ticket with the Pilot Training team via the helpdesk:
+		<a href="{{ config('training.pilot.helpdesk_url') }}">{{ config('training.pilot.helpdesk_url') }}</a>
+	</p>
+@stop

--- a/resources/views/emails/training/training_place_offer_pilot.blade.php
+++ b/resources/views/emails/training/training_place_offer_pilot.blade.php
@@ -1,0 +1,32 @@
+@extends('emails.messages.post')
+
+@section('body')
+
+	<p>A training place is now available for you on our <strong>{{ $course_name }}</strong>.
+		Training times vary from student to student, but you should expect to be training for the next three to five months.
+		Please inform us before accepting this place if you will not be available to complete your training during this
+		period.</p>
+
+	<p>Pilot Training in VATSIM UK is challenging. You are expected to remain current with your flying skills, undertake
+		independent theoretical study and remain engaged with VATSIM UK wherever possible. For rated pilots undertaking the
+		P2, P3 or P4, this includes being proficient in all content from previous courses.</p>
+
+	<p>If you are ready and able to begin your training, please let us know as soon as possible that you agree with the
+		requirements set out in section 7 of the
+		<a href="{{ config('training.pilot.handbook_url') }}">Pilot Training Handbook</a>.
+	</p>
+
+	<p>We’ll keep the training place open for you for the next 84 hours (3.5 days). If we’ve not heard from you by then,
+		unfortunately, we will have to offer the place to another student.</p>
+
+	<p>This offer expires at <strong>{{ $offer->expires_at->format('H:i') }}Z on
+			{{ $offer->expires_at->format('d/m/Y') }}</strong>.</p>
+
+	<p style="margin-top: 24px;">
+		<a href="{{ $accept_url }}" class="btn btn-primary" style="margin-right: 12px;">Accept Training Place</a>
+		<a href="{{ $decline_url }}" class="btn"
+			style="color: #fff; background-color: #d9534f; border-color: #d43f3a; text-decoration: none; display: inline-block; padding: 6px 12px; font-size: 14px; border-radius: 4px; border: 1px solid #d43f3a;">Decline
+			Training Place</a>
+	</p>
+
+@stop

--- a/resources/views/emails/training/training_place_offer_rescinded_and_removed_pilot.blade.php
+++ b/resources/views/emails/training/training_place_offer_rescinded_and_removed_pilot.blade.php
@@ -1,0 +1,22 @@
+@extends('emails.messages.post')
+
+@section('body')
+
+	<p>We write to inform you that you have been removed from your place on the Pilot Training
+		<strong>{{ $waiting_list->name }}</strong> Waiting List. At the time of your removal, you had an outstanding offer of
+		a training place and, accordingly, that offer has been rescinded — you may no longer accept that training place.
+		Whilst this will be disappointing, there are few reasons why this would occur, which include:</p>
+
+	<p>
+		- Failing to remain active as a pilot on the VATSIM Network<br>
+		- Failing to respond to communications from the Pilot Training Team<br>
+		- Not being a home member of the VATSIM UK Division<br>
+		- A suspension from VATSIM UK's services<br>
+		- A suspension from the VATSIM Network
+	</p>
+
+	<p>If you wish to query the specific details, appeal this matter or otherwise ask any questions, please raise a ticket
+		for the attention of the Pilot Training Team at the
+		<a href="{{ config('training.pilot.helpdesk_url') }}">helpdesk</a>.</p>
+
+@stop

--- a/resources/views/emails/training/training_place_offer_rescinded_pilot.blade.php
+++ b/resources/views/emails/training/training_place_offer_rescinded_pilot.blade.php
@@ -1,0 +1,17 @@
+@extends('emails.messages.post')
+
+@section('body')
+
+	<p>We write to inform you that the previous offer for a training place on <strong>{{ $course_name }}</strong> has been
+		rescinded.</p>
+
+	<p>The reason for this is: <strong>{{ $reason }}</strong>.</p>
+
+	<p>Owing to the fact that the offer has been rescinded rather than you being removed from the waiting list, your
+		position on the waiting list will remain and you will be offered another training place at an appropriate time. We
+		apologise for the inconvenience, but please rest assured that the team are working hard to ensure that training
+		continues to run smoothly and we anticipate that the wait for you to be offered a training place will not be long.
+		If you have any questions in the meantime, you can contact the Pilot Training Team via the
+		<a href="{{ config('training.pilot.helpdesk_url') }}">helpdesk</a>.</p>
+
+@stop

--- a/resources/views/emails/training/training_place_removed_expired_availability_pilot.blade.php
+++ b/resources/views/emails/training/training_place_removed_expired_availability_pilot.blade.php
@@ -1,0 +1,24 @@
+@extends('emails.messages.post')
+
+@section('body')
+	<p>In accordance with the <a href="{{ config('training.pilot.policy_url') }}">Pilot Training Policy</a>, as we’ve not
+		heard from you on the above and you still do not have either a Session Request or Availability in the CTS, your
+		training place has been removed and will shortly be reallocated.</p>
+
+	<p>As no session request and availability were submitted within the seven-day period, your training place has been
+		removed as of <strong>{{ $removal_date }}</strong>. This allows the next person on the waiting list to receive
+		training.</p>
+
+	<p>It is essential that you maintain a session request and up-to-date availability, as without it mentors are unable to
+		accept your mentoring sessions. Failure to do so delays the training process, both for you and others on the waiting
+		list and in order to ensure that training continues to move within the division, we enforce this policy strictly.
+	</p>
+
+	<p>If you would like to continue with Pilot training in the future, you can self-enrol for the waiting list again:
+		<a href="{{ config('training.pilot.waiting_lists_url') }}">{{ config('training.pilot.waiting_lists_url') }}</a>
+	</p>
+
+	<p>If you believe this to be in error, please contact the VATSIM UK Pilot Training team via the Helpdesk:
+		<a href="{{ config('training.pilot.helpdesk_url') }}">{{ config('training.pilot.helpdesk_url') }}</a>
+	</p>
+@stop

--- a/resources/views/emails/training/training_place_removed_fourth_availability_failure_pilot.blade.php
+++ b/resources/views/emails/training/training_place_removed_fourth_availability_failure_pilot.blade.php
@@ -1,0 +1,25 @@
+@extends('emails.messages.post')
+
+@section('body')
+	<p>In accordance with the <a href="{{ config('training.pilot.policy_url') }}">Pilot Training Policy</a>, you currently
+		do not have either a session request and availability entered into the CTS System. As you have already had three
+		reminders to do so, your training place has been removed and will shortly be reallocated.</p>
+
+	<p>You have previously had three instances where you failed the availability check but resolved it within the seven-day period.
+		On this fourth occasion of failing the availability check, your training place has been removed as of
+		<strong>{{ $removal_date }}</strong> and will shortly be reallocated. This allows the next person on the waiting list
+		to receive training.</p>
+
+	<p>It is essential that you maintain a session request and up-to-date availability, as without it mentors are unable to
+		accept your mentoring sessions. Failure to do so delays the training process, both for you and others on the waiting
+		list and in order to ensure that training continues to move within the division, we enforce this policy strictly.
+	</p>
+
+	<p>If you would like to continue with Pilot training in the future, you can self-enrol for the waiting list again:
+		<a href="{{ config('training.pilot.waiting_lists_url') }}">{{ config('training.pilot.waiting_lists_url') }}</a>
+	</p>
+
+	<p>If you believe this to be in error, please contact the VATSIM UK Pilot Training team via the Helpdesk:
+		<a href="{{ config('training.pilot.helpdesk_url') }}">{{ config('training.pilot.helpdesk_url') }}</a>
+	</p>
+@stop

--- a/tests/Unit/Jobs/Training/CheckAvailabilityTest.php
+++ b/tests/Unit/Jobs/Training/CheckAvailabilityTest.php
@@ -12,6 +12,7 @@ use App\Models\Cts\ExamBooking;
 use App\Models\Cts\Member;
 use App\Models\Cts\Session;
 use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPlace\AvailabilityCheck;
 use App\Models\Training\TrainingPlace\AvailabilityWarning;
 use App\Models\Training\TrainingPlace\TrainingPlace;
@@ -219,6 +220,34 @@ class CheckAvailabilityTest extends TestCase
             now()->addDays(5)->endOfDay()->timestamp,
             $warning->expires_at->timestamp,
             60 // Allow 60 seconds delta for test execution time
+        );
+    }
+
+    #[Test]
+    public function it_creates_a_seven_day_availability_warning_for_pilot_training_places(): void
+    {
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $pilotPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forQualification($qualification)
+            ->create([
+                'account_id' => $this->account->id,
+                'waiting_list_account_id' => null,
+            ]));
+
+        $pilotPlace->forceFill([
+            'created_at' => now()->subHours(TrainingPlace::AVAILABILITY_CHECK_GRACE_PERIOD_HOURS + 1),
+        ])->saveQuietly();
+
+        (new CheckAvailability($pilotPlace->fresh(['trainable', 'account'])))->handle();
+
+        $warning = AvailabilityWarning::where('training_place_id', $pilotPlace->id)->first();
+        $this->assertNotNull($warning);
+        $this->assertEqualsWithDelta(
+            now()->addDays(7)->endOfDay()->timestamp,
+            $warning->expires_at->timestamp,
+            60
         );
     }
 

--- a/tests/Unit/Notifications/Training/PilotTrainingPlaceNotificationTest.php
+++ b/tests/Unit/Notifications/Training/PilotTrainingPlaceNotificationTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications\Training;
+
+use App\Enums\TrainingPlaceOfferStatus;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use App\Models\Training\TrainingPlace\AvailabilityCheck;
+use App\Models\Training\TrainingPlace\AvailabilityWarning;
+use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
+use App\Models\Training\WaitingList;
+use App\Notifications\DiscordNotificationChannel;
+use App\Notifications\Training\AvailabilityWarningCreated;
+use App\Notifications\Training\TrainingPlaceOfferDeclined;
+use App\Notifications\Training\TrainingPlaceOffered;
+use App\Notifications\Training\TrainingPlaceOfferRescinded;
+use App\Notifications\Training\TrainingPlaceOfferRescindedAndRemoved;
+use App\Notifications\Training\TrainingPlaceRemovedDueToExpiredAvailability;
+use App\Notifications\Training\TrainingPlaceRemovedDueToFourthAvailabilityFailure;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PilotTrainingPlaceNotificationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Account $account;
+
+    private Qualification $qualification;
+
+    private WaitingList $waitingList;
+
+    private TrainingPlaceOffer $offer;
+
+    private TrainingPlace $trainingPlace;
+
+    private AvailabilityWarning $availabilityWarning;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake();
+
+        config([
+            'training.discord.pilot_training_team_channel_id' => 'pilot-channel-123',
+            'training.availability_warning_days.pilot' => 7,
+        ]);
+
+        $ctsMember = Member::factory()->create();
+        $this->account = Account::factory()->create(['id' => $ctsMember->cid]);
+
+        $this->qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create([
+                'code' => 'PPL',
+                'type' => 'pilot',
+                'name_long' => 'Private Pilot Licence',
+            ]);
+
+        $this->waitingList = WaitingList::factory()->create([
+            'name' => 'P1 Waiting List',
+            'department' => WaitingList::PILOT_DEPARTMENT,
+        ]);
+        $waitingListAccount = $this->waitingList->addToWaitingList($this->account, Account::factory()->create());
+
+        $this->offer = TrainingPlaceOffer::factory()
+            ->forQualification($this->qualification)
+            ->create([
+                'waiting_list_account_id' => $waitingListAccount->id,
+                'status' => TrainingPlaceOfferStatus::Pending,
+                'token' => Str::random(32),
+                'expires_at' => now()->addHours(84),
+            ]);
+
+        $this->trainingPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forQualification($this->qualification)
+            ->create([
+                'waiting_list_account_id' => $waitingListAccount->id,
+                'account_id' => $this->account->id,
+            ]));
+
+        $availabilityCheck = AvailabilityCheck::factory()->failed()->create([
+            'training_place_id' => $this->trainingPlace->id,
+        ]);
+
+        $this->availabilityWarning = AvailabilityWarning::factory()->pending()->create([
+            'training_place_id' => $this->trainingPlace->id,
+            'availability_check_id' => $availabilityCheck->id,
+            'expires_at' => now()->addDays(7),
+        ]);
+    }
+
+    #[Test]
+    public function it_renders_the_pilot_offer_view_with_course_name_and_no_atc_wording(): void
+    {
+        $mail = (new TrainingPlaceOffered($this->offer))->toMail($this->account);
+        $html = $this->renderMail($mail);
+
+        $this->assertEquals('emails.training.training_place_offer_pilot', $mail->view);
+        $this->assertSame($this->offer->display_name, $mail->viewData['course_name']);
+        $this->assertStringContainsString($this->offer->display_name, $html);
+        $this->assertStringContainsString('Pilot Training Handbook', $html);
+        $this->assertStringContainsString('three to five months', $html);
+        $this->assertStringNotContainsString('defer', strtolower($html));
+        $this->assertStringNotContainsString('ATC Training', $html);
+        $this->assertStringNotContainsString('ATC Training Policy', $html);
+        $this->assertStringNotContainsString('ATC Training Handbook', $html);
+    }
+
+    #[Test]
+    public function it_renders_the_pilot_offer_rescinded_view(): void
+    {
+        $reason = 'Mentor capacity was withdrawn for this course.';
+        $mail = (new TrainingPlaceOfferRescinded($this->offer, $reason))->toMail($this->account);
+        $html = $this->renderMail($mail);
+
+        $this->assertEquals('emails.training.training_place_offer_rescinded_pilot', $mail->view);
+        $this->assertStringContainsString($this->offer->display_name, $html);
+        $this->assertStringContainsString($reason, $html);
+        $this->assertStringContainsString('Pilot Training Team', $html);
+        $this->assertStringNotContainsString('ATC Training Team', $html);
+    }
+
+    #[Test]
+    public function it_renders_the_pilot_offer_rescinded_and_removed_view_without_roster_wording(): void
+    {
+        $mail = (new TrainingPlaceOfferRescindedAndRemoved($this->offer, 'Removed by staff'))->toMail($this->account);
+        $html = $this->renderMail($mail);
+
+        $this->assertEquals('emails.training.training_place_offer_rescinded_and_removed_pilot', $mail->view);
+        $this->assertStringContainsString('P1 Waiting List', $html);
+        $this->assertStringContainsString('Pilot Training Team', $html);
+        $this->assertStringContainsString('home member of the VATSIM UK Division', $html);
+        $this->assertStringNotContainsString('UK ATC Roster', $html);
+        $this->assertStringNotContainsString('ATC Training', $html);
+    }
+
+    #[Test]
+    public function it_renders_the_pilot_expired_availability_removal_view(): void
+    {
+        $mail = (new TrainingPlaceRemovedDueToExpiredAvailability($this->availabilityWarning))->toMail($this->account);
+        $html = $this->renderMail($mail);
+
+        $this->assertEquals('emails.training.training_place_removed_expired_availability_pilot', $mail->view);
+        $this->assertStringContainsString('seven-day period', $html);
+        $this->assertStringContainsString('Pilot Training Policy', $html);
+        $this->assertStringContainsString(now()->format('d M Y'), $html);
+        $this->assertStringNotContainsString('ATC Training Policy', $html);
+        $this->assertStringNotContainsString('five-day', $html);
+    }
+
+    #[Test]
+    public function it_renders_the_pilot_fourth_failure_removal_view(): void
+    {
+        $mail = (new TrainingPlaceRemovedDueToFourthAvailabilityFailure($this->availabilityWarning))->toMail($this->account);
+        $html = $this->renderMail($mail);
+
+        $this->assertEquals('emails.training.training_place_removed_fourth_availability_failure_pilot', $mail->view);
+        $this->assertStringContainsString('seven-day period', $html);
+        $this->assertStringContainsString('Pilot Training Policy', $html);
+        $this->assertStringNotContainsString('ATC Training Policy', $html);
+        $this->assertStringNotContainsString('five-day', $html);
+    }
+
+    #[Test]
+    public function it_renders_the_pilot_availability_warning_view_with_seven_day_window(): void
+    {
+        $mail = (new AvailabilityWarningCreated($this->availabilityWarning))->toMail($this->account);
+        $html = $this->renderMail($mail);
+
+        $this->assertEquals('emails.training.availability_warning_pilot', $mail->view);
+        $this->assertSame('7 days', $mail->viewData['availability_window']);
+        $this->assertStringContainsString('7 days of this email', $html);
+        $this->assertStringContainsString('Pilot Training team', $html);
+        $this->assertStringNotContainsString('ATC Training team', $html);
+        $this->assertStringNotContainsString('after five days', $html);
+    }
+
+    #[Test]
+    public function it_routes_pilot_discord_notifications_to_the_configured_pilot_channel(): void
+    {
+        $declined = new TrainingPlaceOfferDeclined($this->offer);
+        $expired = new TrainingPlaceRemovedDueToExpiredAvailability($this->availabilityWarning);
+        $fourth = new TrainingPlaceRemovedDueToFourthAvailabilityFailure($this->availabilityWarning);
+
+        $this->assertSame('pilot-channel-123', $declined->getChannel());
+        $this->assertSame('pilot-channel-123', $expired->getChannel());
+        $this->assertSame('pilot-channel-123', $fourth->getChannel());
+
+        $this->assertContains(DiscordNotificationChannel::class, $declined->via($this->account));
+        $this->assertContains(DiscordNotificationChannel::class, $expired->via($this->account));
+        $this->assertContains(DiscordNotificationChannel::class, $fourth->via($this->account));
+
+        $discord = $declined->toDiscord($this->account);
+        $this->assertStringContainsString($this->offer->display_name, $discord['embeds'][0]['description']);
+    }
+
+    private function renderMail(\Illuminate\Notifications\Messages\MailMessage $mail): string
+    {
+        return view($mail->view, array_merge($mail->viewData, [
+            'subject' => $mail->subject,
+        ]))->render();
+    }
+}


### PR DESCRIPTION
## Summary
- Add department-specific Pilot Training email templates for offer, rescind, removal, and availability warning notifications.
- Route pilot Discord alerts to `config('training.discord.pilot_training_team_channel_id')` and keep ATC channel resolution unchanged.
- Use a 7-day availability warning window for pilot places (ATC remains 5 days), with handbook/policy/helpdesk URLs driven from `config('training.pilot.*')`.

Part of TECH-699. Builds on #5102 (TECH-713 `department` accessor). Independent of #5103.

### Clarifications applied
- Availability window confirmed as **7 days** for PT
- Deferral paragraph omitted (no deferral workflow in Core)
- Pilot Training Policy URL intentionally shares the handbook document

## Test plan
- [ ] Offer a qualification-backed place: member receives the pilot offer email (no ATC handbook/policy/deferral wording)
- [ ] Rescind / rescind-and-remove on a pilot offer: pilot team wording and waiting-list name resolve correctly
- [ ] Trigger an availability warning on a pilot place: email says seven days; warning expires in 7 days
- [ ] Expire / fourth-failure removal on a pilot place: pilot policy wording; Discord posts to the configured pilot channel
- [ ] ATC offer/warning/removal emails and 5-day timing remain unchanged
- [ ] With `DISCORD_PILOT_TRAINING_TEAM_CHANNEL_ID` unset, pilot Discord alerts are omitted


Made with [Cursor](https://cursor.com)