### PR TITLE
fix: center icons on waiting lists page

### DIFF
--- a/resources/views/mship/waiting-lists/_waiting_lists_list.blade.php
+++ b/resources/views/mship/waiting-lists/_waiting_lists_list.blade.php
@@ -38,9 +38,9 @@
 											($waitingListAccount->waitingList->feature_toggles['display_on_roster'] ?? true))
 										<td>
 											@if ($waitingListAccount->account->onRoster())
-												<img src="{{ asset('images/tick_mark_circle.png') }}" width="20" alt="Tick">
+												<img src="{{ asset('images/tick_mark_circle.png') }}" width="20" alt="Tick" style="display: block; margin: 0 auto;">
 											@else
-												<img src="{{ asset('images/cross_mark_circle.png') }}" width="20" alt="Cross">
+												<img src="{{ asset('images/cross_mark_circle.png') }}" width="20" alt="Cross" style="display: block; margin: 0 auto;">
 											@endif
 										</td>
 									@else
@@ -50,9 +50,9 @@
 									@endif
 									<td>
 										@if ($waitingListAccount->waitingList->should_check_cts_theory_exam && $waitingListAccount->theory_exam_passed)
-											<img src="{{ asset('images/tick_mark_circle.png') }}" width="20" alt="Tick">
+											<img src="{{ asset('images/tick_mark_circle.png') }}" width="20" alt="Tick" style="display: block; margin: 0 auto;">
 										@elseif($waitingListAccount->waitingList->should_check_cts_theory_exam)
-											<img src="{{ asset('images/cross_mark_circle.png') }}" width="20" alt="Cross">
+											<img src="{{ asset('images/cross_mark_circle.png') }}" width="20" alt="Cross" style="display: block; margin: 0 auto;">
 										@else
 											N/A
 										@endif

--- a/resources/views/mship/waiting-lists/_waiting_lists_list.blade.php
+++ b/resources/views/mship/waiting-lists/_waiting_lists_list.blade.php
@@ -38,9 +38,11 @@
 											($waitingListAccount->waitingList->feature_toggles['display_on_roster'] ?? true))
 										<td>
 											@if ($waitingListAccount->account->onRoster())
-												<img src="{{ asset('images/tick_mark_circle.png') }}" width="20" alt="Tick" style="display: block; margin: 0 auto;">
+												<img src="{{ asset('images/tick_mark_circle.png') }}" width="20" alt="Tick"
+													style="display: block; margin: 0 auto;">
 											@else
-												<img src="{{ asset('images/cross_mark_circle.png') }}" width="20" alt="Cross" style="display: block; margin: 0 auto;">
+												<img src="{{ asset('images/cross_mark_circle.png') }}" width="20" alt="Cross"
+													style="display: block; margin: 0 auto;">
 											@endif
 										</td>
 									@else
@@ -50,9 +52,11 @@
 									@endif
 									<td>
 										@if ($waitingListAccount->waitingList->should_check_cts_theory_exam && $waitingListAccount->theory_exam_passed)
-											<img src="{{ asset('images/tick_mark_circle.png') }}" width="20" alt="Tick" style="display: block; margin: 0 auto;">
+											<img src="{{ asset('images/tick_mark_circle.png') }}" width="20" alt="Tick"
+												style="display: block; margin: 0 auto;">
 										@elseif($waitingListAccount->waitingList->should_check_cts_theory_exam)
-											<img src="{{ asset('images/cross_mark_circle.png') }}" width="20" alt="Cross" style="display: block; margin: 0 auto;">
+											<img src="{{ asset('images/cross_mark_circle.png') }}" width="20" alt="Cross"
+												style="display: block; margin: 0 auto;">
 										@else
 											N/A
 										@endif


### PR DESCRIPTION
# Summary of changes
- Center the icon columns

# Screenshots (if necessary)
Before:
<img width="1564" height="380" alt="image" src="https://github.com/user-attachments/assets/3bdc39b0-5f7d-43d7-a08e-4214f499bd18" />

After:
<img width="1583" height="215" alt="image" src="https://github.com/user-attachments/assets/9a861f4b-6672-41fa-88ec-d29170daa232" />
