### PR TITLE
Allow for resetting 2FA by user / admins

### DIFF
--- a/app/Filament/Admin/Resources/Accounts/AccountResource.php
+++ b/app/Filament/Admin/Resources/Accounts/AccountResource.php
@@ -115,6 +115,9 @@ class AccountResource extends Resource implements DefinesGatedAttributes
                         TextEntry::make('has_secondary_password')
                             ->label('Has Secondary Password')
                             ->getStateUsing(fn (Account $record) => $record->hasPassword() ? 'Yes' : 'No'),
+                        TextEntry::make('two_factor_enabled')
+                            ->label('Two-Factor Enabled')
+                            ->getStateUsing(fn (Account $record) => $record->hasEnabledTwoFactorAuthentication() ? 'Yes' : 'No'),
                         TextEntry::make('discord_id')
                             ->label('Discord ID')
                             ->getStateUsing(fn (Account $record) => $record->discord_id ?? 'Not Linked'),

--- a/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
+++ b/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
@@ -11,6 +11,7 @@ use App\Models\Contact;
 use App\Models\Mship\Note\Type;
 use App\Models\Mship\State;
 use App\Models\Roster;
+use App\Notifications\Mship\TwoFactorReset;
 use App\Notifications\Mship\UserImpersonated;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -21,6 +22,7 @@ use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\HtmlString;
+use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 
 class ViewAccount extends BaseViewRecordPage
 {
@@ -125,6 +127,37 @@ class ViewAccount extends BaseViewRecordPage
                     })
                     ->requiresConfirmation()
                     ->successNotificationTitle('Password removed'),
+                Action::make('reset_two_factor')
+                    ->label('Reset Two-Factor Authentication')
+                    ->visible(fn () => $this->record->hasEnabledTwoFactorAuthentication()
+                        && auth()->user()->can('resetTwoFactor', $this->record))
+                    ->color('warning')
+                    ->icon('heroicon-o-shield-exclamation')
+                    ->modalHeading('Reset Two-Factor Authentication')
+                    ->modalDescription('This clears the member\'s authenticator secret and all of their recovery codes. They will be required to enrol again before they can use the site.')
+                    ->schema([
+                        Textarea::make('reason')
+                            ->label('Reason')
+                            ->helperText('You MUST include the Helpdesk ticket reference. The member will be emailed to tell them their two-factor authentication was reset, and this reason will be recorded on their account.')
+                            ->minLength(10)
+                            ->required(),
+                    ])
+                    ->action(function (array $data) {
+                        app(DisableTwoFactorAuthentication::class)($this->record);
+
+                        $this->record->addNote(
+                            Type::isShortCode('security')->first(),
+                            'Two-factor authentication reset: '.$data['reason'],
+                            auth()->user(),
+                        );
+
+                        $this->record->notify(new TwoFactorReset(auth()->user()));
+
+                        $this->refreshFormData(['two_factor_enabled']);
+                        $this->dispatch('refreshNotes');
+                    })
+                    ->requiresConfirmation()
+                    ->successNotificationTitle('Two-factor authentication reset'),
                 Action::make('unlink_discord')
                     ->label('Unlink Discord')
                     ->visible(fn () => $this->record->discord_id && auth()->user()->can('unlinkDiscordAccount', $this->record))

--- a/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
+++ b/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
@@ -12,6 +12,7 @@ use App\Models\Mship\Note\Type;
 use App\Models\Mship\State;
 use App\Models\Roster;
 use App\Notifications\Mship\TwoFactorReset;
+use App\Notifications\Mship\TwoFactorResetPerformed;
 use App\Notifications\Mship\UserImpersonated;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -157,6 +158,10 @@ class ViewAccount extends BaseViewRecordPage
                         );
 
                         $this->record->notify(new TwoFactorReset(auth()->user()));
+
+                        // Notify Privileged users that a member's two-factor authentication was reset
+                        Contact::where('key', 'PRIVACC')->first()
+                            ->notify(new TwoFactorResetPerformed($this->record, auth()->user(), $data['reason']));
 
                         $this->refreshFormData(['two_factor_enabled']);
                         $this->dispatch('refreshNotes');

--- a/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
+++ b/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
@@ -144,10 +144,15 @@ class ViewAccount extends BaseViewRecordPage
                             ->required(),
                     ])
                     ->action(function (array $data) {
-                        // visible() governs rendering only, so re-check the gate here:
+                        // visible() governs rendering only, so re-check both gates here:
                         // this must not be reachable by a crafted request from someone
-                        // who can view the page but holds no reset permission.
-                        abort_unless(auth()->user()->can('resetTwoFactor', $this->record), 403);
+                        // who can view the page but holds no reset permission, or against
+                        // a member who no longer has two-factor enabled.
+                        abort_unless(
+                            $this->record->hasEnabledTwoFactorAuthentication()
+                            && auth()->user()->can('resetTwoFactor', $this->record),
+                            403,
+                        );
 
                         app(DisableTwoFactorAuthentication::class)($this->record);
 

--- a/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
+++ b/app/Filament/Admin/Resources/Accounts/Pages/ViewAccount.php
@@ -143,6 +143,11 @@ class ViewAccount extends BaseViewRecordPage
                             ->required(),
                     ])
                     ->action(function (array $data) {
+                        // visible() governs rendering only, so re-check the gate here:
+                        // this must not be reachable by a crafted request from someone
+                        // who can view the page but holds no reset permission.
+                        abort_unless(auth()->user()->can('resetTwoFactor', $this->record), 403);
+
                         app(DisableTwoFactorAuthentication::class)($this->record);
 
                         $this->record->addNote(

--- a/app/Http/Controllers/Auth/TwoFactorRekeyController.php
+++ b/app/Http/Controllers/Auth/TwoFactorRekeyController.php
@@ -18,7 +18,16 @@ class TwoFactorRekeyController extends BaseController
      */
     public function store(Request $request, EnableTwoFactorAuthentication $enable): RedirectResponse
     {
-        $enable($request->user(), true);
+        $user = $request->user();
+
+        $enable($user, true);
+
+        // Fortify's enable action rotates the secret and recovery codes but leaves
+        // two_factor_confirmed_at alone, which would leave the new, never-scanned
+        // secret marked as confirmed - locking the member out of an account whose
+        // old authenticator has just stopped working. Clear it so the setup page
+        // shows them the new QR code to confirm.
+        $user->forceFill(['two_factor_confirmed_at' => null])->save();
 
         return redirect()->route('two-factor.setup')
             ->withSuccess('Scan the new QR code with your authenticator application, then enter a code to finish.');

--- a/app/Http/Controllers/Auth/TwoFactorRekeyController.php
+++ b/app/Http/Controllers/Auth/TwoFactorRekeyController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\BaseController;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+
+class TwoFactorRekeyController extends BaseController
+{
+    /**
+     * Discard the current authenticator secret and issue a fresh one, leaving the
+     * account in Fortify's pending-confirmation state so the member must verify
+     * their new device before two-factor is considered enabled again.
+     */
+    public function store(Request $request, EnableTwoFactorAuthentication $enable): RedirectResponse
+    {
+        $enable($request->user(), true);
+
+        return redirect()->route('two-factor.setup')
+            ->withSuccess('Scan the new QR code with your authenticator application, then enter a code to finish.');
+    }
+}

--- a/app/Http/Responses/Auth/TwoFactorLoginResponse.php
+++ b/app/Http/Responses/Auth/TwoFactorLoginResponse.php
@@ -13,7 +13,7 @@ class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
             return new JsonResponse('', 204);
         }
 
-        if ($request->filled('recovery_code')) {
+        if ($request->session()->pull('two_factor.recovery_code_used', false)) {
             return redirect()->route('two-factor.setup')
                 ->withSuccess('You signed in using a recovery code. Here are your remaining recovery codes.');
         }

--- a/app/Http/Responses/Auth/TwoFactorLoginResponse.php
+++ b/app/Http/Responses/Auth/TwoFactorLoginResponse.php
@@ -13,6 +13,11 @@ class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
             return new JsonResponse('', 204);
         }
 
+        if ($request->filled('recovery_code')) {
+            return redirect()->route('two-factor.setup')
+                ->withSuccess('You signed in using a recovery code. Here are your remaining recovery codes.');
+        }
+
         return redirect()->intended(route('mship.manage.dashboard'));
     }
 }

--- a/app/Listeners/Mship/NotifyOfRecoveryCodeUse.php
+++ b/app/Listeners/Mship/NotifyOfRecoveryCodeUse.php
@@ -3,12 +3,21 @@
 namespace App\Listeners\Mship;
 
 use App\Notifications\Mship\RecoveryCodeUsed;
+use Illuminate\Support\Facades\Session;
 use Laravel\Fortify\Events\RecoveryCodeReplaced;
 
 class NotifyOfRecoveryCodeUse
 {
+    /**
+     * Flag the current session as having just consumed a recovery code, so the
+     * post-login response can tell this apart from an authenticator-code login
+     * without trusting the raw `recovery_code` request field (which may be
+     * present but invalid on a request that actually authenticated via `code`).
+     */
     public function handle(RecoveryCodeReplaced $event): void
     {
+        Session::put('two_factor.recovery_code_used', true);
+
         $event->user->notify(new RecoveryCodeUsed);
     }
 }

--- a/app/Listeners/Mship/NotifyOfRecoveryCodeUse.php
+++ b/app/Listeners/Mship/NotifyOfRecoveryCodeUse.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Listeners\Mship;
+
+use App\Notifications\Mship\RecoveryCodeUsed;
+use Laravel\Fortify\Events\RecoveryCodeReplaced;
+
+class NotifyOfRecoveryCodeUse
+{
+    public function handle(RecoveryCodeReplaced $event): void
+    {
+        $event->user->notify(new RecoveryCodeUsed);
+    }
+}

--- a/app/Notifications/Mship/RecoveryCodeUsed.php
+++ b/app/Notifications/Mship/RecoveryCodeUsed.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Notifications\Mship;
+
+use App\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class RecoveryCodeUsed extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * @param  mixed  $notifiable
+     */
+    public function via($notifiable)
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * @param  mixed  $notifiable
+     */
+    public function toMail($notifiable)
+    {
+        $subject = 'A recovery code was used to sign in to your account';
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK Web Services')
+            ->subject($subject)
+            ->view('emails.mship.security.recovery_code_used', [
+                'subject' => $subject,
+                'recipient' => $notifiable,
+                'account' => $notifiable,
+            ]);
+    }
+
+    /**
+     * @param  mixed  $notifiable
+     */
+    public function toArray($notifiable)
+    {
+        return [];
+    }
+}

--- a/app/Notifications/Mship/RecoveryCodeUsed.php
+++ b/app/Notifications/Mship/RecoveryCodeUsed.php
@@ -46,6 +46,8 @@ class RecoveryCodeUsed extends Notification implements ShouldQueue
      */
     public function toArray($notifiable)
     {
-        return [];
+        return [
+            'message' => 'A recovery code was used to sign in to your account.',
+        ];
     }
 }

--- a/app/Notifications/Mship/TwoFactorReset.php
+++ b/app/Notifications/Mship/TwoFactorReset.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Notifications\Mship;
+
+use App\Models\Mship\Account;
+use App\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class TwoFactorReset extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected Account $administrator;
+
+    public function __construct(Account $administrator)
+    {
+        parent::__construct();
+
+        $this->administrator = $administrator;
+    }
+
+    /**
+     * @param  mixed  $notifiable
+     */
+    public function via($notifiable)
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * @param  mixed  $notifiable
+     */
+    public function toMail($notifiable)
+    {
+        $subject = 'Your two-factor authentication has been reset';
+
+        return (new MailMessage)
+            ->from(config('mail.from.address'), 'VATSIM UK Web Services')
+            ->subject($subject)
+            ->view('emails.mship.security.two_factor_reset', [
+                'subject' => $subject,
+                'recipient' => $notifiable,
+                'account' => $notifiable,
+                'administrator' => $this->administrator,
+            ]);
+    }
+
+    /**
+     * @param  mixed  $notifiable
+     */
+    public function toArray($notifiable)
+    {
+        return ['administrator' => $this->administrator->id];
+    }
+}

--- a/app/Notifications/Mship/TwoFactorResetPerformed.php
+++ b/app/Notifications/Mship/TwoFactorResetPerformed.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Notifications\Mship;
+
+use App\Models\Mship\Account;
+use App\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class TwoFactorResetPerformed extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected Account $target;
+
+    protected Account $administrator;
+
+    protected string $reason;
+
+    public function __construct(Account $target, Account $administrator, string $reason)
+    {
+        parent::__construct();
+
+        $this->target = $target;
+        $this->administrator = $administrator;
+        $this->reason = $reason;
+    }
+
+    /**
+     * @param  mixed  $notifiable
+     */
+    public function via($notifiable)
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * @param  mixed  $notifiable
+     */
+    public function toMail($notifiable)
+    {
+        $subject = "{$this->administrator->name} reset two-factor authentication for {$this->target->name}";
+
+        return (new MailMessage)
+            ->from('admin@vatsim.uk', 'VATSIM UK - Admin')
+            ->subject($subject)
+            ->view('emails.mship.security.two_factor_reset_performed', [
+                'recipient' => $notifiable,
+                'subject' => $subject,
+                'target' => $this->target,
+                'administrator' => $this->administrator,
+                'reason' => $this->reason,
+            ]);
+    }
+
+    /**
+     * @param  mixed  $notifiable
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            'target' => $this->target->id,
+            'administrator' => $this->administrator->id,
+            'reason' => $this->reason,
+        ];
+    }
+}

--- a/app/Policies/AccountPolicy.php
+++ b/app/Policies/AccountPolicy.php
@@ -84,6 +84,17 @@ class AccountPolicy
     }
 
     /**
+     * Whether the user can reset another user's two-factor authentication.
+     *
+     * Deliberately reuses the remove-password permission: both are account
+     * recovery powers exercised by the same people.
+     */
+    public function resetTwoFactor(Account $actor, Account $subject)
+    {
+        return $actor->can("account.remove-password.{$subject->id}") && $this->passesSelfCheck($actor, $subject);
+    }
+
+    /**
      * Whether the user can unlink another user's Discount account
      *
      * @return void

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -85,6 +85,10 @@ class EventServiceProvider extends ServiceProvider
         \App\Events\NetworkData\AtcSessionEnded::class => [
             \App\Listeners\TeamSpeak\RemoveAtcServerGroup::class,
         ],
+
+        \Laravel\Fortify\Events\RecoveryCodeReplaced::class => [
+            \App\Listeners\Mship\NotifyOfRecoveryCodeUse::class,
+        ],
     ];
 
     /**

--- a/database/migrations/2026_08_19_000000_add_security_note_type.php
+++ b/database/migrations/2026_08_19_000000_add_security_note_type.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('mship_note_type')->insert([
+            'name' => 'Security',
+            'short_code' => 'security',
+            'is_available' => true,
+            'is_system' => false,
+            'colour_code' => 'danger',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('mship_note_type')->where('short_code', 'security')->delete();
+    }
+};

--- a/resources/views/auth/two-factor/manage.blade.php
+++ b/resources/views/auth/two-factor/manage.blade.php
@@ -69,6 +69,13 @@
 					onclick="return confirm('This will invalidate your existing recovery codes. Continue?');">
 			</form>
 
+			<form method="POST" action="{{ route('two-factor.rekey') }}" class="form-horizontal"
+				style="margin-bottom: 1.5em;">
+				@csrf
+				<input class="btn btn-warning" type="submit" value="Replace Authenticator App"
+					onclick="return confirm('This will immediately stop your current authenticator application and ALL of your existing recovery codes from working. You will need to finish setting up your new device straight away. Continue?');">
+			</form>
+
 			@if (!Auth::user()->mandatory_two_factor)
 				<form method="POST" action="{{ route('two-factor.disable') }}"
 					onsubmit="return confirm('Disable two-factor authentication for this account?');">

--- a/resources/views/auth/two-factor/manage.blade.php
+++ b/resources/views/auth/two-factor/manage.blade.php
@@ -69,8 +69,7 @@
 					onclick="return confirm('This will invalidate your existing recovery codes. Continue?');">
 			</form>
 
-			<form method="POST" action="{{ route('two-factor.rekey') }}" class="form-horizontal"
-				style="margin-bottom: 1.5em;">
+			<form method="POST" action="{{ route('two-factor.rekey') }}" class="form-horizontal" style="margin-bottom: 1.5em;">
 				@csrf
 				<input class="btn btn-warning" type="submit" value="Replace Authenticator App"
 					onclick="return confirm('This will immediately stop your current authenticator application and ALL of your existing recovery codes from working. You will need to finish setting up your new device straight away. Continue?');">

--- a/resources/views/emails/mship/security/recovery_code_used.blade.php
+++ b/resources/views/emails/mship/security/recovery_code_used.blade.php
@@ -1,0 +1,19 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>
+        Somebody has just signed in to your VATSIM UK account using one of your two-factor
+        recovery codes instead of your authenticator application.
+    </p>
+
+    <p>
+        That code has now been used up and replaced with a new one, so if you keep a saved copy
+        of your recovery codes it is now out of date. You can view and download your current
+        codes from your account settings.
+    </p>
+
+    <p>
+        <strong>If this was not you, contact us immediately</strong> - someone else may have
+        access to your recovery codes.
+    </p>
+@stop

--- a/resources/views/emails/mship/security/two_factor_reset.blade.php
+++ b/resources/views/emails/mship/security/two_factor_reset.blade.php
@@ -1,0 +1,19 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>
+        Two-factor authentication on your VATSIM UK account has been reset by
+        {{ $administrator->name }} ({{ $administrator->id }}) at the request of our helpdesk.
+    </p>
+
+    <p>
+        Your previous authenticator application and all of your existing recovery codes have
+        stopped working. The next time you sign in you will be asked to set up two-factor
+        authentication again, and you will be given a fresh set of recovery codes.
+    </p>
+
+    <p>
+        <strong>If you did not request this, contact us immediately</strong> - someone may have
+        obtained access to your account.
+    </p>
+@stop

--- a/resources/views/emails/mship/security/two_factor_reset_performed.blade.php
+++ b/resources/views/emails/mship/security/two_factor_reset_performed.blade.php
@@ -1,0 +1,10 @@
+@extends('emails.messages.post')
+
+@section('body')
+    <p>
+        {{ $administrator->name }} ({{ $administrator->id }}) has reset two-factor authentication for
+        {{ $target->name }} ({{ $target->id }}).
+    </p>
+
+    <p><span style="font-weight: bold;">The administrator provided the following reason:</span><br>{{ $reason }}</p>
+@stop

--- a/resources/views/mship/management/dashboard-beta.blade.php
+++ b/resources/views/mship/management/dashboard-beta.blade.php
@@ -195,6 +195,26 @@
 									@endif
 								</div>
 							</div>
+						@else
+							<div class="px-5 py-3 flex flex-col sm:flex-row sm:items-start gap-3 sm:justify-between">
+								<div class="flex gap-3 min-w-0">
+									<div class="size-9 shrink-0 rounded-lg bg-gray-100 flex items-center justify-center text-gray-600">
+										<i class="fa fa-shield"></i>
+									</div>
+									<div class="min-w-0">
+										<p class="text-xs font-semibold text-gray-900 m-0">Two-factor authentication</p>
+										<p class="mt-1 text-sm text-gray-500 mb-0">
+											Extra protection using an authenticator app on your phone or computer.
+										</p>
+									</div>
+								</div>
+								<div class="flex flex-col items-start sm:items-end gap-2 sm:pl-4 shrink-0">
+									<span
+										class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-600 ring-1 ring-inset ring-gray-300">Disabled</span>
+									<a href="{{ route('two-factor.setup') }}"
+										class="text-sm font-medium text-brand hover:text-sky-700 no-underline">Enable two-factor</a>
+								</div>
+							</div>
 						@endif
 
 						<div class="px-5 py-3 flex flex-col sm:flex-row sm:items-start gap-3 sm:justify-between">

--- a/resources/views/mship/management/dashboard.blade.php
+++ b/resources/views/mship/management/dashboard.blade.php
@@ -190,32 +190,34 @@
 					@endforelse
 				</div>
 			</div>
-			@if ($_account->hasEnabledTwoFactorAuthentication())
-				<div class="panel panel-ukblue">
-					<div class="panel-heading"><i class="fa fa-shield"></i> &thinsp; Two-Factor Authentication
-					</div>
-					<div class="panel-body">
-						<div class="row">
-							<div class="col-xs-12">
-								Two-factor authentication adds an extra layer of security using an authenticator application on
-								your phone or computer.
-							</div>
+			<div class="panel panel-ukblue">
+				<div class="panel-heading"><i class="fa fa-shield"></i> &thinsp; Two-Factor Authentication
+				</div>
+				<div class="panel-body">
+					<div class="row">
+						<div class="col-xs-12">
+							Two-factor authentication adds an extra layer of security using an authenticator application on
+							your phone or computer.
 						</div>
-						<br />
-						<div class="row">
-							<div class="col-xs-4">
-								<b>STATUS: </b>ENABLED
-							</div>
-							<div class="col-xs-8">
+					</div>
+					<br />
+					<div class="row">
+						<div class="col-xs-4">
+							<b>STATUS: </b>{{ $_account->hasEnabledTwoFactorAuthentication() ? 'ENABLED' : 'DISABLED' }}
+						</div>
+						<div class="col-xs-8">
+							@if ($_account->hasEnabledTwoFactorAuthentication())
 								<a href="{{ route('two-factor.setup') }}">Manage Settings</a>
 								@if ($_account->mandatory_two_factor)
 									&mdash; Cannot be disabled.
 								@endif
-							</div>
+							@else
+								<a href="{{ route('two-factor.setup') }}">Click to Enable</a>
+							@endif
 						</div>
 					</div>
 				</div>
-			@endif
+			</div>
 			<div class="panel panel-ukblue">
 				<div class="panel-heading"><i class="fa fa-lock"></i> &thinsp; Secondary Password
 				</div>

--- a/routes/fortify-two-factor.php
+++ b/routes/fortify-two-factor.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\TwoFactorBackupCodesController;
+use App\Http\Controllers\Auth\TwoFactorRekeyController;
 use App\Http\Controllers\Auth\TwoFactorSetupController;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
@@ -45,6 +46,10 @@ Route::prefix('auth/two-factor')->middleware(config('fortify.middleware', ['web'
         Route::post('enable', [TwoFactorAuthenticationController::class, 'store'])
             ->middleware($twoFactorMiddleware)
             ->name('two-factor.enable');
+
+        Route::post('rekey', [TwoFactorRekeyController::class, 'store'])
+            ->middleware($twoFactorMiddleware)
+            ->name('two-factor.rekey');
 
         Route::post('confirm', [ConfirmedTwoFactorAuthenticationController::class, 'store'])
             ->middleware($twoFactorMiddleware)

--- a/tests/Feature/Account/Auth/RecoveryCodeNotificationTest.php
+++ b/tests/Feature/Account/Auth/RecoveryCodeNotificationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Account\Auth;
+
+use App\Models\Mship\Account;
+use App\Notifications\Mship\RecoveryCodeUsed;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Fortify;
+use PHPUnit\Framework\Attributes\Test;
+use PragmaRX\Google2FA\Google2FA;
+use Tests\TestCase;
+
+class RecoveryCodeNotificationTest extends TestCase
+{
+    protected Account $account;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->account = Account::factory()->create([
+            'password' => 'secret-password',
+        ]);
+
+        app(EnableTwoFactorAuthentication::class)($this->account, true);
+        $this->account->forceFill(['two_factor_confirmed_at' => now()])->save();
+    }
+
+    #[Test]
+    public function using_a_recovery_code_notifies_the_member(): void
+    {
+        $recoveryCode = $this->account->fresh()->recoveryCodes()[0];
+
+        session([
+            'login.id' => $this->account->id,
+            'login.remember' => false,
+        ]);
+
+        $this->post(route('two-factor.login.store'), ['recovery_code' => $recoveryCode])
+            ->assertRedirect(route('mship.manage.dashboard'));
+
+        Notification::assertSentTo($this->account, RecoveryCodeUsed::class);
+    }
+
+    #[Test]
+    public function using_an_authenticator_code_does_not_notify_the_member(): void
+    {
+        $secret = Fortify::currentEncrypter()->decrypt($this->account->fresh()->two_factor_secret);
+        $code = app(Google2FA::class)->getCurrentOtp($secret);
+
+        session([
+            'login.id' => $this->account->id,
+            'login.remember' => false,
+        ]);
+
+        $this->post(route('two-factor.login.store'), ['code' => $code])
+            ->assertRedirect(route('mship.manage.dashboard'));
+
+        Notification::assertNotSentTo($this->account, RecoveryCodeUsed::class);
+    }
+}

--- a/tests/Feature/Account/Auth/RecoveryCodeNotificationTest.php
+++ b/tests/Feature/Account/Auth/RecoveryCodeNotificationTest.php
@@ -38,7 +38,7 @@ class RecoveryCodeNotificationTest extends TestCase
         ]);
 
         $this->post(route('two-factor.login.store'), ['recovery_code' => $recoveryCode])
-            ->assertRedirect(route('mship.manage.dashboard'));
+            ->assertRedirect(route('two-factor.setup'));
 
         Notification::assertSentTo($this->account, RecoveryCodeUsed::class);
     }

--- a/tests/Feature/Account/Auth/TwoFactorAuthTest.php
+++ b/tests/Feature/Account/Auth/TwoFactorAuthTest.php
@@ -163,7 +163,7 @@ class TwoFactorAuthTest extends TestCase
         $this->post(route('two-factor.login.store'), [
             'recovery_code' => $recoveryCode,
         ])
-            ->assertRedirect(route('mship.manage.dashboard'));
+            ->assertRedirect(route('two-factor.setup'));
 
         $this->assertAuthenticatedAs($this->account);
         $this->assertNull(session('login.id'));

--- a/tests/Feature/Account/Auth/TwoFactorAuthTest.php
+++ b/tests/Feature/Account/Auth/TwoFactorAuthTest.php
@@ -24,6 +24,22 @@ class TwoFactorAuthTest extends TestCase
     }
 
     #[Test]
+    public function dashboard_offers_two_factor_setup_link_when_not_enabled(): void
+    {
+        $this->actingAs($this->account)
+            ->get(route('mship.manage.dashboard'))
+            ->assertOk()
+            ->assertSee(route('two-factor.setup'), false)
+            ->assertSee('Click to Enable', false);
+
+        $this->actingAs($this->account)
+            ->get(route('mship.manage.dashboard.beta'))
+            ->assertOk()
+            ->assertSee(route('two-factor.setup'), false)
+            ->assertSee('Enable two-factor', false);
+    }
+
+    #[Test]
     public function mandatory_two_factor_middleware_redirects_to_setup(): void
     {
         $role = factory(Role::class)->create(['two_factor_mandatory' => true]);

--- a/tests/Feature/Account/Auth/TwoFactorAuthTest.php
+++ b/tests/Feature/Account/Auth/TwoFactorAuthTest.php
@@ -2,9 +2,12 @@
 
 namespace Tests\Feature\Account\Auth;
 
+use App\Libraries\UKCP;
 use App\Models\Mship\Account;
+use Illuminate\Support\Collection;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
 use Laravel\Fortify\Fortify;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PragmaRX\Google2FA\Google2FA;
 use Spatie\Permission\Models\Role;
@@ -26,6 +29,11 @@ class TwoFactorAuthTest extends TestCase
     #[Test]
     public function dashboard_offers_two_factor_setup_link_when_not_enabled(): void
     {
+        $this->mock(UKCP::class, function (MockInterface $mock) {
+            $mock->shouldReceive('getValidTokensFor')
+                ->andReturn(Collection::make());
+        });
+
         $this->actingAs($this->account)
             ->get(route('mship.manage.dashboard'))
             ->assertOk()

--- a/tests/Feature/Account/Auth/TwoFactorRekeyTest.php
+++ b/tests/Feature/Account/Auth/TwoFactorRekeyTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature\Account\Auth;
+
+use App\Models\Mship\Account;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Fortify;
+use PHPUnit\Framework\Attributes\Test;
+use PragmaRX\Google2FA\Google2FA;
+use Tests\TestCase;
+
+class TwoFactorRekeyTest extends TestCase
+{
+    protected Account $account;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->account = Account::factory()->create([
+            'password' => 'secret-password',
+        ]);
+    }
+
+    #[Test]
+    public function rekey_requires_authentication(): void
+    {
+        $this->post(route('two-factor.rekey'))
+            ->assertRedirect();
+    }
+
+    #[Test]
+    public function rekey_requires_password_confirmation(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $this->actingAs($this->account)
+            ->post(route('two-factor.rekey'))
+            ->assertRedirect(route('two-factor.confirm-password', [
+                'redirect' => route('two-factor.rekey'),
+            ]));
+    }
+
+    #[Test]
+    public function rekey_replaces_the_secret_and_clears_confirmation(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $originalSecret = $this->account->fresh()->two_factor_secret;
+        $originalCodes = $this->account->fresh()->two_factor_recovery_codes;
+
+        $this->actingAs($this->account)
+            ->withSession(['auth.password_confirmed_at' => now()->unix()])
+            ->post(route('two-factor.rekey'))
+            ->assertRedirect(route('two-factor.setup'));
+
+        $fresh = $this->account->fresh();
+
+        $this->assertNotEquals($originalSecret, $fresh->two_factor_secret);
+        $this->assertNotEquals($originalCodes, $fresh->two_factor_recovery_codes);
+        $this->assertNull($fresh->two_factor_confirmed_at);
+        $this->assertFalse($fresh->hasEnabledTwoFactorAuthentication());
+    }
+
+    #[Test]
+    public function rekey_then_confirming_the_new_device_re_enables_two_factor(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $this->actingAs($this->account)
+            ->withSession(['auth.password_confirmed_at' => now()->unix()])
+            ->post(route('two-factor.rekey'));
+
+        $newSecret = Fortify::currentEncrypter()->decrypt($this->account->fresh()->two_factor_secret);
+        $code = app(Google2FA::class)->getCurrentOtp($newSecret);
+
+        $this->actingAs($this->account)
+            ->withSession(['auth.password_confirmed_at' => now()->unix()])
+            ->post(route('two-factor.confirm'), ['code' => $code])
+            ->assertRedirect(route('two-factor.backup-codes'));
+
+        $this->assertTrue($this->account->fresh()->hasEnabledTwoFactorAuthentication());
+    }
+
+    #[Test]
+    public function manage_page_offers_replace_authenticator(): void
+    {
+        $this->enableTwoFactorFor($this->account);
+
+        $this->actingAs($this->account)
+            ->get(route('two-factor.setup'))
+            ->assertOk()
+            ->assertSee('Replace Authenticator App', false)
+            ->assertSee(route('two-factor.rekey'), false);
+    }
+
+    #[Test]
+    public function manage_page_offers_replace_authenticator_to_mandatory_users(): void
+    {
+        $role = factory(\Spatie\Permission\Models\Role::class)->create(['two_factor_mandatory' => true]);
+        $this->account->assignRole($role);
+        $this->enableTwoFactorFor($this->account);
+
+        $this->actingAs($this->account)
+            ->get(route('two-factor.setup'))
+            ->assertOk()
+            ->assertSee('Replace Authenticator App', false)
+            ->assertDontSee('Disable Two-Factor Authentication', false);
+    }
+
+    protected function enableTwoFactorFor(Account $account): void
+    {
+        app(EnableTwoFactorAuthentication::class)($account, true);
+
+        $account->forceFill([
+            'two_factor_confirmed_at' => now(),
+        ])->save();
+    }
+}

--- a/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
+++ b/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
@@ -398,6 +398,20 @@ class ViewAccountPageTest extends BaseAdminTestCase
             ->assertActionHidden('reset_two_factor');
     }
 
+    public function test_cant_reset_two_factor_via_crafted_request_without_permission()
+    {
+        $this->user->givePermissionTo('account.view-insensitive.*');
+        $this->enableTwoFactorFor($this->privacc);
+
+        Livewire::actingAs($this->user);
+        Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
+            ->assertActionHidden('reset_two_factor')
+            ->callAction('reset_two_factor', data: ['reason' => 'Lost phone and codes, HELPDESK-1234'])
+            ->assertForbidden();
+
+        $this->assertTrue($this->privacc->fresh()->hasEnabledTwoFactorAuthentication());
+    }
+
     public function test_reset_two_factor_hidden_when_two_factor_disabled()
     {
         $this->user->givePermissionTo('account.view-insensitive.*');

--- a/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
+++ b/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
@@ -404,9 +404,14 @@ class ViewAccountPageTest extends BaseAdminTestCase
         $this->enableTwoFactorFor($this->privacc);
 
         Livewire::actingAs($this->user);
+        // callAction() asserts the action is visible before invoking it, which
+        // can never happen here by design. Mount and call it directly instead,
+        // as a crafted request would, to exercise the abort_unless() backstop.
         Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
             ->assertActionHidden('reset_two_factor')
-            ->callAction('reset_two_factor', data: ['reason' => 'Lost phone and codes, HELPDESK-1234'])
+            ->mountAction('reset_two_factor')
+            ->setActionData(['reason' => 'Lost phone and codes, HELPDESK-1234'])
+            ->callMountedAction()
             ->assertForbidden();
 
         $this->assertTrue($this->privacc->fresh()->hasEnabledTwoFactorAuthentication());

--- a/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
+++ b/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
@@ -404,15 +404,12 @@ class ViewAccountPageTest extends BaseAdminTestCase
         $this->enableTwoFactorFor($this->privacc);
 
         Livewire::actingAs($this->user);
-        // callAction() asserts the action is visible before invoking it, which
-        // can never happen here by design. Mount and call it directly instead,
-        // as a crafted request would, to exercise the abort_unless() backstop.
+        // Filament treats hidden actions as disabled, so a crafted request
+        // cannot mount or invoke the action: the mount is silently rejected.
         Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
             ->assertActionHidden('reset_two_factor')
             ->mountAction('reset_two_factor')
-            ->setActionData(['reason' => 'Lost phone and codes, HELPDESK-1234'])
-            ->callMountedAction()
-            ->assertForbidden();
+            ->assertActionNotMounted();
 
         $this->assertTrue($this->privacc->fresh()->hasEnabledTwoFactorAuthentication());
     }

--- a/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
+++ b/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
@@ -4,10 +4,12 @@ namespace Tests\Feature\Admin\Account\Pages;
 
 use App\Filament\Admin\Resources\Accounts\Pages\ViewAccount;
 use App\Jobs\UpdateMember;
+use App\Models\Contact;
 use App\Models\Mship\Note\Type;
 use App\Models\Mship\State;
 use App\Models\Roster;
 use App\Notifications\Mship\TwoFactorReset;
+use App\Notifications\Mship\TwoFactorResetPerformed;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
@@ -456,6 +458,22 @@ class ViewAccountPageTest extends BaseAdminTestCase
             ->callAction('reset_two_factor', data: ['reason' => 'Lost phone and codes, HELPDESK-1234']);
 
         Notification::assertSentTo($this->privacc, TwoFactorReset::class);
+    }
+
+    public function test_reset_two_factor_notifies_privileged_users()
+    {
+        $this->user->givePermissionTo('account.view-insensitive.*');
+        $this->user->givePermissionTo('account.remove-password.*');
+        $this->enableTwoFactorFor($this->privacc);
+
+        Livewire::actingAs($this->user);
+        Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
+            ->callAction('reset_two_factor', data: ['reason' => 'Lost phone and codes, HELPDESK-1234']);
+
+        Notification::assertSentTo(
+            Contact::where('key', 'PRIVACC')->first(),
+            TwoFactorResetPerformed::class,
+        );
     }
 
     public function test_reset_two_factor_requires_a_reason()

--- a/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
+++ b/tests/Feature/Admin/Account/Pages/ViewAccountPageTest.php
@@ -7,7 +7,10 @@ use App\Jobs\UpdateMember;
 use App\Models\Mship\Note\Type;
 use App\Models\Mship\State;
 use App\Models\Roster;
+use App\Notifications\Mship\TwoFactorReset;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
 use Livewire\Livewire;
 use Tests\Feature\Admin\BaseAdminTestCase;
 
@@ -374,5 +377,98 @@ class ViewAccountPageTest extends BaseAdminTestCase
 
         Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
             ->assertActionHidden('grant_visiting_status');
+    }
+
+    protected function enableTwoFactorFor(\App\Models\Mship\Account $account): void
+    {
+        app(EnableTwoFactorAuthentication::class)($account, true);
+
+        $account->forceFill(['two_factor_confirmed_at' => now()])->save();
+    }
+
+    public function test_cant_reset_two_factor_without_permission()
+    {
+        $this->user->givePermissionTo('account.view-insensitive.*');
+        $this->enableTwoFactorFor($this->privacc);
+
+        Livewire::actingAs($this->user);
+        Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
+            ->assertActionHidden('reset_two_factor');
+    }
+
+    public function test_reset_two_factor_hidden_when_two_factor_disabled()
+    {
+        $this->user->givePermissionTo('account.view-insensitive.*');
+        $this->user->givePermissionTo('account.remove-password.*');
+
+        Livewire::actingAs($this->user);
+        Livewire::test(ViewAccount::class, ['record' => $this->privacc->id])
+            ->assertActionHidden('reset_two_factor');
+    }
+
+    public function test_can_reset_two_factor_with_permission()
+    {
+        $this->user->givePermissionTo('account.view-insensitive.*');
+        $this->user->givePermissionTo('account.remove-password.*');
+        $this->enableTwoFactorFor($this->privacc);
+
+        $this->assertTrue($this->privacc->fresh()->hasEnabledTwoFactorAuthentication());
+
+        Livewire::actingAs($this->user);
+        Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
+            ->assertActionVisible('reset_two_factor')
+            ->callAction('reset_two_factor', data: ['reason' => 'Lost phone and codes, HELPDESK-1234']);
+
+        $fresh = $this->privacc->fresh();
+
+        $this->assertNull($fresh->two_factor_secret);
+        $this->assertNull($fresh->two_factor_recovery_codes);
+        $this->assertNull($fresh->two_factor_confirmed_at);
+        $this->assertFalse($fresh->hasEnabledTwoFactorAuthentication());
+    }
+
+    public function test_reset_two_factor_creates_a_security_note()
+    {
+        $this->user->givePermissionTo('account.view-insensitive.*');
+        $this->user->givePermissionTo('account.remove-password.*');
+        $this->enableTwoFactorFor($this->privacc);
+
+        Livewire::actingAs($this->user);
+        Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
+            ->callAction('reset_two_factor', data: ['reason' => 'Lost phone and codes, HELPDESK-1234']);
+
+        $this->assertDatabaseHas('mship_account_note', [
+            'note_type_id' => Type::isShortCode('security')->first()->id,
+            'account_id' => $this->privacc->id,
+            'writer_id' => $this->user->id,
+            'content' => 'Two-factor authentication reset: Lost phone and codes, HELPDESK-1234',
+        ]);
+    }
+
+    public function test_reset_two_factor_notifies_the_member()
+    {
+        $this->user->givePermissionTo('account.view-insensitive.*');
+        $this->user->givePermissionTo('account.remove-password.*');
+        $this->enableTwoFactorFor($this->privacc);
+
+        Livewire::actingAs($this->user);
+        Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
+            ->callAction('reset_two_factor', data: ['reason' => 'Lost phone and codes, HELPDESK-1234']);
+
+        Notification::assertSentTo($this->privacc, TwoFactorReset::class);
+    }
+
+    public function test_reset_two_factor_requires_a_reason()
+    {
+        $this->user->givePermissionTo('account.view-insensitive.*');
+        $this->user->givePermissionTo('account.remove-password.*');
+        $this->enableTwoFactorFor($this->privacc);
+
+        Livewire::actingAs($this->user);
+        Livewire::test(ViewAccount::class, ['record' => $this->privacc->refresh()->id])
+            ->callAction('reset_two_factor', data: ['reason' => 'short'])
+            ->assertHasActionErrors(['reason']);
+
+        $this->assertTrue($this->privacc->fresh()->hasEnabledTwoFactorAuthentication());
     }
 }

--- a/tests/Unit/Account/ResetTwoFactorPolicyTest.php
+++ b/tests/Unit/Account/ResetTwoFactorPolicyTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Account;
+
+use App\Models\Mship\Account;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ResetTwoFactorPolicyTest extends TestCase
+{
+    #[Test]
+    public function it_denies_reset_without_the_permission(): void
+    {
+        $actor = Account::factory()->create();
+        $subject = Account::factory()->create();
+
+        $this->assertFalse($actor->can('resetTwoFactor', $subject));
+    }
+
+    #[Test]
+    public function it_allows_reset_with_the_remove_password_permission(): void
+    {
+        $actor = Account::factory()->create();
+        $actor->givePermissionTo('account.remove-password.*');
+        $subject = Account::factory()->create();
+
+        $this->assertTrue($actor->fresh()->can('resetTwoFactor', $subject));
+    }
+
+    #[Test]
+    public function it_denies_self_reset_without_the_self_permission(): void
+    {
+        $actor = Account::factory()->create();
+        $actor->givePermissionTo('account.remove-password.*');
+
+        $this->assertFalse($actor->fresh()->can('resetTwoFactor', $actor));
+    }
+
+    #[Test]
+    public function it_allows_self_reset_with_the_self_permission(): void
+    {
+        $actor = Account::factory()->create();
+        $actor->givePermissionTo('account.remove-password.*');
+        $actor->givePermissionTo('account.self');
+
+        $this->assertTrue($actor->fresh()->can('resetTwoFactor', $actor));
+    }
+}

--- a/tests/Unit/Account/SecurityNoteTypeTest.php
+++ b/tests/Unit/Account/SecurityNoteTypeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\Account;
+
+use App\Models\Mship\Note\Type;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SecurityNoteTypeTest extends TestCase
+{
+    #[Test]
+    public function it_has_a_security_note_type(): void
+    {
+        $type = Type::isShortCode('security')->first();
+
+        $this->assertNotNull($type);
+        $this->assertEquals('Security', $type->name);
+        $this->assertTrue((bool) $type->is_available);
+        $this->assertFalse((bool) $type->is_system);
+    }
+}

--- a/tests/Unit/Account/TwoFactorResetNotificationTest.php
+++ b/tests/Unit/Account/TwoFactorResetNotificationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit\Account;
+
+use App\Models\Mship\Account;
+use App\Notifications\Mship\TwoFactorReset;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TwoFactorResetNotificationTest extends TestCase
+{
+    #[Test]
+    public function it_names_the_administrator_and_omits_any_reason(): void
+    {
+        $member = Account::factory()->create();
+        $administrator = Account::factory()->create();
+
+        $mail = (new TwoFactorReset($administrator))->toMail($member);
+        $rendered = $mail->render();
+
+        $this->assertStringContainsString($administrator->name, $rendered);
+        $this->assertStringContainsString('two-factor authentication', strtolower($rendered));
+        $this->assertStringNotContainsString('HELPDESK-1234', $rendered);
+    }
+
+    #[Test]
+    public function it_sends_by_mail_and_database(): void
+    {
+        $member = Account::factory()->create();
+        $administrator = Account::factory()->create();
+
+        $this->assertEquals(['mail', 'database'], (new TwoFactorReset($administrator))->via($member));
+    }
+}

--- a/tests/Unit/Account/TwoFactorResetPerformedNotificationTest.php
+++ b/tests/Unit/Account/TwoFactorResetPerformedNotificationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\Account;
+
+use App\Models\Contact;
+use App\Models\Mship\Account;
+use App\Notifications\Mship\TwoFactorResetPerformed;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TwoFactorResetPerformedNotificationTest extends TestCase
+{
+    #[Test]
+    public function it_names_the_target_administrator_and_reason(): void
+    {
+        $target = Account::factory()->create();
+        $administrator = Account::factory()->create();
+        $recipient = factory(Contact::class)->create(['name' => 'Privileged Access']);
+
+        $mail = (new TwoFactorResetPerformed($target, $administrator, 'HELPDESK-1234: lost device'))->toMail($recipient);
+        $rendered = $mail->render();
+
+        $this->assertStringContainsString($administrator->name, $rendered);
+        $this->assertStringContainsString($target->name, $rendered);
+        $this->assertStringContainsString('HELPDESK-1234: lost device', $rendered);
+    }
+
+    #[Test]
+    public function it_sends_by_mail_and_database(): void
+    {
+        $target = Account::factory()->create();
+        $administrator = Account::factory()->create();
+        $recipient = factory(Contact::class)->create(['name' => 'Privileged Access']);
+
+        $this->assertEquals(
+            ['mail', 'database'],
+            (new TwoFactorResetPerformed($target, $administrator, 'HELPDESK-1234'))->via($recipient)
+        );
+    }
+}


### PR DESCRIPTION
Add 2FA recovery/reset options.

- Admin reset action on the account page: requires a reason, writes a `security` note,
  emails the member. Gated by `account.remove-password.*`
- Self-service "Replace Authenticator App" on the 2FA page, visible to mandatory-2FA
  staff, behind `password.confirm`
- Members emailed when a recovery code is used to sign in

<img width="1222" height="829" alt="image" src="https://github.com/user-attachments/assets/1aa5152f-9041-4bca-a800-b90934cf4da2" />
