### PR TITLE
feat: automatically reject ATC VT applications that fail automated checks

### DIFF
--- a/app/Console/Commands/VisitTransfer/ApplicationsCleanup.php
+++ b/app/Console/Commands/VisitTransfer/ApplicationsCleanup.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands\VisitTransfer;
 
 use App\Console\Commands\Command;
+use App\Enums\VTCheckStatus;
 use App\Exceptions\VisitTransfer\Application\ApplicationCannotBeExpiredException;
 use App\Models\VisitTransfer\Application;
 
@@ -65,7 +66,14 @@ class ApplicationsCleanup extends Command
                 $application->setCheckOutcome('90_day', $application->check90DayQualification());
                 $application->setCheckOutcome('50_hours', $application->check50Hours());
 
-                $application->markAsUnderReview('Automated checks have completed.');
+                if ($application->check_outcome_90_day === VTCheckStatus::Failed || $application->check_outcome_50_hours === VTCheckStatus::Failed) {
+                    $application->reject(
+                        'Your application has been automatically rejected as one or more of the automated checks failed. Please contact the Community team via the helpdesk if you believe this is in error.',
+                        'Application automatically rejected after failing an automated check. 90-day: '.$application->check_outcome_90_day->label().', 50-hours: '.$application->check_outcome_50_hours->label().'.'
+                    );
+                } else {
+                    $application->markAsUnderReview('Automated checks have completed.');
+                }
             } else {
                 $application->markAsUnderReview('Automated checks have been disabled for this facility - requires manual checking.');
             }

--- a/app/Console/Commands/VisitTransfer/ApplicationsCleanup.php
+++ b/app/Console/Commands/VisitTransfer/ApplicationsCleanup.php
@@ -66,6 +66,7 @@ class ApplicationsCleanup extends Command
                 $application->setCheckOutcome('90_day', $application->check90DayQualification());
                 $application->setCheckOutcome('50_hours', $application->check50Hours());
 
+                // If automated checks fail, automatically reject the application
                 if ($application->check_outcome_90_day === VTCheckStatus::Failed || $application->check_outcome_50_hours === VTCheckStatus::Failed) {
                     $application->reject(
                         'Your application has been automatically rejected as one or more of the automated checks failed. Please contact the Community team via the helpdesk if you believe this is in error.',

--- a/app/Console/Commands/VisitTransfer/ApplicationsCleanup.php
+++ b/app/Console/Commands/VisitTransfer/ApplicationsCleanup.php
@@ -68,8 +68,18 @@ class ApplicationsCleanup extends Command
 
                 // If automated checks fail, automatically reject the application
                 if ($application->check_outcome_90_day === VTCheckStatus::Failed || $application->check_outcome_50_hours === VTCheckStatus::Failed) {
+                    $failedChecks = [];
+
+                    if ($application->check_outcome_90_day === VTCheckStatus::Failed) {
+                        $failedChecks[] = '90-day: You have not held your current rating for at least 90 days';
+                    }
+
+                    if ($application->check_outcome_50_hours === VTCheckStatus::Failed) {
+                        $failedChecks[] = '50-hours: You have not controlled a minimum of 50 hours at your current rating';
+                    }
+
                     $application->reject(
-                        'Your application has been automatically rejected as one or more of the automated checks failed. Please contact the Community team via the helpdesk if you believe this is in error.',
+                        'Your application has been automatically rejected as one or more of the automated checks failed ('.implode('. ', $failedChecks).'). Please note there may additionally be other conditions not met. You can find out more about the requirements for your application in VATSIM .NETs TV Policy. Please contact the Community team via the helpdesk if you believe this is in error.',
                         'Application automatically rejected after failing an automated check. 90-day: '.$application->check_outcome_90_day->label().', 50-hours: '.$application->check_outcome_50_hours->label().'.'
                     );
                 } else {

--- a/app/Exceptions/VisitTransfer/Application/ApplicationNotReopenableException.php
+++ b/app/Exceptions/VisitTransfer/Application/ApplicationNotReopenableException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Exceptions\VisitTransfer\Application;
+
+use App\Models\VisitTransfer\Application;
+
+class ApplicationNotReopenableException extends \Exception
+{
+    private $application;
+
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+
+        $this->message = 'This application is not rejected and as such cannot be reopened for review.';
+    }
+
+    public function __toString()
+    {
+        return $this->message;
+    }
+}

--- a/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ViewVisitTransferApplication.php
+++ b/app/Filament/Admin/Resources/VisitTransfer/VisitTransferApplications/Pages/ViewVisitTransferApplication.php
@@ -107,6 +107,19 @@ class ViewVisitTransferApplication extends ViewRecord
                         ->required(),
                 ])->authorize(fn ($record) => auth()->user()->can('reject', $record)),
 
+            Action::make('reopen_for_review')
+                ->label('Reopen for Manual Review')
+                ->color('warning')
+                ->modalHeading('Reopen Application')
+                ->modalDescription('This will return this rejected application to Under Review.')
+                ->requiresConfirmation()
+                ->action(fn ($record, array $data) => $record->reopenForReview(auth()->user(), $data['staff_note']))
+                ->schema([
+                    Textarea::make('staff_note')
+                        ->label('Staff Note')
+                        ->required(),
+                ])->authorize(fn ($record) => auth()->user()->can('reopenForReview', $record)),
+
             Action::make('complete')
                 ->label('Complete')
                 ->color('primary')

--- a/app/Models/VisitTransfer/Application.php
+++ b/app/Models/VisitTransfer/Application.php
@@ -16,6 +16,7 @@ use App\Exceptions\VisitTransfer\Application\ApplicationCannotBeExpiredException
 use App\Exceptions\VisitTransfer\Application\ApplicationCannotBeWithdrawnException;
 use App\Exceptions\VisitTransfer\Application\ApplicationNotAcceptedException;
 use App\Exceptions\VisitTransfer\Application\ApplicationNotRejectableException;
+use App\Exceptions\VisitTransfer\Application\ApplicationNotReopenableException;
 use App\Exceptions\VisitTransfer\Application\ApplicationNotUnderReviewException;
 use App\Exceptions\VisitTransfer\Application\AttemptingToTransferToNonTrainingFacilityException;
 use App\Exceptions\VisitTransfer\Application\CheckOutcomeAlreadySetException;
@@ -655,6 +656,13 @@ class Application extends Model
         event(new ApplicationUnderReview($this));
     }
 
+    public function reopenForReview(?Account $actor = null, ?string $staffReason = 'Application reopened for manual review.')
+    {
+        $this->guardAgainstNonReopenableApplication();
+
+        $this->markAsUnderReview($staffReason, $actor);
+    }
+
     public function reject($publicReason = 'No reason was provided.', $staffReason = null, ?Account $actor = null)
     {
         $this->guardAgainstNonRejectableApplication();
@@ -899,6 +907,15 @@ class Application extends Model
         }
 
         throw new ApplicationNotRejectableException($this);
+    }
+
+    private function guardAgainstNonReopenableApplication()
+    {
+        if ($this->is_rejected) {
+            return true;
+        }
+
+        throw new ApplicationNotReopenableException($this);
     }
 
     private function guardAgainstUnAcceptableApplication()

--- a/app/Policies/VisitTransfer/ApplicationPolicy.php
+++ b/app/Policies/VisitTransfer/ApplicationPolicy.php
@@ -43,6 +43,11 @@ class ApplicationPolicy
         return $user->can('vt.application.reject.*') && $application->can_reject;
     }
 
+    public function reopenForReview(Account $user, Application $application)
+    {
+        return $user->can('vt.application.accept.*') && $application->is_rejected;
+    }
+
     public function complete(Account $user, Application $application)
     {
         return $user->can('vt.application.complete.*') && $application->is_accepted;

--- a/tests/Feature/VisitTransfer/Application/ViewApplicationPageTest.php
+++ b/tests/Feature/VisitTransfer/Application/ViewApplicationPageTest.php
@@ -349,6 +349,64 @@ class ViewApplicationPageTest extends BaseAdminTestCase
     }
 
     #[Test]
+    public function it_shows_reopen_for_review_action_if_user_can_reopen()
+    {
+        $this->adminUser->givePermissionTo('vt.application.accept.*');
+
+        $this->application->status = Application::STATUS_REJECTED;
+        $this->application->save();
+
+        $component = Livewire::actingAs($this->adminUser)
+            ->test(ViewVisitTransferApplication::class, ['record' => $this->application->id])
+            ->assertSuccessful()
+            ->assertActionVisible('reopen_for_review');
+    }
+
+    #[Test]
+    public function it_hides_reopen_for_review_action_without_permission()
+    {
+        $this->application->status = Application::STATUS_REJECTED;
+        $this->application->save();
+
+        $component = Livewire::actingAs($this->adminUser)
+            ->test(ViewVisitTransferApplication::class, ['record' => $this->application->id])
+            ->assertSuccessful()
+            ->assertActionHidden('reopen_for_review');
+    }
+
+    #[Test]
+    public function it_hides_reopen_for_review_action_when_application_is_not_rejected()
+    {
+        $this->adminUser->givePermissionTo('vt.application.accept.*');
+
+        $this->application->status = Application::STATUS_SUBMITTED;
+        $this->application->save();
+
+        $component = Livewire::actingAs($this->adminUser)
+            ->test(ViewVisitTransferApplication::class, ['record' => $this->application->id])
+            ->assertSuccessful()
+            ->assertActionHidden('reopen_for_review');
+    }
+
+    #[Test]
+    public function it_can_reopen_a_rejected_application_for_manual_review()
+    {
+        $this->adminUser->givePermissionTo('vt.application.accept.*');
+
+        $this->application->status = Application::STATUS_REJECTED;
+        $this->application->save();
+
+        Livewire::actingAs($this->adminUser)
+            ->test(ViewVisitTransferApplication::class, ['record' => $this->application->id])
+            ->callAction('reopen_for_review', data: ['staff_note' => 'Reopened for manual review after contacting the member.'])
+            ->assertHasNoFormErrors();
+
+        $this->application->refresh();
+
+        $this->assertTrue($this->application->is_under_review);
+    }
+
+    #[Test]
     public function it_can_change_facility_with_permission()
     {
         $this->adminUser->givePermissionTo('vt.application.modify.*');

--- a/tests/Feature/VisitTransfer/ApplicationCleanUpTest.php
+++ b/tests/Feature/VisitTransfer/ApplicationCleanUpTest.php
@@ -70,4 +70,77 @@ class ApplicationCleanUpTest extends TestCase
         Artisan::call('visit-transfer:cleanup');
         $this->assertEquals(VTCheckStatus::Passed, $this->application->fresh()->check_outcome_90_day);
     }
+
+    #[Test]
+    public function test_it_will_auto_reject_application_when_50_hour_check_fails()
+    {
+        $user = Account::factory()->create();
+        $qualification = Qualification::code('S2')->first();
+        $user->addQualification($qualification)->save();
+        $user->qualifications()->updateExistingPivot($qualification->id, ['created_at' => new Carbon('100 days ago')]);
+        $user->save();
+
+        $facility = Facility::factory()->transfer('atc')->create();
+        $application = Application::factory()->transfer('atc')->create([
+            'account_id' => $user->id,
+            'status' => Application::STATUS_SUBMITTED,
+            'should_perform_checks' => 1,
+            'facility_id' => $facility->id,
+            'submitted_at' => now(),
+        ]);
+
+        Artisan::call('visit-transfer:cleanup');
+
+        $application = $application->fresh();
+        $this->assertTrue($application->is_rejected);
+        $this->assertEquals(VTCheckStatus::Passed, $application->check_outcome_90_day);
+        $this->assertEquals(VTCheckStatus::Failed, $application->check_outcome_50_hours);
+        $this->assertStringContainsString('automatically rejected', $application->status_note);
+        $this->assertStringContainsString('automatically rejected', $user->fresh()->notes->first()->content);
+    }
+
+    #[Test]
+    public function test_it_will_auto_reject_application_when_90_day_check_fails()
+    {
+        $user = Account::factory()->create();
+        $qualification = Qualification::code('S2')->first();
+        $user->addQualification($qualification)->save();
+
+        $start = new Carbon('80 hours ago');
+        $end = new Carbon('20 hours ago');
+        factory(Atc::class)->states('offline')->create([
+            'account_id' => $user->id,
+            'qualification_id' => $qualification->id,
+            'connected_at' => $start,
+            'disconnected_at' => $end,
+            'minutes_online' => $start->diffInMinutes($end),
+        ]);
+
+        $facility = Facility::factory()->transfer('atc')->create();
+        $application = Application::factory()->transfer('atc')->create([
+            'account_id' => $user->id,
+            'status' => Application::STATUS_SUBMITTED,
+            'should_perform_checks' => 1,
+            'facility_id' => $facility->id,
+            'submitted_at' => now(),
+        ]);
+
+        Artisan::call('visit-transfer:cleanup');
+
+        $application = $application->fresh();
+        $this->assertTrue($application->is_rejected);
+        $this->assertEquals(VTCheckStatus::Failed, $application->check_outcome_90_day);
+        $this->assertEquals(VTCheckStatus::Passed, $application->check_outcome_50_hours);
+    }
+
+    #[Test]
+    public function test_it_will_not_reject_application_when_all_checks_pass()
+    {
+        Artisan::call('visit-transfer:cleanup');
+
+        $application = $this->application->fresh();
+        $this->assertTrue($application->is_under_review);
+        $this->assertEquals(VTCheckStatus::Passed, $application->check_outcome_90_day);
+        $this->assertEquals(VTCheckStatus::Passed, $application->check_outcome_50_hours);
+    }
 }

--- a/tests/Unit/VisitTransfer/ApplicationPolicyTest.php
+++ b/tests/Unit/VisitTransfer/ApplicationPolicyTest.php
@@ -64,4 +64,46 @@ class ApplicationPolicyTest extends TestCase
 
         $this->assertTrue($policy->changeFacility($this->user, $application));
     }
+
+    public function test_reopen_for_review_is_allowed_for_rejected_application()
+    {
+        $application = Application::factory()->create([
+            'status' => Application::STATUS_REJECTED,
+        ]);
+
+        $policy = app(\App\Policies\VisitTransfer\ApplicationPolicy::class);
+
+        $this->assertTrue($policy->reopenForReview($this->user, $application));
+    }
+
+    public function test_reopen_for_review_is_not_allowed_for_non_rejected_application()
+    {
+        foreach ([
+            Application::STATUS_SUBMITTED,
+            Application::STATUS_UNDER_REVIEW,
+            Application::STATUS_ACCEPTED,
+            Application::STATUS_CANCELLED,
+            Application::STATUS_WITHDRAWN,
+        ] as $status) {
+            $application = Application::factory()->create([
+                'status' => $status,
+            ]);
+
+            $policy = app(\App\Policies\VisitTransfer\ApplicationPolicy::class);
+
+            $this->assertFalse($policy->reopenForReview($this->user, $application));
+        }
+    }
+
+    public function test_reopen_for_review_requires_accept_permission()
+    {
+        $user = Account::factory()->create();
+        $application = Application::factory()->create([
+            'status' => Application::STATUS_REJECTED,
+        ]);
+
+        $policy = app(\App\Policies\VisitTransfer\ApplicationPolicy::class);
+
+        $this->assertFalse($policy->reopenForReview($user, $application));
+    }
 }

--- a/tests/Unit/VisitTransfer/ApplicationTest.php
+++ b/tests/Unit/VisitTransfer/ApplicationTest.php
@@ -354,4 +354,31 @@ class ApplicationTest extends TestCase
         $this->assertTrue($this->user->fresh()->hasState($visiting));
 
     }
+
+    #[Test]
+    public function rejecting_an_application_records_the_reason_as_an_account_note()
+    {
+        $application = Application::factory()->transfer('atc')->create([
+            'account_id' => $this->user->id,
+            'status' => Application::STATUS_SUBMITTED,
+        ]);
+
+        $application->reject('Some public reason.', 'A staff note about the rejection.');
+
+        $this->assertTrue($application->fresh()->is_rejected);
+        $this->assertStringContainsString('A staff note about the rejection.', $this->user->fresh()->notes->first()->content);
+    }
+
+    #[Test]
+    public function it_can_reopen_a_rejected_application_for_manual_review()
+    {
+        $application = Application::factory()->transfer('atc')->create([
+            'account_id' => $this->user->id,
+            'status' => Application::STATUS_REJECTED,
+        ]);
+
+        $application->reopenForReview();
+
+        $this->assertTrue($application->fresh()->is_under_review);
+    }
 }


### PR DESCRIPTION
# Summary of changes
- If an automated check fails on a VT application, automatically reject the application
- Allow an admin to reopen a rejected application

# Screenshots (if necessary)
<img width="1277" height="189" alt="image" src="https://github.com/user-attachments/assets/c48a3410-9396-4a78-8a8c-fe67a294617b" />
<img width="578" height="409" alt="image" src="https://github.com/user-attachments/assets/cab60125-63b1-45a1-84c9-fb1bebb95a56" />
