### PR TITLE
feat: backfill ATC qualifications on feedback records + make submitter searchable

### DIFF
--- a/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
+++ b/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
@@ -15,6 +15,7 @@ use Filament\Actions\BulkActionGroup;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
@@ -23,6 +24,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
@@ -142,7 +144,10 @@ class FeedbackResource extends Resource
                 TextColumn::make('form.name')->label('Feedback Type')
                     ->sortable(),
                 NameColumn::make('account.name')->label('Subject'),
-                TextColumn::make('submitter.name')->label('Submitted By')->visible(self::canSeeSubmitter()),
+                TextColumn::make('submitter.name')
+                    ->label('Submitted By')
+                    ->visible(self::canSeeSubmitter())
+                    ->searchable(self::canSeeSubmitter() ? ['name_first', 'name_last'] : false),
                 TextColumn::make('created_at')
                     ->dateTime('d/m/Y H:i')
                     ->sortable(),
@@ -182,6 +187,21 @@ class FeedbackResource extends Resource
                     ->options(
                         Qualification::whereType('atc')->get()->mapWithKeys(fn ($qualification) => [$qualification->id => $qualification->name])
                     ),
+
+                Filter::make('position')
+                    ->label('Controller Position')
+                    ->schema([
+                        TextInput::make('position')
+                            ->label('Position')
+                            ->placeholder('Starts with, e.g. EGKK'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query->when(
+                        filled($data['position'] ?? null),
+                        fn (Builder $query) => $query->wherePositionLike(strtoupper((string) $data['position']))
+                    ))
+                    ->indicateUsing(fn (array $state): array => filled($state['position'] ?? null)
+                        ? ['Position: '.strtoupper((string) $state['position'])]
+                        : []),
             ])
             ->recordActions([
                 ViewAction::make(),

--- a/app/Models/Mship/Feedback/Feedback.php
+++ b/app/Models/Mship/Feedback/Feedback.php
@@ -102,6 +102,13 @@ class Feedback extends Model
         return $query->whereNotNull('sent_at');
     }
 
+    public function scopeWherePositionLike($query, string $term)
+    {
+        return $query->whereHas('position', function ($query) use ($term) {
+            $query->where('response', 'like', "{$term}%");
+        });
+    }
+
     public function form()
     {
         return $this->belongsTo(Form::class);

--- a/database/migrations/2026_08_09_000002_backfill_feedback_atc_ratings.php
+++ b/database/migrations/2026_08_09_000002_backfill_feedback_atc_ratings.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    private const REJECT_REASON = 'Rejected automatically: the controller was not rated as a controller at the time of this submission and therefore cannot be the correct recipient.';
+
+    public function up(): void
+    {
+        $atcFormId = DB::table('mship_feedback_forms')->where('slug', 'atc')->value('id');
+
+        if (! $atcFormId) {
+            Log::info('No ATC Feedback form found, data backfill could not be conducted');
+
+            return;
+        }
+
+        [$updated, $rejected] = DB::transaction(function () use ($atcFormId) {
+            $updated = 0;
+            $rejected = 0;
+
+            $feedbackRecords = DB::table('mship_feedback')
+                ->where('form_id', $atcFormId)
+                ->whereNull('account_atc_qualification_id')
+                ->whereNull('deleted_at')
+                ->get(['id', 'account_id', 'created_at']);
+
+            foreach ($feedbackRecords as $feedback) {
+                $qualificationId = $this->atcQualificationIdAt($feedback->account_id, $feedback->created_at);
+
+                if ($qualificationId) {
+                    DB::table('mship_feedback')
+                        ->where('id', $feedback->id)
+                        ->update(['account_atc_qualification_id' => $qualificationId]);
+                    $updated++;
+                } else {
+                    DB::table('mship_feedback')
+                        ->where('id', $feedback->id)
+                        ->update(['deleted_at' => now(), 'reject_reason' => self::REJECT_REASON]);
+                    $rejected++;
+                }
+            }
+
+            return [$updated, $rejected];
+        });
+
+        Log::info('Backfilled ATC feedback ratings', [
+            'updated' => $updated,
+            'rejected' => $rejected,
+        ]);
+    }
+
+    public function down(): void
+    {
+        // Data migration so non-reversable
+    }
+
+    private function atcQualificationIdAt(int $accountId, ?string $at): ?int
+    {
+        return DB::table('mship_account_qualification as aq')
+            ->join('mship_qualification as q', 'q.id', '=', 'aq.qualification_id')
+            ->where('aq.account_id', $accountId)
+            ->where('q.type', 'atc')
+            ->where('q.vatsim', '>', 1)
+            ->where(function ($query) use ($at) {
+                $query->whereNull('aq.created_at')
+                    ->orWhere('aq.created_at', '<=', $at);
+            })
+            ->orderByDesc('q.vatsim')
+            ->value('q.id');
+    }
+};

--- a/tests/Feature/Admin/Feedback/BackfillFeedbackAtcRatingsMigrationTest.php
+++ b/tests/Feature/Admin/Feedback/BackfillFeedbackAtcRatingsMigrationTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Tests\Feature\Admin\Feedback;
+
+use App\Models\Mship\Account;
+use App\Models\Mship\Feedback\Feedback;
+use App\Models\Mship\Feedback\Form;
+use App\Models\Mship\Qualification;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BackfillFeedbackAtcRatingsMigrationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private const REJECT_REASON = 'Rejected automatically: the controller was not rated as a controller at the time of this submission and therefore cannot be the correct recipient.';
+
+    private function runMigration(): void
+    {
+        $migration = require database_path('migrations/2026_08_09_000002_backfill_feedback_atc_ratings.php');
+        $migration->up();
+    }
+
+    private function atcForm(): ?Form
+    {
+        return Form::where('slug', 'atc')->first();
+    }
+
+    private function createQualification(int $vatsim, ?string $code = null): Qualification
+    {
+        return Qualification::factory()->create([
+            'type' => 'atc',
+            'vatsim' => $vatsim,
+            'code' => $code,
+        ]);
+    }
+
+    private function attachQualification(Account $account, Qualification $qualification, Carbon $awardedAt): void
+    {
+        $account->qualifications()->attach($qualification->id, [
+            'created_at' => $awardedAt,
+            'updated_at' => $awardedAt,
+        ]);
+    }
+
+    private function createFeedback(Form $form, Account $account, Carbon $createdAt): Feedback
+    {
+        $feedback = factory(Feedback::class)->create([
+            'form_id' => $form->id,
+            'account_id' => $account->id,
+        ]);
+
+        $feedback->timestamps = false;
+        $feedback->created_at = $createdAt;
+        $feedback->save();
+
+        return $feedback;
+    }
+
+    #[Test]
+    public function it_backfills_rating_from_qualification_history(): void
+    {
+        $form = $this->atcForm();
+        if (! $form) {
+            $this->markTestSkipped('ATC feedback form not seeded');
+        }
+
+        $qualification = $this->createQualification(3);
+        $account = Account::factory()->create();
+        $this->attachQualification($account, $qualification, now()->subYears(2));
+
+        $feedback = $this->createFeedback($form, $account, now()->subMonths(6));
+
+        $this->runMigration();
+
+        $this->assertDatabaseHas('mship_feedback', [
+            'id' => $feedback->id,
+            'account_atc_qualification_id' => $qualification->id,
+        ]);
+        $this->assertNull($feedback->fresh()->deleted_at);
+    }
+
+    #[Test]
+    public function it_picks_the_highest_qualification_held_at_the_time(): void
+    {
+        $form = $this->atcForm();
+        if (! $form) {
+            $this->markTestSkipped('ATC feedback form not seeded');
+        }
+
+        $second = $this->createQualification(3, 'Z2');
+        $third = $this->createQualification(4, 'Z3');
+        $account = Account::factory()->create();
+        $this->attachQualification($account, $second, now()->subYears(2));
+        $this->attachQualification($account, $third, now()->subYears(1));
+
+        $feedback = $this->createFeedback($form, $account, now()->subMonths(6));
+
+        $this->runMigration();
+
+        $this->assertDatabaseHas('mship_feedback', [
+            'id' => $feedback->id,
+            'account_atc_qualification_id' => $third->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_ignores_qualifications_awarded_after_the_feedback(): void
+    {
+        $form = $this->atcForm();
+        if (! $form) {
+            $this->markTestSkipped('ATC feedback form not seeded');
+        }
+
+        $second = $this->createQualification(3, 'Z2');
+        $third = $this->createQualification(4, 'Z3');
+        $account = Account::factory()->create();
+        $this->attachQualification($account, $second, now()->subYears(2));
+        $this->attachQualification($account, $third, now()->subMonths(3));
+
+        $feedback = $this->createFeedback($form, $account, now()->subMonths(6));
+
+        $this->runMigration();
+
+        $this->assertDatabaseHas('mship_feedback', [
+            'id' => $feedback->id,
+            'account_atc_qualification_id' => $second->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_ignores_the_pivot_deleted_at_when_qualifications_are_not_removed_on_upgrade(): void
+    {
+        $form = $this->atcForm();
+        if (! $form) {
+            $this->markTestSkipped('ATC feedback form not seeded');
+        }
+
+        $qualification = $this->createQualification(3);
+        $account = Account::factory()->create();
+        $this->attachQualification($account, $qualification, now()->subYears(2));
+        $account->qualifications()->updateExistingPivot($qualification->id, ['deleted_at' => now()]);
+
+        $feedback = $this->createFeedback($form, $account, now()->subMonths(6));
+
+        $this->runMigration();
+
+        $feedback = $feedback->fresh();
+
+        $this->assertSame($qualification->id, $feedback->account_atc_qualification_id);
+        $this->assertNull($feedback->deleted_at);
+    }
+
+    #[Test]
+    public function it_rejects_feedback_where_the_recipient_was_not_rated_at_the_time(): void
+    {
+        $form = $this->atcForm();
+        if (! $form) {
+            $this->markTestSkipped('ATC feedback form not seeded');
+        }
+
+        $observer = $this->createQualification(1);
+        $account = Account::factory()->create();
+        $this->attachQualification($account, $observer, now()->subYears(2));
+
+        $feedback = $this->createFeedback($form, $account, now()->subMonths(6));
+
+        $this->runMigration();
+
+        $feedback = $feedback->fresh();
+
+        $this->assertNotNull($feedback->deleted_at);
+        $this->assertNull($feedback->account_atc_qualification_id);
+        $this->assertSame(self::REJECT_REASON, $feedback->reject_reason);
+    }
+
+    #[Test]
+    public function it_skips_feedback_that_already_has_a_rating(): void
+    {
+        $form = $this->atcForm();
+        if (! $form) {
+            $this->markTestSkipped('ATC feedback form not seeded');
+        }
+
+        $qualification = $this->createQualification(3);
+        $account = Account::factory()->create();
+        $this->attachQualification($account, $qualification, now()->subYears(2));
+
+        $feedback = factory(Feedback::class)->create([
+            'form_id' => $form->id,
+            'account_id' => $account->id,
+            'account_atc_qualification_id' => $qualification->id,
+        ]);
+
+        $this->runMigration();
+
+        $feedback = $feedback->fresh();
+
+        $this->assertSame($qualification->id, $feedback->account_atc_qualification_id);
+        $this->assertNull($feedback->deleted_at);
+    }
+
+    #[Test]
+    public function it_skips_feedback_that_was_already_rejected(): void
+    {
+        $form = $this->atcForm();
+        if (! $form) {
+            $this->markTestSkipped('ATC feedback form not seeded');
+        }
+
+        $qualification = $this->createQualification(3);
+        $account = Account::factory()->create();
+        $this->attachQualification($account, $qualification, now()->subYears(2));
+
+        $feedback = $this->createFeedback($form, $account, now()->subMonths(6));
+        $feedback->markRejected(null, 'Manual rejection');
+
+        $this->runMigration();
+
+        $feedback = $feedback->fresh();
+
+        $this->assertNotNull($feedback->deleted_at);
+        $this->assertSame('Manual rejection', $feedback->reject_reason);
+    }
+}

--- a/tests/Feature/Admin/Feedback/Pages/ListFeedbackPageTest.php
+++ b/tests/Feature/Admin/Feedback/Pages/ListFeedbackPageTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Feature\Admin\Feedback\Pages;
 
 use App\Filament\Admin\Resources\Feedback\Pages\ListFeedback;
+use App\Models\Mship\Account;
+use App\Models\Mship\Feedback\Answer;
 use App\Models\Mship\Feedback\Feedback;
 use App\Models\Mship\Feedback\Form;
+use App\Models\Mship\Feedback\Question;
 use Filament\Actions\Testing\TestAction;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Livewire\Livewire;
@@ -135,5 +138,78 @@ class ListFeedbackPageTest extends BaseAdminTestCase
         // Second feedback was not selected
         $this->assertNull($feedback2->fresh()->sent_at);
         $this->assertNull($feedback2->fresh()->actioned_at);
+    }
+
+    public function test_search_by_submitter_name_with_permission()
+    {
+        $form = factory(Form::class)->create(['slug' => 'atc']);
+        $submitter = Account::factory()->create(['name_first' => 'Searchable', 'name_last' => 'Submitter']);
+        $feedback = factory(Feedback::class)->create(['form_id' => $form->id, 'submitter_account_id' => $submitter->id]);
+
+        $this->adminUser->givePermissionTo('feedback.access');
+        $this->adminUser->givePermissionTo("feedback.view-type.{$form->slug}");
+        $this->adminUser->givePermissionTo('feedback.view-submitter');
+
+        Livewire::actingAs($this->adminUser);
+        Livewire::test(ListFeedback::class)
+            ->searchTable('Submitter')
+            ->assertCanSeeTableRecords([$feedback]);
+    }
+
+    public function test_search_by_submitter_name_does_not_leak_without_permission()
+    {
+        $form = factory(Form::class)->create(['slug' => 'atc']);
+        $submitter = Account::factory()->create(['name_first' => 'Hidden', 'name_last' => 'Submitter']);
+        $feedback = factory(Feedback::class)->create(['form_id' => $form->id, 'submitter_account_id' => $submitter->id]);
+
+        $this->adminUser->givePermissionTo('feedback.access');
+        $this->adminUser->givePermissionTo("feedback.view-type.{$form->slug}");
+
+        Livewire::actingAs($this->adminUser);
+        Livewire::test(ListFeedback::class)
+            ->searchTable('Submitter')
+            ->assertCanNotSeeTableRecords([$feedback]);
+    }
+
+    public function test_position_filter_matches_starts_with()
+    {
+        $form = factory(Form::class)->create(['slug' => 'atc']);
+        $positionQuestion = factory(Question::class)->create(['slug' => 'callsign3']);
+
+        $egkkFeedback = factory(Feedback::class)->create(['form_id' => $form->id]);
+        factory(Answer::class)->create(['feedback_id' => $egkkFeedback->id, 'question_id' => $positionQuestion->id, 'response' => 'EGKK_APP']);
+
+        $egpdFeedback = factory(Feedback::class)->create(['form_id' => $form->id]);
+        factory(Answer::class)->create(['feedback_id' => $egpdFeedback->id, 'question_id' => $positionQuestion->id, 'response' => 'EGPD_TWR']);
+
+        $this->adminUser->givePermissionTo('feedback.access');
+        $this->adminUser->givePermissionTo("feedback.view-type.{$form->slug}");
+
+        Livewire::actingAs($this->adminUser);
+        Livewire::test(ListFeedback::class)
+            ->filterTable('position', ['position' => 'EGKK'])
+            ->assertCanSeeTableRecords([$egkkFeedback])
+            ->assertCanNotSeeTableRecords([$egpdFeedback]);
+    }
+
+    public function test_position_filter_matches_exact_position()
+    {
+        $form = factory(Form::class)->create(['slug' => 'atc']);
+        $positionQuestion = factory(Question::class)->create(['slug' => 'callsign3']);
+
+        $target = factory(Feedback::class)->create(['form_id' => $form->id]);
+        factory(Answer::class)->create(['feedback_id' => $target->id, 'question_id' => $positionQuestion->id, 'response' => 'EGLL_TWR']);
+
+        $other = factory(Feedback::class)->create(['form_id' => $form->id]);
+        factory(Answer::class)->create(['feedback_id' => $other->id, 'question_id' => $positionQuestion->id, 'response' => 'EGPH_TWR']);
+
+        $this->adminUser->givePermissionTo('feedback.access');
+        $this->adminUser->givePermissionTo("feedback.view-type.{$form->slug}");
+
+        Livewire::actingAs($this->adminUser);
+        Livewire::test(ListFeedback::class)
+            ->filterTable('position', ['position' => 'EGLL'])
+            ->assertCanSeeTableRecords([$target])
+            ->assertCanNotSeeTableRecords([$other]);
     }
 }


### PR DESCRIPTION
# Summary of changes
- Backfills the ATC qualification on the recipient of feedback at the time of the feedback being submitted
- Allows you to filter by position
- Makes the feedback submitters name searchable

<img width="363" height="490" alt="image" src="https://github.com/user-attachments/assets/0140676c-3d2a-4b6f-9e45-4f0c52f5fccc" />
