### PR TITLE
Use Position/Qualification labels in Training Places UI

### DIFF
--- a/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
+++ b/app/Filament/Training/Pages/TrainingPlace/ViewTrainingPlace.php
@@ -262,7 +262,7 @@ class ViewTrainingPlace extends BaseMentoringHistoryPage implements HasInfolists
                 TextEntry::make('account.name')->label('Name'),
                 TextEntry::make('account.id')->label('CID'),
                 TextEntry::make('display_name')
-                    ->label('Position')
+                    ->label(fn (): string => $this->trainingPlace->trainable_type_label)
                     ->state(fn (): string => $this->trainingPlace->trainingPosition?->position?->name ?? $this->trainingPlace->display_name),
                 TextEntry::make('created_at')->label('Training Start')->date('d/m/Y'),
                 TextEntry::make('waitingListAccount.created_at')

--- a/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/TrainingPlaceResource.php
@@ -199,7 +199,7 @@ class TrainingPlaceResource extends Resource
                     ),
 
                 TextColumn::make('display_name')
-                    ->label('Position')
+                    ->label(fn (): string => self::trainableColumnLabel(auth()->user()))
                     ->state(fn (TrainingPlace $record): string => $record->display_name)
                     ->searchable(query: fn (Builder $query, string $search): Builder => $query->where(function (Builder $query) use ($search) {
                         $query->whereHasMorph(
@@ -312,6 +312,18 @@ class TrainingPlaceResource extends Resource
         }
 
         return app(TrainingPlacePolicy::class)->canViewDepartment($user, $department);
+    }
+
+    private static function trainableColumnLabel(?Account $user): string
+    {
+        $canViewAtc = self::canViewDepartment($user, WaitingList::ATC_DEPARTMENT);
+        $canViewPilot = self::canViewDepartment($user, WaitingList::PILOT_DEPARTMENT);
+
+        return match (true) {
+            $canViewAtc && $canViewPilot => 'Position / Qualification',
+            $canViewPilot => 'Qualification',
+            default => 'Position',
+        };
     }
 
     public static function getPages(): array

--- a/app/Filament/Training/Resources/TrainingPlaces/Widgets/TrainingPlaceOffersOverview.php
+++ b/app/Filament/Training/Resources/TrainingPlaces/Widgets/TrainingPlaceOffersOverview.php
@@ -4,9 +4,11 @@ namespace App\Filament\Training\Resources\TrainingPlaces\Widgets;
 
 use App\Enums\TrainingPlaceOfferStatus;
 use App\Filament\Support\NameColumn;
+use App\Models\Mship\Account;
 use App\Models\Training\TrainingPlace\TrainingPlaceOffer;
 use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
+use App\Policies\TrainingPlacePolicy;
 use App\Services\Training\TrainingPlaceOfferService;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
@@ -55,7 +57,7 @@ class TrainingPlaceOffersOverview extends BaseWidget
                     ->searchable(),
 
                 TextColumn::make('display_name')
-                    ->label('Position')
+                    ->label(fn (): string => $this->trainableColumnLabel(auth()->user()))
                     ->state(fn (TrainingPlaceOffer $record): string => $record->display_name),
 
                 TextColumn::make('status')
@@ -187,5 +189,22 @@ class TrainingPlaceOffersOverview extends BaseWidget
             ->defaultPaginationPageOption(10)
             ->emptyStateHeading('No training place offers')
             ->emptyStateDescription('No offers match the current filter.');
+    }
+
+    private function trainableColumnLabel(?Account $user): string
+    {
+        if (! $user) {
+            return 'Position';
+        }
+
+        $policy = app(TrainingPlacePolicy::class);
+        $canViewAtc = $policy->canViewDepartment($user, WaitingList::ATC_DEPARTMENT);
+        $canViewPilot = $policy->canViewDepartment($user, WaitingList::PILOT_DEPARTMENT);
+
+        return match (true) {
+            $canViewAtc && $canViewPilot => 'Position / Qualification',
+            $canViewPilot => 'Qualification',
+            default => 'Position',
+        };
     }
 }

--- a/app/Filament/Training/Resources/WaitingLists/RelationManagers/AccountsRelationManager.php
+++ b/app/Filament/Training/Resources/WaitingLists/RelationManagers/AccountsRelationManager.php
@@ -264,7 +264,7 @@ class AccountsRelationManager extends RelationManager
                                         ->content($offer->status->label()),
 
                                     Placeholder::make('offer_position')
-                                        ->label('Position')
+                                        ->label($offer->trainable_type_label)
                                         ->content($offer->display_name),
 
                                     Placeholder::make('offer_expires_at')

--- a/app/Models/Training/TrainingPlace/TrainingPlace.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlace.php
@@ -101,6 +101,13 @@ class TrainingPlace extends Model
         );
     }
 
+    protected function trainableTypeLabel(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): string => $this->trainable instanceof Qualification ? 'Qualification' : 'Position',
+        );
+    }
+
     public function availabilityWarningDays(): int
     {
         return (int) config(

--- a/app/Models/Training/TrainingPlace/TrainingPlaceOffer.php
+++ b/app/Models/Training/TrainingPlace/TrainingPlaceOffer.php
@@ -89,6 +89,13 @@ class TrainingPlaceOffer extends Model
         );
     }
 
+    protected function trainableTypeLabel(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): string => $this->trainable instanceof Qualification ? 'Qualification' : 'Position',
+        );
+    }
+
     public function trainingTeamDiscordChannelId(): string
     {
         if ($this->department === WaitingList::PILOT_DEPARTMENT) {

--- a/resources/views/training/training-place-offer/result.blade.php
+++ b/resources/views/training/training-place-offer/result.blade.php
@@ -8,12 +8,12 @@
 			@if ($result === 'accepted')
 				<div class="alert alert-success">
 					<strong>Training place accepted!</strong> You have accepted your training place on
-					{{ $offer->trainingPosition->position->name }} ({{ $offer->trainingPosition->position->callsign }}).
+					{{ $offer->display_name }}.
 				</div>
 			@elseif($result === 'declined')
 				<div class="alert alert-danger">
 					<strong>Training place declined.</strong> You have declined your training place offer for
-					{{ $offer->trainingPosition->position->name }} ({{ $offer->trainingPosition->position->callsign }}) and
+					{{ $offer->display_name }} and
 					therefore have been removed from the waiting list.
 				</div>
 			@endif

--- a/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
+++ b/tests/Feature/TrainingPanel/TrainingPlace/ViewTrainingPlaceTest.php
@@ -123,7 +123,23 @@ class ViewTrainingPlaceTest extends BaseTrainingPanelTestCase
             ->assertStatus(200)
             ->assertSee($trainingPlace->account->name)
             ->assertSee($trainingPlace->account->id)
+            ->assertSee('Position')
             ->assertSee($trainingPlace->trainingPosition->position->name);
+    }
+
+    public function test_infolist_displays_qualification_label_for_pilot_training_places()
+    {
+        $qualification = Qualification::firstWhere('code', 'PPL')
+            ?? Qualification::factory()->create(['code' => 'PPL', 'type' => 'pilot']);
+
+        $trainingPlace = TrainingPlace::withoutEvents(fn () => TrainingPlace::factory()
+            ->forQualification($qualification)
+            ->create());
+
+        Livewire::test(ViewTrainingPlace::class, ['trainingPlaceId' => $trainingPlace->id])
+            ->assertStatus(200)
+            ->assertSee('Qualification')
+            ->assertSee($trainingPlace->display_name);
     }
 
     public function test_infolist_displays_dates_correctly()

--- a/tests/Unit/Training/TrainingPlace/QualificationTrainingPlaceTest.php
+++ b/tests/Unit/Training/TrainingPlace/QualificationTrainingPlaceTest.php
@@ -46,6 +46,7 @@ class QualificationTrainingPlaceTest extends TestCase
         $this->assertInstanceOf(Qualification::class, $trainingPlace->trainable);
         $this->assertNull($trainingPlace->trainingPosition);
         $this->assertTrue($trainingPlace->qualification->is($qualification));
+        $this->assertSame('Qualification', $trainingPlace->trainable_type_label);
         $this->assertDatabaseHas('training_places', [
             'id' => $trainingPlace->id,
             'trainable_type' => Qualification::class,


### PR DESCRIPTION
## Summary
- Replace hardcoded `Position` labels in Training Places Filament UI with `Position` or `Qualification` based on trainable type (and department view permissions on mixed list columns).
- Add a shared `trainable_type_label` accessor on training places and offers.
- Fix the offer accept/decline result page to use `display_name` so qualification-backed offers render correctly.

## Test plan
- [ ] View an ATC training place — details label shows **Position**
- [ ] View a pilot/qualification training place — details label shows **Qualification**
- [ ] As a user with both ATC + pilot place view permissions — list/offers column shows **Position / Qualification**
- [ ] As ATC-only / pilot-only — list column label matches the department
- [ ] Open a pending offer on a pilot waiting list — offer details label shows **Qualification**
- [ ] Accept/decline a qualification-backed offer — result page shows the qualification name without error


Made with [Cursor](https://cursor.com)