### PR TITLE
feat: allow self enrolment when holding an unrelated training place

### DIFF
--- a/app/Services/Training/WaitingListSelfEnrolment.php
+++ b/app/Services/Training/WaitingListSelfEnrolment.php
@@ -104,7 +104,7 @@ class WaitingListSelfEnrolment
 
         if ($trainables->isEmpty()) {
             // If there are no trainables then we should pass this check
-            return true;
+            return false;
         }
 
         $idsByType = $trainables

--- a/app/Services/Training/WaitingListSelfEnrolment.php
+++ b/app/Services/Training/WaitingListSelfEnrolment.php
@@ -30,7 +30,7 @@ class WaitingListSelfEnrolment
             return false;
         }
 
-        if (TrainingPlace::where('account_id', $account->id)->whereNull('deleted_at')->exists()) {
+        if (self::accountHasDisqualifyingTrainingPlace($account, $waitingList)) {
             return false;
         }
 
@@ -92,6 +92,36 @@ class WaitingListSelfEnrolment
         }
 
         return true;
+    }
+
+    /**
+     * An account is disqualified if it holds an active TrainingPlace on one of
+     * this waiting list's trainables (a TrainingPosition or Qualification attached to the list)
+     */
+    private static function accountHasDisqualifyingTrainingPlace(Account $account, WaitingList $waitingList): bool
+    {
+        $trainables = $waitingList->trainables;
+
+        if ($trainables->isEmpty()) {
+            // If there are no trainables then we should pass this check
+            return true;
+        }
+
+        $idsByType = $trainables
+            ->groupBy(fn ($trainable) => $trainable->getMorphClass())
+            ->map(fn (Collection $group) => $group->pluck('id'));
+
+        return TrainingPlace::where('account_id', $account->id)
+            ->whereNull('deleted_at')
+            ->where(function ($query) use ($idsByType) {
+                foreach ($idsByType as $morphType => $ids) {
+                    $query->orWhere(function ($q) use ($morphType, $ids) {
+                        $q->where('trainable_type', $morphType)
+                            ->whereIn('trainable_id', $ids);
+                    });
+                }
+            })
+            ->exists();
     }
 
     public static function getListsAccountCanSelfEnrol(Account $account): Collection

--- a/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentServiceTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentServiceTest.php
@@ -282,7 +282,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
         $this->assertTrue(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
     }
 
-    public function test_cannot_enrol_when_holding_active_training_place_and_list_has_no_trainables_attached()
+    public function test_can_enrol_when_holding_active_training_place_and_list_has_no_trainables_attached()
     {
         $account = Account::factory()->create();
         TrainingPlace::factory()->create([
@@ -295,7 +295,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
             'requires_roster_membership' => false,
         ]);
 
-        $this->assertFalse(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+        $this->assertTrue(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
     }
 
     public function test_cannot_enrol_when_holding_active_training_place_on_position_attached_to_list()

--- a/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentServiceTest.php
+++ b/tests/Unit/Training/WaitingList/WaitingListSelfEnrolmentServiceTest.php
@@ -9,6 +9,7 @@ use App\Models\Mship\State;
 use App\Models\NetworkData\Atc;
 use App\Models\Roster;
 use App\Models\Training\TrainingPlace\TrainingPlace;
+use App\Models\Training\TrainingPosition\TrainingPosition;
 use App\Models\Training\WaitingList;
 use App\Services\Training\WaitingListSelfEnrolment;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -281,7 +282,7 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
         $this->assertTrue(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
     }
 
-    public function test_cannot_enrol_when_holding_active_training_place()
+    public function test_cannot_enrol_when_holding_active_training_place_and_list_has_no_trainables_attached()
     {
         $account = Account::factory()->create();
         TrainingPlace::factory()->create([
@@ -295,6 +296,116 @@ class WaitingListSelfEnrolmentServiceTest extends TestCase
         ]);
 
         $this->assertFalse(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+    }
+
+    public function test_cannot_enrol_when_holding_active_training_place_on_position_attached_to_list()
+    {
+        $account = Account::factory()->create();
+        $position = TrainingPosition::factory()->create();
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+        $waitingList->trainingPositions()->attach($position->id);
+
+        TrainingPlace::factory()->create([
+            'account_id' => $account->id,
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $position->id,
+        ]);
+
+        $this->assertFalse(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+    }
+
+    public function test_can_enrol_when_holding_active_training_place_on_position_not_attached_to_list()
+    {
+        $account = Account::factory()->create();
+        $listPosition = TrainingPosition::factory()->create();
+        $otherPosition = TrainingPosition::factory()->create();
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+        $waitingList->trainingPositions()->attach($listPosition->id);
+
+        TrainingPlace::factory()->create([
+            'account_id' => $account->id,
+            'trainable_type' => TrainingPosition::class,
+            'trainable_id' => $otherPosition->id,
+        ]);
+
+        $this->assertTrue(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+    }
+
+    public function test_cannot_enrol_when_holding_active_training_place_on_qualification_attached_to_list()
+    {
+        $account = Account::factory()->create();
+        $qualification = Qualification::code('S1')->first();
+
+        $waitingList = WaitingList::factory()->create([
+            'department' => WaitingList::PILOT_DEPARTMENT,
+            'self_enrolment_enabled' => true,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+        $waitingList->qualifications()->attach($qualification->id);
+
+        TrainingPlace::factory()->create([
+            'account_id' => $account->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+        ]);
+
+        $this->assertFalse(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+    }
+
+    public function test_can_enrol_when_holding_active_training_place_on_qualification_not_attached_to_list()
+    {
+        $account = Account::factory()->create();
+        $listQualification = Qualification::code('S1')->first();
+        $otherQualification = Qualification::code('S2')->first();
+
+        $waitingList = WaitingList::factory()->create([
+            'department' => WaitingList::PILOT_DEPARTMENT,
+            'self_enrolment_enabled' => true,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+        $waitingList->qualifications()->attach($listQualification->id);
+
+        TrainingPlace::factory()->create([
+            'account_id' => $account->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $otherQualification->id,
+        ]);
+
+        $this->assertTrue(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
+    }
+
+    public function test_can_enrol_when_holding_active_training_place_on_qualification_but_list_only_has_positions_attached()
+    {
+        $account = Account::factory()->create();
+        $position = TrainingPosition::factory()->create();
+        $qualification = Qualification::code('S1')->first();
+
+        $waitingList = WaitingList::factory()->create([
+            'self_enrolment_enabled' => true,
+            'home_members_only' => false,
+            'requires_roster_membership' => false,
+        ]);
+        $waitingList->trainingPositions()->attach($position->id);
+
+        TrainingPlace::factory()->create([
+            'account_id' => $account->id,
+            'trainable_type' => Qualification::class,
+            'trainable_id' => $qualification->id,
+        ]);
+
+        $this->assertTrue(WaitingListSelfEnrolment::canAccountEnrolOnList($account, $waitingList));
     }
 
     public function test_cannot_enrol_when_required_endorsement_missing()


### PR DESCRIPTION
# Summary of changes
- Previously, if you held ANY TP you were unable to enrol on any waiting list (which meant holding a pilot TP led to you not being able to enrol on ATC lists)
- Now, you are only disqualified from enrolling on lists with Trainables that you are training on actively

# Screenshots (if necessary)
