### PR TITLE
Allow training place viewing to be scoped by ATC or Pilot permission

### DIFF
--- a/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
+++ b/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
@@ -49,12 +49,8 @@ class ViewTrainingPlace extends BaseMentoringHistoryPage implements HasInfolists
 
     public function mount(): void
     {
-        // Check training places view permission
         /** @var Account|null $user */
         $user = Auth::user();
-        if (! $user || ! $user->can('training-places.view.*')) {
-            abort(403, 'You do not have permission to view training places.');
-        }
 
         $this->trainingPlace = TrainingPlace::withTrashed()
             ->where('id', $this->trainingPlaceId)
@@ -64,6 +60,10 @@ class ViewTrainingPlace extends BaseMentoringHistoryPage implements HasInfolists
                 'trainable' => fn (MorphTo $morphTo) => $morphTo->morphWith([TrainingPosition::class => ['position']]),
             ])
             ->firstOrFail();
+
+        if (! $user || ! $user->can('view', $this->trainingPlace)) {
+            abort(403, 'You do not have permission to view training places.');
+        }
     }
 
     public function getTitle(): string|Htmlable

--- a/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
@@ -4,9 +4,12 @@ namespace App\Filament\Training\Resources\TrainingPlaces;
 
 use App\Filament\Training\Pages\TrainingPlace\ViewTrainingPlace;
 use App\Filament\Training\Resources\TrainingPlaces\Pages\ListTrainingPlaces;
+use App\Models\Mship\Account;
 use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Models\Training\WaitingList;
+use App\Policies\TrainingPlacePolicy;
 use App\Services\Training\MentorPermissionService;
 use Filament\Actions\RestoreAction;
 use Filament\Actions\ViewAction;
@@ -36,6 +39,31 @@ class TrainingPlaceResource extends Resource
     protected static string|\UnitEnum|null $navigationGroup = 'Training';
 
     protected static ?int $navigationSort = 2;
+
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        /** @var Account|null $user */
+        $user = auth()->user();
+
+        $canViewAtc = self::canViewDepartment($user, WaitingList::ATC_DEPARTMENT);
+        $canViewPilot = self::canViewDepartment($user, WaitingList::PILOT_DEPARTMENT);
+
+        if ($canViewAtc && $canViewPilot) {
+            return $query;
+        }
+
+        if ($canViewAtc) {
+            return $query->where('trainable_type', TrainingPosition::class);
+        }
+
+        if ($canViewPilot) {
+            return $query->where('trainable_type', Qualification::class);
+        }
+
+        return $query->whereRaw('0 = 1');
+    }
 
     public static function table(Table $table): Table
     {
@@ -252,20 +280,38 @@ class TrainingPlaceResource extends Resource
      */
     protected static function categoryFilterOptions(): array
     {
-        $positionCategories = TrainingPosition::query()
-            ->whereNotNull('category')
-            ->where('category', '!=', '')
-            ->distinct()
-            ->orderBy('category')
-            ->pluck('category', 'category');
+        /** @var Account|null $user */
+        $user = auth()->user();
+        $canViewAtc = self::canViewDepartment($user, WaitingList::ATC_DEPARTMENT);
+        $canViewPilot = self::canViewDepartment($user, WaitingList::PILOT_DEPARTMENT);
 
-        $pilotCategories = collect(MentorPermissionService::pilotCategories())
-            ->mapWithKeys(fn (string $category): array => [$category => $category]);
+        $positionCategories = $canViewAtc
+            ? TrainingPosition::query()
+                ->whereNotNull('category')
+                ->where('category', '!=', '')
+                ->distinct()
+                ->orderBy('category')
+                ->pluck('category', 'category')
+            : collect();
+
+        $pilotCategories = $canViewPilot
+            ? collect(MentorPermissionService::pilotCategories())
+                ->mapWithKeys(fn (string $category): array => [$category => $category])
+            : collect();
 
         return $positionCategories
             ->union($pilotCategories)
             ->map(fn (string $category): string => Str::title($category))
             ->all();
+    }
+
+    private static function canViewDepartment(?Account $user, string $department): bool
+    {
+        if (! $user) {
+            return false;
+        }
+
+        return app(TrainingPlacePolicy::class)->canViewDepartment($user, $department);
     }
 
     public static function getPages(): array

--- a/app/Livewire/Training/AvailabilityLogReview.php
+++ b/app/Livewire/Training/AvailabilityLogReview.php
@@ -32,7 +32,7 @@ class AvailabilityLogReview extends Component implements HasActions, HasForms, H
 
     public function mount(): void
     {
-        if (! auth()->user()?->can('training-places.view.*')) {
+        if (! auth()->user()?->can('view', $this->trainingPlace)) {
             abort(403);
         }
 

--- a/app/Livewire/Training/AvailabilityLogTable.php
+++ b/app/Livewire/Training/AvailabilityLogTable.php
@@ -30,7 +30,7 @@ class AvailabilityLogTable extends Component implements HasActions, HasSchemas, 
 
     public function mount(): void
     {
-        if (! auth()->user()?->can('training-places.view.*')) {
+        if (! auth()->user()?->can('view', $this->trainingPlace)) {
             abort(403);
         }
     }

--- a/app/Policies/Training/Mentoring/MentoringPolicy.php
+++ b/app/Policies/Training/Mentoring/MentoringPolicy.php
@@ -8,6 +8,7 @@ use App\Models\Cts\Member;
 use App\Models\Cts\Session;
 use App\Models\Mship\Account;
 use App\Models\Training\Mentoring\MentoringScope;
+use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Services\Training\MentorPermissionService;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
@@ -94,7 +95,7 @@ class MentoringPolicy
      */
     public function viewStudentTrainingPlace(Account $user): bool
     {
-        return $user->can('training-places.view.*');
+        return $user->can('viewAny', TrainingPlace::class);
     }
 
     // Action permissions

--- a/app/Policies/TrainingPlacePolicy.php
+++ b/app/Policies/TrainingPlacePolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\Mship\Account;
 use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\WaitingList;
 
 class TrainingPlacePolicy
 {
@@ -12,7 +13,8 @@ class TrainingPlacePolicy
      */
     public function viewAny(Account $account): bool
     {
-        return $account->hasPermissionTo('training-places.view.*');
+        return $this->canViewDepartment($account, WaitingList::ATC_DEPARTMENT)
+            || $this->canViewDepartment($account, WaitingList::PILOT_DEPARTMENT);
     }
 
     /**
@@ -20,7 +22,7 @@ class TrainingPlacePolicy
      */
     public function view(Account $account, TrainingPlace $trainingPlace): bool
     {
-        return $account->hasPermissionTo('training-places.view.*');
+        return $this->canViewDepartment($account, $trainingPlace->department);
     }
 
     /**
@@ -77,5 +79,17 @@ class TrainingPlacePolicy
     public function forceDelete(Account $account, TrainingPlace $trainingPlace): bool
     {
         return false;
+    }
+
+    /**
+     * Wildcard (`training-places.view.*`) grants both departments; otherwise require the
+     * department-specific permission.
+     */
+    public function canViewDepartment(Account $account, string $department): bool
+    {
+        return $account->hasAnyPermission([
+            'training-places.view.*',
+            sprintf('training-places.view.%s', $department),
+        ]);
     }
 }

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -180,6 +180,8 @@ class RolesAndPermissionsSeeder extends Seeder
 
             // Training Places Permissions
             'training-places.view.*',
+            'training-places.view.atc',
+            'training-places.view.pilot',
             'training-places.manual-setup',
             'training-places.manual-setup.atc',
             'training-places.manual-setup.pilot',

--- a/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php
@@ -253,6 +253,102 @@ class ListTrainingPlacesTest extends BaseTrainingPanelTestCase
     }
 
     #[Test]
+    public function it_scopes_list_records_to_department_view_permission()
+    {
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $ctsPosition = CtsPosition::factory()->create(['callsign' => 'EGLL_APP']);
+        $trainingPosition = TrainingPosition::factory()
+            ->withCtsPositions([$ctsPosition->callsign])
+            ->create();
+
+        $waitingList = WaitingList::factory()->create();
+        $pilotStudent = Account::factory()->create();
+        $atcStudent = Account::factory()->create();
+        Member::factory()->create(['cid' => $pilotStudent->id]);
+        Member::factory()->create(['cid' => $atcStudent->id]);
+
+        $pilotWaitingListAccount = $waitingList->addToWaitingList($pilotStudent, $this->privacc);
+        $atcWaitingListAccount = $waitingList->addToWaitingList($atcStudent, $this->privacc);
+
+        $qualificationPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::create([
+            'waiting_list_account_id' => $pilotWaitingListAccount->id,
+            'account_id' => $pilotStudent->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+        ]));
+
+        $positionPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::create([
+            'waiting_list_account_id' => $atcWaitingListAccount->id,
+            'account_id' => $atcStudent->id,
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
+        ]));
+
+        $atcUser = Account::factory()->create();
+        $atcUser->givePermissionTo('training.access');
+        $atcUser->givePermissionTo('training-places.view.atc');
+
+        Livewire::actingAs($atcUser)
+            ->test(ListTrainingPlaces::class)
+            ->assertCanSeeTableRecords([$positionPlace])
+            ->assertCanNotSeeTableRecords([$qualificationPlace]);
+
+        $pilotUser = Account::factory()->create();
+        $pilotUser->givePermissionTo('training.access');
+        $pilotUser->givePermissionTo('training-places.view.pilot');
+
+        Livewire::actingAs($pilotUser)
+            ->test(ListTrainingPlaces::class)
+            ->assertCanSeeTableRecords([$qualificationPlace])
+            ->assertCanNotSeeTableRecords([$positionPlace]);
+    }
+
+    #[Test]
+    public function it_shows_all_departments_when_user_has_wildcard_view_permission()
+    {
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $ctsPosition = CtsPosition::factory()->create(['callsign' => 'EGLL_APP']);
+        $trainingPosition = TrainingPosition::factory()
+            ->withCtsPositions([$ctsPosition->callsign])
+            ->create();
+
+        $waitingList = WaitingList::factory()->create();
+        $pilotStudent = Account::factory()->create();
+        $atcStudent = Account::factory()->create();
+        Member::factory()->create(['cid' => $pilotStudent->id]);
+        Member::factory()->create(['cid' => $atcStudent->id]);
+
+        $pilotWaitingListAccount = $waitingList->addToWaitingList($pilotStudent, $this->privacc);
+        $atcWaitingListAccount = $waitingList->addToWaitingList($atcStudent, $this->privacc);
+
+        $qualificationPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::create([
+            'waiting_list_account_id' => $pilotWaitingListAccount->id,
+            'account_id' => $pilotStudent->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+        ]));
+
+        $positionPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::create([
+            'waiting_list_account_id' => $atcWaitingListAccount->id,
+            'account_id' => $atcStudent->id,
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $trainingPosition->id,
+        ]));
+
+        $user = Account::factory()->create();
+        $user->givePermissionTo('training.access');
+        $user->givePermissionTo('training-places.view.*');
+
+        Livewire::actingAs($user)
+            ->test(ListTrainingPlaces::class)
+            ->assertCanSeeTableRecords([$qualificationPlace, $positionPlace]);
+    }
+
+    #[Test]
     public function it_cannot_render_training_places_list_page_without_permission()
     {
         // Arrange

--- a/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
@@ -9,6 +9,7 @@ use App\Models\Cts\ExamBooking;
 use App\Models\Cts\Member;
 use App\Models\Cts\Session;
 use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
 use App\Models\Mship\State;
 use App\Models\Training\TrainingPlace\TrainingPlace;
 use App\Models\Training\TrainingPosition\TrainingPosition;
@@ -82,6 +83,36 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
         Livewire::actingAs($userWithPermission)
             ->test(ViewTrainingPlace::class, ['trainingPlaceId' => $trainingPlace->id])
             ->assertStatus(200);
+    }
+
+    public function test_page_cannot_be_accessed_with_mismatched_department_permission()
+    {
+        $atcPlace = $this->createTrainingPlace();
+
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $pilotPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forQualification($qualification)
+            ->create());
+
+        $atcUser = Account::factory()->create();
+        Member::factory()->forAccount($atcUser)->create();
+        $atcUser->givePermissionTo('training.access');
+        $atcUser->givePermissionTo('training-places.view.atc');
+
+        Livewire::actingAs($atcUser)
+            ->test(ViewTrainingPlace::class, ['trainingPlaceId' => $pilotPlace->id])
+            ->assertForbidden();
+
+        $pilotUser = Account::factory()->create();
+        Member::factory()->forAccount($pilotUser)->create();
+        $pilotUser->givePermissionTo('training.access');
+        $pilotUser->givePermissionTo('training-places.view.pilot');
+
+        Livewire::actingAs($pilotUser)
+            ->test(ViewTrainingPlace::class, ['trainingPlaceId' => $atcPlace->id])
+            ->assertForbidden();
     }
 
     public function test_infolist_displays_training_place_details()

--- a/tests/Unit/Policies/TrainingPlacePolicyTest.php
+++ b/tests/Unit/Policies/TrainingPlacePolicyTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Unit\Policies;
 
 use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
 use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
 use App\Policies\TrainingPlacePolicy;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -21,6 +23,106 @@ class TrainingPlacePolicyTest extends TestCase
         parent::setUp();
 
         $this->policy = app(TrainingPlacePolicy::class);
+    }
+
+    #[Test]
+    public function view_any_allows_when_user_has_atc_or_pilot_view_permission(): void
+    {
+        $atcOnly = Account::factory()->create();
+        $atcOnly->givePermissionTo('training-places.view.atc');
+
+        $pilotOnly = Account::factory()->create();
+        $pilotOnly->givePermissionTo('training-places.view.pilot');
+
+        $neither = Account::factory()->create();
+
+        $this->assertTrue($this->policy->viewAny($atcOnly));
+        $this->assertTrue($this->policy->viewAny($pilotOnly));
+        $this->assertFalse($this->policy->viewAny($neither));
+    }
+
+    #[Test]
+    public function view_any_allows_wildcard_view_permission(): void
+    {
+        $account = Account::factory()->create();
+        $account->givePermissionTo('training-places.view.*');
+
+        $this->assertTrue($this->policy->viewAny($account));
+    }
+
+    #[Test]
+    public function view_respects_department_permissions(): void
+    {
+        $atcPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forTrainingPosition(TrainingPosition::factory()->create())
+            ->create());
+
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $pilotPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forQualification($qualification)
+            ->create());
+
+        $atcOnly = Account::factory()->create();
+        $atcOnly->givePermissionTo('training-places.view.atc');
+
+        $pilotOnly = Account::factory()->create();
+        $pilotOnly->givePermissionTo('training-places.view.pilot');
+
+        $this->assertTrue($this->policy->view($atcOnly, $atcPlace));
+        $this->assertFalse($this->policy->view($atcOnly, $pilotPlace));
+
+        $this->assertTrue($this->policy->view($pilotOnly, $pilotPlace));
+        $this->assertFalse($this->policy->view($pilotOnly, $atcPlace));
+    }
+
+    #[Test]
+    public function view_allows_wildcard_for_either_department(): void
+    {
+        $atcPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forTrainingPosition(TrainingPosition::factory()->create())
+            ->create());
+
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $pilotPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forQualification($qualification)
+            ->create());
+
+        $account = Account::factory()->create();
+        $account->givePermissionTo('training-places.view.*');
+
+        $this->assertTrue($this->policy->view($account, $atcPlace));
+        $this->assertTrue($this->policy->view($account, $pilotPlace));
+        $this->assertTrue($this->policy->canViewDepartment($account, WaitingList::ATC_DEPARTMENT));
+        $this->assertTrue($this->policy->canViewDepartment($account, WaitingList::PILOT_DEPARTMENT));
+    }
+
+    #[Test]
+    public function view_allows_both_department_permissions_together(): void
+    {
+        $atcPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forTrainingPosition(TrainingPosition::factory()->create())
+            ->create());
+
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $pilotPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forQualification($qualification)
+            ->create());
+
+        $account = Account::factory()->create();
+        $account->givePermissionTo([
+            'training-places.view.atc',
+            'training-places.view.pilot',
+        ]);
+
+        $this->assertTrue($this->policy->viewAny($account));
+        $this->assertTrue($this->policy->view($account, $atcPlace));
+        $this->assertTrue($this->policy->view($account, $pilotPlace));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Seed `training-places.view.atc` and `training-places.view.pilot`, while keeping `training-places.view.*` as a wildcard that grants both.
- Scope the training places list/query and view page (plus related availability log components) so users only see places for departments they can view.
- Cover department-only, both-department, and wildcard cases in policy and feature tests.

## Test plan
- [ ] Re-seed / sync permissions so `training-places.view.atc` and `.pilot` exist
- [ ] Confirm a user with only `training-places.view.atc` can open ATC places and is forbidden from pilot places
- [ ] Confirm a user with only `training-places.view.pilot` sees only qualification places on the list
- [ ] Confirm `training-places.view.*` still shows and opens both ATC and pilot places
- [ ] `php artisan test tests/Unit/Policies/TrainingPlacePolicyTest.php tests/Feature/TrainingPanel/TrainingPlace/ListTrainingPlacesTest.php --filter='view_|scopes_list|wildcard' tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php --filter=mismatched`


Made with [Cursor](https://cursor.com)