### PR TITLE
Scroll bookings calendar to current time on load

### DIFF
--- a/resources/assets/js/bookings-calendar.js
+++ b/resources/assets/js/bookings-calendar.js
@@ -41,11 +41,43 @@ document.addEventListener('alpine:init', () => {
                 this.scrolledBy = this.$el.scrollLeft;
             };
             this.$el.addEventListener('scroll', this._boundScroll, { passive: true });
+            // Wait for Alpine to drop x-cloak (display:none → 0-width track) before
+            // measuring. Narrow viewports otherwise stay pinned at midnight.
+            this.$nextTick(() => this.scrollToNow());
         },
 
         destroy() {
             clearInterval(this._nowTimer);
             this.$el.removeEventListener('scroll', this._boundScroll);
+        },
+
+        // Centre today's "now" marker in the horizontal viewport. Desktop often
+        // shows it already; mobile's ~375px window only covers the early hours
+        // from scrollLeft 0, so without this the red line is off-screen.
+        scrollToNow(attempt = 0) {
+            if (!this.isToday || attempt > 10) return;
+
+            const track = this.$refs.headerTrack;
+            const scrollEl = this.$el;
+            if (!track || !track.offsetWidth || !scrollEl.clientWidth) {
+                requestAnimationFrame(() => this.scrollToNow(attempt + 1));
+                return;
+            }
+
+            const nowInTrack = (this.nowPct / 100) * track.offsetWidth;
+            const nowInContent =
+                track.getBoundingClientRect().left -
+                scrollEl.getBoundingClientRect().left +
+                scrollEl.scrollLeft +
+                nowInTrack;
+            const maxScroll = Math.max(0, scrollEl.scrollWidth - scrollEl.clientWidth);
+            const target = Math.max(
+                0,
+                Math.min(maxScroll, Math.round(nowInContent - scrollEl.clientWidth / 2)),
+            );
+
+            scrollEl.scrollLeft = target;
+            this.scrolledBy = target;
         },
 
         // The current time ball is drawn in the hour header so the header cannot


### PR DESCRIPTION
## Summary
- On today's view, auto-scroll the bookings timeline so the current-time marker is centred in the viewport
- Fixes mobile (and other narrow viewports) where the day starts at midnight and "now" was off-screen

## Test plan
- [ ] Open `/atc/bookings/calendar` for today on a phone or narrow browser width — timeline should land on the red "now" line, not midnight
- [ ] Confirm desktop today view still shows "now" (centred or nearby)
- [ ] Navigate to a non-today date — no auto-scroll to a bogus position
- [ ] Use the Today control / day arrows to return to today — auto-scroll runs again
- [ ] Rebuild assets (`npm run build` / `npm run dev`) before checking locally


Made with [Cursor](https://cursor.com)