### PR TITLE
fix: add copy button back on the side of feedback text

### DIFF
--- a/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
+++ b/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
@@ -28,6 +28,7 @@ use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Webbingbrasil\FilamentCopyActions\Actions\CopyAction;
 
 class FeedbackResource extends Resource
 {
@@ -128,7 +129,9 @@ class FeedbackResource extends Resource
 
                                 TextEntry::make('response')
                                     ->label('Answer')
-                                    ->extraAttributes(['style' => 'white-space: pre-line;'])
+                                    ->suffixAction(CopyAction::make()
+                                        ->copyable(fn ($record) => $record->response)
+                                        ->successNotificationMessage('Copied!'))
                                     ->state(fn ($record) => $record->response),
                             ]),
                     ]),

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,6 @@
     }
   ],
   "require": {
-    "php": "^8.4",
     "barryvdh/laravel-debugbar": "^4.2",
     "barryvdh/laravel-ide-helper": "^3.0",
     "bugsnag/bugsnag-laravel": "^2.0",
@@ -105,6 +104,7 @@
     "malahierba-lab/public-id": "dev-main",
     "ohdearapp/ohdear-php-sdk": "^4.4",
     "opcodesio/log-viewer": "^3.24",
+    "php": "^8.4",
     "planetteamspeak/ts3-php-framework": "~1.3.0",
     "predis/predis": "^3.4",
     "pusher/pusher-php-server": "~7.2",

--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
     }
   ],
   "require": {
+    "php": "^8.4",
     "barryvdh/laravel-debugbar": "^4.2",
     "barryvdh/laravel-ide-helper": "^3.0",
     "bugsnag/bugsnag-laravel": "^2.0",
@@ -104,7 +105,6 @@
     "malahierba-lab/public-id": "dev-main",
     "ohdearapp/ohdear-php-sdk": "^4.4",
     "opcodesio/log-viewer": "^3.24",
-    "php": "^8.4",
     "planetteamspeak/ts3-php-framework": "~1.3.0",
     "predis/predis": "^3.4",
     "pusher/pusher-php-server": "~7.2",
@@ -119,6 +119,7 @@
     "symfony/translation": "^7.2",
     "team-reflex/discord-php": "^10.48",
     "watson/rememberable": "^7.0",
+    "webbingbrasil/filament-copyactions": "^4.0",
     "whitecube/laravel-cookie-consent": "^1.0.1",
     "wohali/oauth2-discord-new": "^1.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "544e4b6892ba52fb7c0b30e4377ec545",
+    "content-hash": "1328cf4f9cb04952f0c3c0ab8d27b823",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -15568,6 +15568,60 @@
             "time": "2026-05-31T15:00:08+00:00"
         },
         {
+            "name": "webbingbrasil/filament-copyactions",
+            "version": "4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webbingbrasil/filament-copyactions.git",
+                "reference": "40575d597780d17e2c8384820e7c7e2e45a28330"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webbingbrasil/filament-copyactions/zipball/40575d597780d17e2c8384820e7c7e2e45a28330",
+                "reference": "40575d597780d17e2c8384820e7c7e2e45a28330",
+                "shasum": ""
+            },
+            "require": {
+                "filament/filament": "^4.0|^5.0",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Webbingbrasil\\FilamentCopyActions\\FilamentCopyActionsProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webbingbrasil\\FilamentCopyActions\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Danilo Andrade",
+                    "email": "danilo@webbingbrasil.com.br",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A easy-to-use copy actions for Filament Admin.",
+            "homepage": "https://github.com/webbingbrasil/filament-copyactions",
+            "keywords": [
+                "filament",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/webbingbrasil/filament-copyactions/issues",
+                "source": "https://github.com/webbingbrasil/filament-copyactions/tree/4.0.3"
+            },
+            "time": "2026-03-31T15:23:38+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "2.4.1",
             "source": {
@@ -19691,5 +19745,5 @@
     "platform-dev": {
         "ext-json": "*"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
# Summary of changes
- Filaments `->copyable()` doesn't have a button anymore, so I've used another plugin

# Screenshots (if necessary)
<img width="795" height="257" alt="image" src="https://github.com/user-attachments/assets/10318d5e-8a18-45cb-b012-66512f02dc5e" />
