### PR TITLE
feat: add pages to feedback forms

### DIFF
--- a/app/Http/Controllers/Mship/Feedback.php
+++ b/app/Http/Controllers/Mship/Feedback.php
@@ -47,7 +47,7 @@ class Feedback extends \App\Http\Controllers\BaseController
     public function getFeedback(Form $form)
     {
         /** @var Question[] $questions */
-        $questions = $form->questions()->orderBy('sequence')->get();
+        $questions = $form->questions()->orderBy('page')->orderBy('sequence')->get();
         if (! $questions || ! $form->enabled) {
             // We have no questions to display!
             return Redirect::route('mship.manage.dashboard')

--- a/database/migrations/2026_08_22_160954_add_page_to_mship_feedback_questions.php
+++ b/database/migrations/2026_08_22_160954_add_page_to_mship_feedback_questions.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('mship_feedback_questions', function (Blueprint $table) {
+            $table->integer('page')->after('sequence')->default('1');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('mship_feedback_questions', function (Blueprint $table) {
+            $table->dropColumn('page');
+        });
+    }
+};

--- a/resources/views/mship/feedback/form.blade.php
+++ b/resources/views/mship/feedback/form.blade.php
@@ -20,23 +20,42 @@
 			}
 
 			function pageValid() {
-				var ok = true, first = null;
-				$pages.eq(idx).find('.form-group[data-required="true"]').each(function () {
-					var $g = $(this), filled = false;
-					$g.find('input[type=radio],input[type=checkbox]').each(function () { if (this.checked) filled = true; });
-					$g.find('input:not([type=radio]):not([type=checkbox]),textarea,select').each(function () { if ($.trim($(this).val() || '') !== '') filled = true; });
+				var ok = true,
+					first = null;
+				$pages.eq(idx).find('.form-group[data-required="true"]').each(function() {
+					var $g = $(this),
+						filled = false;
+					$g.find('input[type=radio],input[type=checkbox]').each(function() {
+						if (this.checked) filled = true;
+					});
+					$g.find('input:not([type=radio]):not([type=checkbox]),textarea,select').each(function() {
+						if ($.trim($(this).val() || '') !== '') filled = true;
+					});
 					$g.toggleClass('has-error', !filled);
-					if (!filled) { ok = false; first = first || $g; }
+					if (!filled) {
+						ok = false;
+						first = first || $g;
+					}
 				});
-				if (first) $('html,body').animate({ scrollTop: first.offset().top - 100 }, 200);
+				if (first) $('html,body').animate({
+					scrollTop: first.offset().top - 100
+				}, 200);
 				return ok;
 			}
 
-			$('#feedbackNext').click(function () { if (pageValid()) { idx++; renderPage(); } });
-			$('#feedbackPrev').click(function () { idx--; renderPage(); });
+			$('#feedbackNext').click(function() {
+				if (pageValid()) {
+					idx++;
+					renderPage();
+				}
+			});
+			$('#feedbackPrev').click(function() {
+				idx--;
+				renderPage();
+			});
 
 			if (total) renderPage();
-			});
+		});
 	</script>
 @endsection
 
@@ -90,26 +109,27 @@
 								All questions are required unless an <i>(optional)</i> is displayed beside it.
 							</p>
 							<hr>
-							
+
 							@php $pages = $questions->groupBy('page'); @endphp
 
 							<p class="text-center">Step <span id="feedbackStep">1</span> of {{ $pages->count() }}</p>
-								@foreach ($pages as $pageQuestions)
-									<div class="feedback-page" style="{{ $loop->first ? '' : 'display:none;' }}">
-										@foreach ($pageQuestions as $question)
-											<div class="form-group{{ $errors->has($question->slug) ? ' has-error' : '' }}" data-required="{{ $question->required ? 'true' : 'false' }}">
-												<label for="{{ $question->slug }}">{!! $question->question . ($question->required ? '' : ' (optional)') !!}</label> </br>
-												{!! $question->form_html !!}
-											</div>
-										@endforeach
-									</div>
-								@endforeach
-
-								<div class="form-group text-center">
-									<button type="button" id="feedbackPrev" class="btn btn-default" style="display:none;">Previous</button>
-									<button type="button" id="feedbackNext" class="btn btn-primary">Next <i class="fa fa-arrow-right"></i></button>
-									<button type="submit" id="feedbackSubmit" class="btn btn-success" style="display:none;">Submit</button>
+							@foreach ($pages as $pageQuestions)
+								<div class="feedback-page" style="{{ $loop->first ? '' : 'display:none;' }}">
+									@foreach ($pageQuestions as $question)
+										<div class="form-group{{ $errors->has($question->slug) ? ' has-error' : '' }}"
+											data-required="{{ $question->required ? 'true' : 'false' }}">
+											<label for="{{ $question->slug }}">{!! $question->question . ($question->required ? '' : ' (optional)') !!}</label> </br>
+											{!! $question->form_html !!}
+										</div>
+									@endforeach
 								</div>
+							@endforeach
+
+							<div class="form-group text-center">
+								<button type="button" id="feedbackPrev" class="btn btn-default" style="display:none;">Previous</button>
+								<button type="button" id="feedbackNext" class="btn btn-primary">Next <i class="fa fa-arrow-right"></i></button>
+								<button type="submit" id="feedbackSubmit" class="btn btn-success" style="display:none;">Submit</button>
+							</div>
 						</form>
 					@endif
 				</div>

--- a/resources/views/mship/feedback/form.blade.php
+++ b/resources/views/mship/feedback/form.blade.php
@@ -7,7 +7,36 @@
 	<script type="text/javascript">
 		$(document).ready(function() {
 			$('.datetimepickercustom').datetimepicker();
-		});
+			var $pages = $('.feedback-page');
+			var total = $pages.length;
+			var idx = 0;
+
+			function renderPage() {
+				$pages.hide().eq(idx).show();
+				$('#feedbackStep').text(idx + 1);
+				$('#feedbackPrev').toggle(idx > 0);
+				$('#feedbackNext').toggle(idx < total - 1);
+				$('#feedbackSubmit').toggle(idx === total - 1);
+			}
+
+			function pageValid() {
+				var ok = true, first = null;
+				$pages.eq(idx).find('.form-group[data-required="true"]').each(function () {
+					var $g = $(this), filled = false;
+					$g.find('input[type=radio],input[type=checkbox]').each(function () { if (this.checked) filled = true; });
+					$g.find('input:not([type=radio]):not([type=checkbox]),textarea,select').each(function () { if ($.trim($(this).val() || '') !== '') filled = true; });
+					$g.toggleClass('has-error', !filled);
+					if (!filled) { ok = false; first = first || $g; }
+				});
+				if (first) $('html,body').animate({ scrollTop: first.offset().top - 100 }, 200);
+				return ok;
+			}
+
+			$('#feedbackNext').click(function () { if (pageValid()) { idx++; renderPage(); } });
+			$('#feedbackPrev').click(function () { idx--; renderPage(); });
+
+			if (total) renderPage();
+			});
 	</script>
 @endsection
 
@@ -61,15 +90,26 @@
 								All questions are required unless an <i>(optional)</i> is displayed beside it.
 							</p>
 							<hr>
-							@foreach ($questions as $question)
-								<div class="form-group{{ $errors->has($question->slug) ? ' has-error' : '' }}">
-									<label for="{{ $question->slug }}">{!! $question->question . ($question->required ? '' : ' (optional)') !!}</label> </br>
-									{!! $question->form_html !!}
+							
+							@php $pages = $questions->groupBy('page'); @endphp
+
+							<p class="text-center">Step <span id="feedbackStep">1</span> of {{ $pages->count() }}</p>
+								@foreach ($pages as $pageQuestions)
+									<div class="feedback-page" style="{{ $loop->first ? '' : 'display:none;' }}">
+										@foreach ($pageQuestions as $question)
+											<div class="form-group{{ $errors->has($question->slug) ? ' has-error' : '' }}" data-required="{{ $question->required ? 'true' : 'false' }}">
+												<label for="{{ $question->slug }}">{!! $question->question . ($question->required ? '' : ' (optional)') !!}</label> </br>
+												{!! $question->form_html !!}
+											</div>
+										@endforeach
+									</div>
+								@endforeach
+
+								<div class="form-group text-center">
+									<button type="button" id="feedbackPrev" class="btn btn-default" style="display:none;">Previous</button>
+									<button type="button" id="feedbackNext" class="btn btn-primary">Next <i class="fa fa-arrow-right"></i></button>
+									<button type="submit" id="feedbackSubmit" class="btn btn-success" style="display:none;">Submit</button>
 								</div>
-							@endforeach
-							<div class="form-group">
-								<button type="submit" class="btn btn-success">Submit</button>
-							</div>
 						</form>
 					@endif
 				</div>

--- a/tests/Feature/Account/Feedback/FeedbackTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackTest.php
@@ -225,6 +225,134 @@ class FeedbackTest extends TestCase
             ->assertSessionHas('success');
     }
 
+    #[Test]
+    public function test_it_orders_questions_by_page_then_sequence()
+    {
+        $form = Form::whereSlug('atc')->first();
+        if (! $form) {
+            $this->markTestSkipped('could not find atc form');
+        }
+
+        $response = $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new.form', $form->slug));
+
+        $response->assertSuccessful();
+
+        $questions = $form->questions()->orderBy('page')->orderBy('sequence')->get();
+        $previousPage = 0;
+        $previousSequence = 0;
+        foreach ($questions as $question) {
+            if ($question->page === $previousPage) {
+                $this->assertGreaterThan($previousSequence, $question->sequence);
+            } else {
+                $this->assertGreaterThan($previousPage, $question->page);
+            }
+            $previousPage = $question->page;
+            $previousSequence = $question->sequence;
+        }
+    }
+
+    #[Test]
+    public function test_it_renders_feedback_page_navigation_elements()
+    {
+        $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new.form', $this->form->slug))
+            ->assertSuccessful()
+            ->assertSee('feedbackStep')
+            ->assertSee('feedbackPrev')
+            ->assertSee('feedbackNext')
+            ->assertSee('feedbackSubmit');
+    }
+
+    #[Test]
+    public function test_it_renders_step_indicator_with_page_count()
+    {
+        $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new.form', $this->form->slug))
+            ->assertSuccessful()
+            ->assertSee('Step')
+            ->assertSee('of');
+    }
+
+    #[Test]
+    public function test_it_renders_feedback_page_containers()
+    {
+        $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new.form', $this->form->slug))
+            ->assertSuccessful()
+            ->assertSee('feedback-page', false);
+    }
+
+    #[Test]
+    public function test_it_renders_required_data_attributes_on_form_groups()
+    {
+        $response = $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new.form', $this->form->slug));
+
+        $response->assertSuccessful();
+
+        $questions = $this->form->questions()->orderBy('page')->orderBy('sequence')->get();
+        $hasRequired = $questions->contains('required', true);
+        $hasOptional = $questions->contains('required', false);
+
+        if ($hasRequired) {
+            $response->assertSee('data-required="true"', false);
+        }
+        if ($hasOptional) {
+            $response->assertSee('data-required="false"', false);
+        }
+    }
+
+    #[Test]
+    public function test_it_groups_questions_by_page_in_response()
+    {
+        $response = $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new.form', $this->form->slug));
+
+        $response->assertSuccessful();
+
+        $questions = $this->form->questions()->orderBy('page')->orderBy('sequence')->get();
+        $pages = $questions->groupBy('page');
+
+        $html = $response->getContent();
+        foreach ($pages as $pageNum => $pageQuestions) {
+            foreach ($pageQuestions as $question) {
+                $this->assertStringContainsString(
+                    $question->question,
+                    $html,
+                    "Question '{$question->slug}' (page {$pageNum}) not found in response"
+                );
+            }
+        }
+    }
+
+    #[Test]
+    public function test_it_renders_multi_page_form_with_correct_step_count()
+    {
+        $response = $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new.form', $this->form->slug));
+
+        $response->assertSuccessful();
+
+        $questions = $this->form->questions()->orderBy('page')->orderBy('sequence')->get();
+        $pageCount = $questions->groupBy('page')->count();
+
+        $response->assertSee('of '.$pageCount);
+    }
+
+    #[Test]
+    public function test_it_renders_navigation_buttons_for_multi_page_form()
+    {
+        $response = $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new.form', $this->form->slug));
+
+        $response->assertSuccessful();
+
+        $response->assertSee('btn-default', false)
+            ->assertSee('btn-primary', false)
+            ->assertSee('btn-success', false);
+    }
+
     /**
      * Build form data with answers to all questions.
      */


### PR DESCRIPTION
# Summary of changes
- Adds `page` column
- Sorts feedback questions into pages

# Screenshots (if necessary)
<img width="672" height="333" alt="image" src="https://github.com/user-attachments/assets/ba456cf6-0d8f-4a63-a5aa-4c09a5ea5b39" />
<img width="762" height="443" alt="image" src="https://github.com/user-attachments/assets/e296fd89-7193-4014-9ae7-b37ec49c9ca1" />
<img width="757" height="412" alt="image" src="https://github.com/user-attachments/assets/a3e6472e-d1e0-4049-98bf-f39dc1b89536" />
