### PR TITLE
Add CID lookup discord command

### DIFF
--- a/app/Console/Commands/Discord/RunDiscordBot.php
+++ b/app/Console/Commands/Discord/RunDiscordBot.php
@@ -7,6 +7,8 @@ namespace App\Console\Commands\Discord;
 use App\Jobs\Discord\HandleHoneypotTrigger;
 use App\Models\Discord\DiscordTag;
 use App\Models\NetworkData\Atc;
+use App\Services\Discord\CidLookupService;
+use App\Services\Discord\CidLookupStatus;
 use Discord\Builders\MessageBuilder;
 use Discord\Discord;
 use Discord\Parts\Channel\Message;
@@ -53,6 +55,10 @@ class RunDiscordBot extends Command
             $this->honeypotStartup();
 
             $this->registerTagCommand($discord);
+
+            $this->registerLookupCommand($discord);
+
+            app(\App\Libraries\Discord::class)->syncLookupCommand();
 
             $discord->on(Event::MESSAGE_CREATE, function (Message $message, Discord $discord) {
                 if ($message->author->bot) {
@@ -190,6 +196,27 @@ class RunDiscordBot extends Command
                             'text' => "/tag {$tag->key}",
                         ],
                     ])
+            );
+        });
+    }
+
+    private function registerLookupCommand(Discord $discord): void
+    {
+        $discord->listenCommand('lookup', function (ApplicationCommand $interaction) {
+            $cid = (int) $interaction->data->options->get('name', 'cid')?->value;
+
+            $result = app(CidLookupService::class)->lookup($cid);
+
+            $message = match ($result->status) {
+                CidLookupStatus::Invalid => 'Please provide a valid CID.',
+                CidLookupStatus::NotFound => "No account found for CID `{$cid}`.",
+                CidLookupStatus::NotLinked => "CID `{$cid}` is not linked to a Discord account.",
+                CidLookupStatus::Found => "<@{$result->discordId}>",
+            };
+
+            $interaction->respondWithMessage(
+                MessageBuilder::new()->setContent($message),
+                ephemeral: true
             );
         });
     }

--- a/app/Libraries/Discord.php
+++ b/app/Libraries/Discord.php
@@ -453,6 +453,33 @@ class Discord
         $this->upsertGuildCommand($commandPayload, $applicationId);
     }
 
+    public function syncLookupCommand(): void
+    {
+        $applicationId = config('services.discord.client_id');
+
+        if (! $applicationId) {
+            Log::error('Cannot sync lookup command: no Discord client ID configured');
+
+            return;
+        }
+
+        $commandPayload = [
+            'name' => 'lookup',
+            'description' => 'Look up the Discord account linked to a VATSIM CID.',
+            'options' => [
+                [
+                    'type' => 4, // INTEGER
+                    'name' => 'cid',
+                    'description' => 'The VATSIM CID to look up.',
+                    'required' => true,
+                    'min_value' => 1,
+                ],
+            ],
+        ];
+
+        $this->upsertGuildCommand($commandPayload, $applicationId);
+    }
+
     /**
      * Create or update a guild slash command.
      */

--- a/app/Services/Discord/CidLookupResult.php
+++ b/app/Services/Discord/CidLookupResult.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Discord;
+
+final class CidLookupResult
+{
+    public function __construct(
+        public readonly CidLookupStatus $status,
+        public readonly ?string $discordId = null,
+    ) {}
+}

--- a/app/Services/Discord/CidLookupService.php
+++ b/app/Services/Discord/CidLookupService.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Discord;
+
+use App\Models\Mship\Account;
+
+final class CidLookupService
+{
+    public function lookup(int $cid): CidLookupResult
+    {
+        if ($cid <= 0) {
+            return new CidLookupResult(CidLookupStatus::Invalid);
+        }
+
+        $account = Account::find($cid);
+
+        if (! $account) {
+            return new CidLookupResult(CidLookupStatus::NotFound);
+        }
+
+        if (! $account->discord_id) {
+            return new CidLookupResult(CidLookupStatus::NotLinked);
+        }
+
+        return new CidLookupResult(CidLookupStatus::Found, $account->discord_id);
+    }
+}

--- a/app/Services/Discord/CidLookupStatus.php
+++ b/app/Services/Discord/CidLookupStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Discord;
+
+enum CidLookupStatus
+{
+    case Invalid;
+    case NotFound;
+    case NotLinked;
+    case Found;
+}

--- a/tests/Feature/Services/DiscordTest.php
+++ b/tests/Feature/Services/DiscordTest.php
@@ -861,4 +861,63 @@ class DiscordTest extends TestCase
             return $request->method() === 'GET';
         });
     }
+
+    #[Test]
+    public function sync_lookup_command_creates_new_command_when_none_exists()
+    {
+        $this->configureDiscordApi();
+
+        Http::fake([
+            'discord.com/api/v10/applications/test-app/guilds/test-guild/commands' => Http::sequence()
+                ->push([], 200)
+                ->push(['id' => 'cmd-1'], 200),
+        ]);
+
+        (new Discord)->syncLookupCommand();
+
+        Http::assertSent(function ($request) {
+            return $request->method() === 'POST'
+                && str_contains($request->url(), '/commands')
+                && $request->data()['name'] === 'lookup'
+                && $request->data()['options'][0]['name'] === 'cid'
+                && $request->data()['options'][0]['type'] === 4
+                && $request->data()['options'][0]['required'] === true
+                && $request->data()['options'][0]['min_value'] === 1;
+        });
+    }
+
+    #[Test]
+    public function sync_lookup_command_updates_existing_command()
+    {
+        $this->configureDiscordApi();
+
+        Http::fake([
+            'discord.com/api/v10/applications/test-app/guilds/test-guild/commands' => Http::response([
+                ['id' => 'cmd-1', 'name' => 'lookup'],
+            ], 200),
+            'discord.com/api/v10/applications/test-app/guilds/test-guild/commands/cmd-1' => Http::response([], 200),
+        ]);
+
+        (new Discord)->syncLookupCommand();
+
+        Http::assertSent(function ($request) {
+            return $request->method() === 'PATCH'
+                && str_contains($request->url(), '/commands/cmd-1');
+        });
+    }
+
+    #[Test]
+    public function sync_lookup_command_logs_error_when_no_client_id()
+    {
+        Config::set('services.discord.token', 'test-token');
+        Config::set('services.discord.guild_id', 'test-guild');
+        Config::set('services.discord.client_id', null);
+        Config::set('services.discord.base_discord_uri', 'https://discord.com/api/v10');
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Cannot sync lookup command: no Discord client ID configured');
+
+        (new Discord)->syncLookupCommand();
+    }
 }

--- a/tests/Unit/Discord/CidLookupServiceTest.php
+++ b/tests/Unit/Discord/CidLookupServiceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Discord;
+
+use App\Models\Mship\Account;
+use App\Services\Discord\CidLookupService;
+use App\Services\Discord\CidLookupStatus;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CidLookupServiceTest extends TestCase
+{
+    #[Test]
+    public function it_returns_invalid_for_a_non_positive_cid()
+    {
+        $result = (new CidLookupService)->lookup(0);
+
+        $this->assertSame(CidLookupStatus::Invalid, $result->status);
+        $this->assertNull($result->discordId);
+    }
+
+    #[Test]
+    public function it_returns_not_found_when_no_account_has_that_cid()
+    {
+        // AccountFactory only generates ids in 100_000..9_999_999, so this is guaranteed unused.
+        $result = (new CidLookupService)->lookup(999999999);
+
+        $this->assertSame(CidLookupStatus::NotFound, $result->status);
+        $this->assertNull($result->discordId);
+    }
+
+    #[Test]
+    public function it_returns_not_linked_when_account_has_no_discord_id()
+    {
+        $account = Account::factory()->createQuietly(['discord_id' => null]);
+
+        $result = (new CidLookupService)->lookup($account->id);
+
+        $this->assertSame(CidLookupStatus::NotLinked, $result->status);
+        $this->assertNull($result->discordId);
+    }
+
+    #[Test]
+    public function it_returns_found_with_discord_id_when_linked()
+    {
+        $account = Account::factory()->createQuietly(['discord_id' => 555444333]);
+
+        $result = (new CidLookupService)->lookup($account->id);
+
+        $this->assertSame(CidLookupStatus::Found, $result->status);
+        $this->assertSame('555444333', $result->discordId);
+    }
+}


### PR DESCRIPTION
adds `/lookup <cid>` to easily look up a Discord account linked to a core account