### PR TITLE
Show old events in bookings calendar

### DIFF
--- a/app/Repositories/Cts/BookingRepository.php
+++ b/app/Repositories/Cts/BookingRepository.php
@@ -53,7 +53,6 @@ class BookingRepository
         // Events live in the CTS events table (not cts.bookings), so they must be
         // pulled in separately or they never appear on the calendar.
         $events = Event::whereDate('date', $date->toDateString())
-            ->where(fn ($q) => $q->where('gone', 0)->orWhereNull('gone'))
             ->orderBy('from')
             ->get();
 

--- a/tests/Feature/Bookings/CtsBookingsCalendarTest.php
+++ b/tests/Feature/Bookings/CtsBookingsCalendarTest.php
@@ -791,7 +791,7 @@ class CtsBookingsCalendarTest extends TestCase
     }
 
     #[Test]
-    public function it_excludes_events_marked_as_gone(): void
+    public function it_includes_events_marked_as_gone(): void
     {
         $date = Carbon::parse('2026-08-01');
 
@@ -804,6 +804,6 @@ class CtsBookingsCalendarTest extends TestCase
 
         $bookings = app(BookingRepository::class)->getBookings($date);
 
-        $this->assertEmpty($bookings->where('type', 'EV'), 'Gone events must not appear on the calendar');
+        $this->assertNotEmpty($bookings->where('type', 'EV'), 'Gone events must still appear on the calendar');
     }
 }


### PR DESCRIPTION
Stop filtering by `gone` for events