### PR TITLE
feat: add a restrictions system to feedback forms

### DIFF
--- a/app/Enums/Feedback/FormRestrictionSubject.php
+++ b/app/Enums/Feedback/FormRestrictionSubject.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums\Feedback;
+
+enum FormRestrictionSubject: string
+{
+    case Atc = 'atc';
+    case Pilot = 'pilot';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Atc => 'ATC',
+            self::Pilot => 'Pilot',
+        };
+    }
+}

--- a/app/Enums/Feedback/FormRestrictionType.php
+++ b/app/Enums/Feedback/FormRestrictionType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums\Feedback;
+
+enum FormRestrictionType: string
+{
+    case Qualification = 'qualification';
+    case Hours = 'hours';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Qualification => 'Minimum qualification',
+            self::Hours => 'Minimum hours',
+        };
+    }
+}

--- a/app/Enums/Feedback/FormRestrictionType.php
+++ b/app/Enums/Feedback/FormRestrictionType.php
@@ -6,12 +6,14 @@ enum FormRestrictionType: string
 {
     case Qualification = 'qualification';
     case Hours = 'hours';
+    case AccountAge = 'account_age';
 
     public function label(): string
     {
         return match ($this) {
             self::Qualification => 'Minimum qualification',
             self::Hours => 'Minimum hours',
+            self::AccountAge => 'Minimum account age',
         };
     }
 }

--- a/app/Http/Controllers/Mship/Feedback.php
+++ b/app/Http/Controllers/Mship/Feedback.php
@@ -20,15 +20,30 @@ class Feedback extends \App\Http\Controllers\BaseController
     public function getFeedbackFormSelect()
     {
         $forms = Form::whereEnabled(true)->orderBy('id', 'asc')->public()->getModels();
+
         $feedbackForms = [];
+        $ineligibleForms = [];
+
         foreach ($forms as $f) {
-            $feedbackForms[$f->slug] = $f->name;
+            if ($f->isEligibleFor(\Auth::user())) {
+                $feedbackForms[$f->slug] = $f->name;
+            } else {
+                $reasons = $f->unmetRestrictionsFor(\Auth::user())
+                    ->map(fn ($r) => $r->reason())
+                    ->all();
+
+                $ineligibleForms[$f->slug] = [
+                    'name' => $f->name,
+                    'reasons' => $reasons,
+                ];
+            }
         }
 
         $this->setTitle('Submit Feedback');
 
         return $this->viewMake('mship.feedback.form')
-            ->with('feedbackForms', $feedbackForms);
+            ->with('feedbackForms', $feedbackForms)
+            ->with('ineligibleForms', $ineligibleForms);
     }
 
     public function postFeedbackFormSelect(Request $request)
@@ -47,6 +62,11 @@ class Feedback extends \App\Http\Controllers\BaseController
 
     public function getFeedback(Form $form)
     {
+        if (! $form->isEligibleFor(\Auth::user())) {
+            return Redirect::route('mship.feedback.new')
+                ->withError('You do not meet the requirements to complete this feedback form.');
+        }
+
         /** @var Question[] $questions */
         $questions = $form->questions()->orderBy('page')->orderBy('sequence')->get();
         if (! $questions || ! $form->enabled) {
@@ -112,6 +132,11 @@ class Feedback extends \App\Http\Controllers\BaseController
 
     public function postFeedback(Form $form, Request $request)
     {
+        if (! $form->isEligibleFor(\Auth::user())) {
+            return Redirect::route('mship.feedback.new')
+                ->withError('You do not meet the requirements to complete this feedback form.');
+        }
+
         $questions = $form->questions;
         $cidfield = null;
         $datetimefield = null;

--- a/app/Http/Controllers/Mship/Feedback.php
+++ b/app/Http/Controllers/Mship/Feedback.php
@@ -28,8 +28,10 @@ class Feedback extends \App\Http\Controllers\BaseController
             if ($f->isEligibleFor(\Auth::user())) {
                 $feedbackForms[$f->slug] = $f->name;
             } else {
-                $reasons = $f->unmetRestrictionsFor(\Auth::user())
-                    ->map(fn ($r) => $r->reason())
+                $reasons = $f->unmetRestrictionGroupsFor(\Auth::user())
+                    ->map(function ($group) {
+                        return $group->map(fn ($r) => $r->reason())->implode(' or ');
+                    })
                     ->all();
 
                 $ineligibleForms[$f->slug] = [

--- a/app/Models/Mship/Feedback/Form.php
+++ b/app/Models/Mship/Feedback/Form.php
@@ -91,13 +91,26 @@ class Form extends Model
         return $this->hasMany(FormRestriction::class);
     }
 
+    /**
+     * Restrictions sharing a `restriction_group` are OR'd (any one satisfies the group).
+     * Ungrouped restrictions, and each distinct group, are AND'd together.
+     */
     public function isEligibleFor(Account $account): bool
     {
-        return $this->restrictions->every(fn (FormRestriction $r) => $r->isSatisfiedBy($account));
+        return $this->restrictionGroups()
+            ->every(fn ($group) => $group->contains(fn (FormRestriction $r) => $r->isSatisfiedBy($account)));
     }
 
-    public function unmetRestrictionsFor(Account $account)
+    public function unmetRestrictionGroupsFor(Account $account)
     {
-        return $this->restrictions->reject(fn (FormRestriction $r) => $r->isSatisfiedBy($account));
+        return $this->restrictionGroups()
+            ->reject(fn ($group) => $group->contains(fn (FormRestriction $r) => $r->isSatisfiedBy($account)));
+    }
+
+    private function restrictionGroups()
+    {
+        return $this->restrictions
+            ->groupBy(fn (FormRestriction $r) => $r->restriction_group ?? 'ungrouped-'.$r->id)
+            ->values();
     }
 }

--- a/app/Models/Mship/Feedback/Form.php
+++ b/app/Models/Mship/Feedback/Form.php
@@ -4,6 +4,7 @@ namespace App\Models\Mship\Feedback;
 
 use App\Models\Contact;
 use App\Models\Model;
+use App\Models\Mship\Account;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
@@ -83,5 +84,20 @@ class Form extends Model
     public function contact()
     {
         return $this->belongsTo(Contact::class);
+    }
+
+    public function restrictions()
+    {
+        return $this->hasMany(FormRestriction::class);
+    }
+
+    public function isEligibleFor(Account $account): bool
+    {
+        return $this->restrictions->every(fn (FormRestriction $r) => $r->isSatisfiedBy($account));
+    }
+
+    public function unmetRestrictionsFor(Account $account)
+    {
+        return $this->restrictions->reject(fn (FormRestriction $r) => $r->isSatisfiedBy($account));
     }
 }

--- a/app/Models/Mship/Feedback/FormRestriction.php
+++ b/app/Models/Mship/Feedback/FormRestriction.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Models\Mship\Feedback;
+
+use App\Enums\Feedback\FormRestrictionSubject;
+use App\Enums\Feedback\FormRestrictionType;
+use App\Models\Model;
+use App\Models\Mship\Account;
+use App\Models\Mship\Qualification;
+use App\Models\NetworkData\Atc;
+
+class FormRestriction extends Model
+{
+    protected $table = 'mship_feedback_form_restrictions';
+
+    protected $fillable = [
+        'form_id',
+        'type',
+        'subject',
+        'minimum_value',
+    ];
+
+    protected $casts = [
+        'type' => FormRestrictionType::class,
+        'subject' => FormRestrictionSubject::class,
+        'minimum_value' => 'integer',
+    ];
+
+    public function form()
+    {
+        return $this->belongsTo(Form::class);
+    }
+
+    public function isSatisfiedBy(Account $account): bool
+    {
+        return match ($this->type) {
+            FormRestrictionType::Qualification => $this->accountMeetsQualification($account),
+            FormRestrictionType::Hours => $this->accountMeetsHours($account),
+        };
+    }
+
+    private function accountMeetsQualification(Account $account): bool
+    {
+        $qualification = match ($this->subject) {
+            FormRestrictionSubject::Atc => $account->qualification_atc,
+            FormRestrictionSubject::Pilot => null, // extend when pilot qualification lookup is needed
+        };
+
+        if (! $qualification) {
+            return false;
+        }
+
+        return $qualification->vatsim >= $this->minimum_value;
+    }
+
+    private function accountMeetsHours(Account $account): bool
+    {
+        $totalMinutes = match ($this->subject) {
+            FormRestrictionSubject::Atc => Atc::query()
+                ->where('account_id', $account->id)
+                ->whereNotNull('minutes_online')
+                ->sum('minutes_online'),
+            FormRestrictionSubject::Pilot => 0, // extend when pilot hours source is available
+        };
+
+        return ($totalMinutes / 60) >= $this->minimum_value;
+    }
+
+    public function reason(): string
+    {
+        return match ($this->type) {
+            FormRestrictionType::Qualification => "requires at least a {$this->minimumQualificationCode()} rating to complete this feedback form",
+            FormRestrictionType::Hours => "requires at least {$this->minimum_value} {$this->subject->label()} hours to submit",
+        };
+    }
+
+    private function minimumQualificationCode(): string
+    {
+        $qualification = Qualification::ofType($this->subject->value)
+            ->networkValue($this->minimum_value)
+            ->first();
+
+        return $qualification->code;
+    }
+}

--- a/app/Models/Mship/Feedback/FormRestriction.php
+++ b/app/Models/Mship/Feedback/FormRestriction.php
@@ -95,7 +95,7 @@ class FormRestriction extends Model
             ->networkValue($this->minimum_value)
             ->first();
 
-        return $qualification->code;
+        return $qualification?->code ?? (string) $this->minimum_value;
     }
 
     private function minimumAgeDescription(): string

--- a/app/Models/Mship/Feedback/FormRestriction.php
+++ b/app/Models/Mship/Feedback/FormRestriction.php
@@ -15,6 +15,7 @@ class FormRestriction extends Model
 
     protected $fillable = [
         'form_id',
+        'restriction_group',
         'type',
         'subject',
         'minimum_value',
@@ -24,6 +25,7 @@ class FormRestriction extends Model
         'type' => FormRestrictionType::class,
         'subject' => FormRestrictionSubject::class,
         'minimum_value' => 'integer',
+        'restriction_group' => 'integer',
     ];
 
     public function form()
@@ -69,8 +71,8 @@ class FormRestriction extends Model
     public function reason(): string
     {
         return match ($this->type) {
-            FormRestrictionType::Qualification => "requires at least a {$this->minimumQualificationCode()} rating to complete this feedback form",
-            FormRestrictionType::Hours => "requires at least {$this->minimum_value} {$this->subject->label()} hours to submit",
+            FormRestrictionType::Qualification => "requires at least a {$this->minimumQualificationCode()} rating",
+            FormRestrictionType::Hours => "requires at least {$this->minimum_value} {$this->subject->label()} hours",
         };
     }
 

--- a/app/Models/Mship/Feedback/FormRestriction.php
+++ b/app/Models/Mship/Feedback/FormRestriction.php
@@ -38,6 +38,7 @@ class FormRestriction extends Model
         return match ($this->type) {
             FormRestrictionType::Qualification => $this->accountMeetsQualification($account),
             FormRestrictionType::Hours => $this->accountMeetsHours($account),
+            FormRestrictionType::AccountAge => $this->accountMeetsAge($account),
         };
     }
 
@@ -45,7 +46,8 @@ class FormRestriction extends Model
     {
         $qualification = match ($this->subject) {
             FormRestrictionSubject::Atc => $account->qualification_atc,
-            FormRestrictionSubject::Pilot => null, // extend when pilot qualification lookup is needed
+            FormRestrictionSubject::Pilot => null,
+            null => null,
         };
 
         if (! $qualification) {
@@ -62,10 +64,20 @@ class FormRestriction extends Model
                 ->where('account_id', $account->id)
                 ->whereNotNull('minutes_online')
                 ->sum('minutes_online'),
-            FormRestrictionSubject::Pilot => 0, // extend when pilot hours source is available
+            FormRestrictionSubject::Pilot => 0,
+            null => 0,
         };
 
         return ($totalMinutes / 60) >= $this->minimum_value;
+    }
+
+    private function accountMeetsAge(Account $account): bool
+    {
+        if (! $account->joined_at) {
+            return false;
+        }
+
+        return $account->joined_at->diffInDays(now()) >= $this->minimum_value;
     }
 
     public function reason(): string
@@ -73,6 +85,7 @@ class FormRestriction extends Model
         return match ($this->type) {
             FormRestrictionType::Qualification => "requires at least a {$this->minimumQualificationCode()} rating",
             FormRestrictionType::Hours => "requires at least {$this->minimum_value} {$this->subject->label()} hours",
+            FormRestrictionType::AccountAge => "requires your account to be at least {$this->minimumAgeDescription()} old",
         };
     }
 
@@ -83,5 +96,24 @@ class FormRestriction extends Model
             ->first();
 
         return $qualification->code;
+    }
+
+    private function minimumAgeDescription(): string
+    {
+        $days = $this->minimum_value;
+
+        if ($days % 365 === 0 && $days >= 365) {
+            $years = intdiv($days, 365);
+
+            return $years === 1 ? '1 year' : "{$years} years";
+        }
+
+        if ($days % 30 === 0 && $days >= 30) {
+            $months = intdiv($days, 30);
+
+            return $months === 1 ? '1 month' : "{$months} months";
+        }
+
+        return $days === 1 ? '1 day' : "{$days} days";
     }
 }

--- a/database/migrations/2026_08_23_164200_create_mship_feedback_form_restrictions_table.php
+++ b/database/migrations/2026_08_23_164200_create_mship_feedback_form_restrictions_table.php
@@ -13,14 +13,12 @@ return new class extends Migration
         Schema::create('mship_feedback_form_restrictions', function (Blueprint $table) {
             $table->id();
             $table->foreignId('form_id')->constrained('mship_feedback_forms')->cascadeOnDelete();
-
+            $table->unsignedInteger('restriction_group')->nullable();
             $table->enum('type', array_column(FormRestrictionType::cases(), 'value'));
             $table->enum('subject', array_column(FormRestrictionSubject::cases(), 'value'));
-
             // For 'qualification': minimum qualification 'vatsim' rank value required (>=)
             // For 'hours': minimum number of hours required (>=)
             $table->unsignedInteger('minimum_value');
-
             $table->timestamps();
         });
     }

--- a/database/migrations/2026_08_23_164200_create_mship_feedback_form_restrictions_table.php
+++ b/database/migrations/2026_08_23_164200_create_mship_feedback_form_restrictions_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->foreignId('form_id')->constrained('mship_feedback_forms')->cascadeOnDelete();
             $table->unsignedInteger('restriction_group')->nullable();
             $table->enum('type', array_column(FormRestrictionType::cases(), 'value'));
-            $table->enum('subject', array_column(FormRestrictionSubject::cases(), 'value'));
+            $table->enum('subject', array_column(FormRestrictionSubject::cases(), 'value'))->nullable();
             // For 'qualification': minimum qualification 'vatsim' rank value required (>=)
             // For 'hours': minimum number of hours required (>=)
             $table->unsignedInteger('minimum_value');

--- a/database/migrations/2026_08_23_164200_create_mship_feedback_form_restrictions_table.php
+++ b/database/migrations/2026_08_23_164200_create_mship_feedback_form_restrictions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Enums\Feedback\FormRestrictionSubject;
+use App\Enums\Feedback\FormRestrictionType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mship_feedback_form_restrictions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('form_id')->constrained('mship_feedback_forms')->cascadeOnDelete();
+
+            $table->enum('type', array_column(FormRestrictionType::cases(), 'value'));
+            $table->enum('subject', array_column(FormRestrictionSubject::cases(), 'value'));
+
+            // For 'qualification': minimum qualification 'vatsim' rank value required (>=)
+            // For 'hours': minimum number of hours required (>=)
+            $table->unsignedInteger('minimum_value');
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mship_feedback_form_restrictions');
+    }
+};

--- a/resources/views/mship/feedback/form.blade.php
+++ b/resources/views/mship/feedback/form.blade.php
@@ -102,6 +102,23 @@
 								<button type="submit" class="btn btn-primary">Next <i class="fa fa-arrow-right"></i></button>
 							</p>
 						</form>
+
+						@if (!empty($ineligibleForms))
+							<hr>
+							<p class="text-muted"><small>The following feedback types are currently unavailable to you:</small></p>
+							<ul class="list-unstyled">
+								@foreach ($ineligibleForms as $slug => $data)
+									<li class="text-muted" style="margin-bottom: 8px;">
+										<i class="fa fa-lock" aria-hidden="true"></i>
+										<b>{{ $data['name'] }}</b>
+										-
+										@foreach ($data['reasons'] as $i => $reason)
+											{{ $reason }}{{ !$loop->last ? ', and ' : '' }}
+										@endforeach
+									</li>
+								@endforeach
+							</ul>
+						@endif
 					@else
 						<form method="POST" action="{{ route('mship.feedback.new.form.post', $form) }}" autocomplete="off">
 							@csrf

--- a/tests/Feature/Account/Feedback/FeedbackRestrictionsTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackRestrictionsTest.php
@@ -506,4 +506,194 @@ class FeedbackRestrictionsTest extends TestCase
         $this->assertCount(1, $unmetGroups);
         $this->assertCount(2, $unmetGroups->first());
     }
+
+    #[Test]
+    public function test_form_eligible_when_account_age_restriction_satisfied()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::AccountAge,
+            'subject' => null,
+            'minimum_value' => 90,
+        ]);
+
+        $account = Account::factory()->create([
+            'joined_at' => now()->subDays(200),
+        ]);
+
+        $this->assertTrue($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_form_ineligible_when_account_age_restriction_not_satisfied()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::AccountAge,
+            'subject' => null,
+            'minimum_value' => 90,
+        ]);
+
+        $account = Account::factory()->create([
+            'joined_at' => now()->subDays(10),
+        ]);
+
+        $this->assertFalse($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_form_eligible_when_account_age_exactly_meets_minimum()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::AccountAge,
+            'subject' => null,
+            'minimum_value' => 90,
+        ]);
+
+        $account = Account::factory()->create([
+            'joined_at' => now()->subDays(90),
+        ]);
+
+        $this->assertTrue($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_account_with_no_joined_at_fails_account_age_restriction()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::AccountAge,
+            'subject' => null,
+            'minimum_value' => 1,
+        ]);
+
+        $account = Account::factory()->create([
+            'joined_at' => null,
+        ]);
+
+        $this->assertFalse($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_account_age_reason_message_describes_days()
+    {
+        $restriction = FormRestriction::create([
+            'form_id' => Form::whereSlug('atc')->first()->id,
+            'type' => FormRestrictionType::AccountAge,
+            'subject' => null,
+            'minimum_value' => 10,
+        ]);
+
+        $reason = $restriction->reason();
+
+        $this->assertIsString($reason);
+        $this->assertStringContainsString('10 days', $reason);
+    }
+
+    #[Test]
+    public function test_account_age_reason_message_describes_months()
+    {
+        $restriction = FormRestriction::create([
+            'form_id' => Form::whereSlug('atc')->first()->id,
+            'type' => FormRestrictionType::AccountAge,
+            'subject' => null,
+            'minimum_value' => 60,
+        ]);
+
+        $reason = $restriction->reason();
+
+        $this->assertStringContainsString('2 months', $reason);
+    }
+
+    #[Test]
+    public function test_account_age_reason_message_describes_years()
+    {
+        $restriction = FormRestriction::create([
+            'form_id' => Form::whereSlug('atc')->first()->id,
+            'type' => FormRestrictionType::AccountAge,
+            'subject' => null,
+            'minimum_value' => 365,
+        ]);
+
+        $reason = $restriction->reason();
+
+        $this->assertStringContainsString('1 year', $reason);
+    }
+
+    #[Test]
+    public function test_account_age_and_qualification_restrictions_are_both_mandatory_when_ungrouped()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::AccountAge,
+            'subject' => null,
+            'minimum_value' => 90,
+        ]);
+
+        $account = Account::factory()->create([
+            'joined_at' => now()->subDays(10),
+        ]);
+        $account->qualifications()->attach($qualification->id);
+
+        $this->assertFalse($form->isEligibleFor($account->fresh()));
+    }
+
+    #[Test]
+    public function test_account_age_can_be_one_of_several_or_alternatives_in_a_group()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::AccountAge,
+            'subject' => null,
+            'minimum_value' => 365, // not satisfied
+        ]);
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 10,
+        ]);
+
+        $account = Account::factory()->create([
+            'joined_at' => now()->subDays(10),
+        ]);
+
+        $session = new Atc([
+            'account_id' => $account->id,
+            'qualification_id' => 1,
+            'callsign' => 'EGLL_TWR',
+            'facility_type' => Atc::TYPE_TWR,
+            'connected_at' => now()->subHours(12),
+            'disconnected_at' => now()->subHours(1),
+        ]);
+        $session->minutes_online = 660;
+        $session->timestamps = false;
+        $session->save();
+
+        $this->assertTrue($form->isEligibleFor($account));
+    }
 }

--- a/tests/Feature/Account/Feedback/FeedbackRestrictionsTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackRestrictionsTest.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace Tests\Feature\Account\Feedback;
+
+use App\Enums\Feedback\FormRestrictionSubject;
+use App\Enums\Feedback\FormRestrictionType;
+use App\Models\Mship\Account;
+use App\Models\Mship\Feedback\Form;
+use App\Models\Mship\Feedback\FormRestriction;
+use App\Models\Mship\Qualification;
+use App\Models\NetworkData\Atc;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class FeedbackRestrictionsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function test_form_eligible_with_no_restrictions()
+    {
+        $form = Form::whereSlug('atc')->first();
+        $account = Account::factory()->create();
+
+        $this->assertTrue($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_form_eligible_when_qualification_restriction_satisfied()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+
+        $account = Account::factory()->create();
+        $account->qualifications()->attach($qualification->id);
+
+        $this->assertTrue($form->isEligibleFor($account->fresh()));
+    }
+
+    #[Test]
+    public function test_form_ineligible_when_qualification_restriction_not_satisfied()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 5, // C1 rating
+        ]);
+
+        $account = Account::factory()->create();
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+        $account->qualifications()->attach($qualification->id);
+
+        $this->assertFalse($form->isEligibleFor($account->fresh()));
+    }
+
+    #[Test]
+    public function test_form_eligible_when_hours_restriction_satisfied()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 10, // 10 hours
+        ]);
+
+        $account = Account::factory()->create();
+
+        // Create ATC sessions totaling more than 10 hours (600 minutes)
+        Atc::create([
+            'account_id' => $account->id,
+            'qualification_id' => 1,
+            'callsign' => 'EGLL_TWR',
+            'facility_type' => Atc::TYPE_TWR,
+            'connected_at' => now()->subHours(12),
+            'disconnected_at' => now()->subHours(1),
+            'minutes_online' => 660,
+        ]);
+
+        $this->assertTrue($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_form_ineligible_when_hours_restriction_not_satisfied()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 100, // 100 hours
+        ]);
+
+        $account = Account::factory()->create();
+
+        // Create ATC sessions totaling only 5 hours
+        Atc::create([
+            'account_id' => $account->id,
+            'qualification_id' => 1,
+            'callsign' => 'EGLL_TWR',
+            'facility_type' => Atc::TYPE_TWR,
+            'connected_at' => now()->subHours(6),
+            'disconnected_at' => now()->subHours(1),
+            'minutes_online' => 300,
+        ]);
+
+        $this->assertFalse($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_unmet_restrictions_returns_only_failed_restrictions()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        // Add a satisfied restriction
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+
+        // Add an unsatisfied restriction
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 100,
+        ]);
+
+        $account = Account::factory()->create();
+        $account->qualifications()->attach($qualification->id);
+
+        $unmet = $form->unmetRestrictionsFor($account->fresh());
+
+        $this->assertCount(1, $unmet);
+        $this->assertEquals(FormRestrictionType::Hours, $unmet->first()->type);
+    }
+
+    #[Test]
+    public function test_form_selector_shows_eligible_forms()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $response = $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new'));
+
+        $response->assertSuccessful();
+        $response->assertSee($form->name);
+    }
+
+    #[Test]
+    public function test_form_selector_shows_ineligible_forms_with_reasons()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 100,
+        ]);
+
+        $response = $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new'));
+
+        $response->assertSuccessful();
+        $response->assertSee('unavailable');
+        $response->assertSee('100');
+    }
+
+    #[Test]
+    public function test_ineligible_user_redirected_from_form_view()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 100,
+        ]);
+
+        $this->actingAs($this->user, 'web')
+            ->get(route('mship.feedback.new.form', $form->slug))
+            ->assertRedirect(route('mship.feedback.new'))
+            ->assertSessionHas('error');
+    }
+
+    #[Test]
+    public function test_ineligible_user_redirected_from_submission()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 100,
+        ]);
+
+        $this->actingAs($this->user, 'web')
+            ->post(route('mship.feedback.new.form.post', $form->slug), [])
+            ->assertRedirect(route('mship.feedback.new'))
+            ->assertSessionHas('error');
+    }
+
+    #[Test]
+    public function test_qualification_reason_message()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $restriction = FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2, // S1
+        ]);
+
+        $reason = $restriction->reason();
+
+        $this->assertIsString($reason);
+        $this->assertNotEmpty($reason);
+        $this->assertStringContainsString('S1', $reason);
+    }
+
+    #[Test]
+    public function test_hours_reason_message()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $restriction = FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 100,
+        ]);
+
+        $reason = $restriction->reason();
+
+        $this->assertIsString($reason);
+        $this->assertStringContainsString('100', $reason);
+        $this->assertStringContainsString('hours', $reason);
+    }
+
+    #[Test]
+    public function test_multiple_restrictions_all_must_be_satisfied()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+
+        // Qualification restriction (satisfied)
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+
+        // Hours restriction (not satisfied)
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 100,
+        ]);
+
+        $account = Account::factory()->create();
+        $account->qualifications()->attach($qualification->id);
+
+        $this->assertFalse($form->isEligibleFor($account->fresh()));
+    }
+
+    #[Test]
+    public function test_form_restriction_belongs_to_form()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $restriction = FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 10,
+        ]);
+
+        $this->assertInstanceOf(Form::class, $restriction->form);
+        $this->assertEquals($form->id, $restriction->form->id);
+    }
+
+    #[Test]
+    public function test_account_with_no_atc_qualification_fails_qualification_restriction()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+
+        $account = Account::factory()->create();
+        // No qualification attached
+
+        $this->assertFalse($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_account_with_no_atc_hours_fails_hours_restriction()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 10,
+        ]);
+
+        $account = Account::factory()->create();
+        // No ATC sessions
+
+        $this->assertFalse($form->isEligibleFor($account));
+    }
+}

--- a/tests/Feature/Account/Feedback/FeedbackRestrictionsTest.php
+++ b/tests/Feature/Account/Feedback/FeedbackRestrictionsTest.php
@@ -79,16 +79,17 @@ class FeedbackRestrictionsTest extends TestCase
 
         $account = Account::factory()->create();
 
-        // Create ATC sessions totaling more than 10 hours (600 minutes)
-        Atc::create([
+        $session = new Atc([
             'account_id' => $account->id,
             'qualification_id' => 1,
             'callsign' => 'EGLL_TWR',
             'facility_type' => Atc::TYPE_TWR,
             'connected_at' => now()->subHours(12),
             'disconnected_at' => now()->subHours(1),
-            'minutes_online' => 660,
         ]);
+        $session->minutes_online = 660;
+        $session->timestamps = false;
+        $session->save();
 
         $this->assertTrue($form->isEligibleFor($account));
     }
@@ -107,16 +108,17 @@ class FeedbackRestrictionsTest extends TestCase
 
         $account = Account::factory()->create();
 
-        // Create ATC sessions totaling only 5 hours
-        Atc::create([
+        $session = new Atc([
             'account_id' => $account->id,
             'qualification_id' => 1,
             'callsign' => 'EGLL_TWR',
             'facility_type' => Atc::TYPE_TWR,
             'connected_at' => now()->subHours(6),
             'disconnected_at' => now()->subHours(1),
-            'minutes_online' => 300,
         ]);
+        $session->minutes_online = 300;
+        $session->timestamps = false;
+        $session->save();
 
         $this->assertFalse($form->isEligibleFor($account));
     }
@@ -126,7 +128,6 @@ class FeedbackRestrictionsTest extends TestCase
     {
         $form = Form::whereSlug('atc')->first();
 
-        // Add a satisfied restriction
         $qualification = Qualification::ofType('atc')->networkValue(2)->first();
         FormRestriction::create([
             'form_id' => $form->id,
@@ -135,7 +136,6 @@ class FeedbackRestrictionsTest extends TestCase
             'minimum_value' => 2,
         ]);
 
-        // Add an unsatisfied restriction
         FormRestriction::create([
             'form_id' => $form->id,
             'type' => FormRestrictionType::Hours,
@@ -146,7 +146,8 @@ class FeedbackRestrictionsTest extends TestCase
         $account = Account::factory()->create();
         $account->qualifications()->attach($qualification->id);
 
-        $unmet = $form->unmetRestrictionsFor($account->fresh());
+        $unmet = $form->unmetRestrictionGroupsFor($account->fresh())
+            ->flatten();
 
         $this->assertCount(1, $unmet);
         $this->assertEquals(FormRestrictionType::Hours, $unmet->first()->type);
@@ -221,89 +222,6 @@ class FeedbackRestrictionsTest extends TestCase
     }
 
     #[Test]
-    public function test_qualification_reason_message()
-    {
-        $form = Form::whereSlug('atc')->first();
-
-        $restriction = FormRestriction::create([
-            'form_id' => $form->id,
-            'type' => FormRestrictionType::Qualification,
-            'subject' => FormRestrictionSubject::Atc,
-            'minimum_value' => 2, // S1
-        ]);
-
-        $reason = $restriction->reason();
-
-        $this->assertIsString($reason);
-        $this->assertNotEmpty($reason);
-        $this->assertStringContainsString('S1', $reason);
-    }
-
-    #[Test]
-    public function test_hours_reason_message()
-    {
-        $form = Form::whereSlug('atc')->first();
-
-        $restriction = FormRestriction::create([
-            'form_id' => $form->id,
-            'type' => FormRestrictionType::Hours,
-            'subject' => FormRestrictionSubject::Atc,
-            'minimum_value' => 100,
-        ]);
-
-        $reason = $restriction->reason();
-
-        $this->assertIsString($reason);
-        $this->assertStringContainsString('100', $reason);
-        $this->assertStringContainsString('hours', $reason);
-    }
-
-    #[Test]
-    public function test_multiple_restrictions_all_must_be_satisfied()
-    {
-        $form = Form::whereSlug('atc')->first();
-
-        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
-
-        // Qualification restriction (satisfied)
-        FormRestriction::create([
-            'form_id' => $form->id,
-            'type' => FormRestrictionType::Qualification,
-            'subject' => FormRestrictionSubject::Atc,
-            'minimum_value' => 2,
-        ]);
-
-        // Hours restriction (not satisfied)
-        FormRestriction::create([
-            'form_id' => $form->id,
-            'type' => FormRestrictionType::Hours,
-            'subject' => FormRestrictionSubject::Atc,
-            'minimum_value' => 100,
-        ]);
-
-        $account = Account::factory()->create();
-        $account->qualifications()->attach($qualification->id);
-
-        $this->assertFalse($form->isEligibleFor($account->fresh()));
-    }
-
-    #[Test]
-    public function test_form_restriction_belongs_to_form()
-    {
-        $form = Form::whereSlug('atc')->first();
-
-        $restriction = FormRestriction::create([
-            'form_id' => $form->id,
-            'type' => FormRestrictionType::Hours,
-            'subject' => FormRestrictionSubject::Atc,
-            'minimum_value' => 10,
-        ]);
-
-        $this->assertInstanceOf(Form::class, $restriction->form);
-        $this->assertEquals($form->id, $restriction->form->id);
-    }
-
-    #[Test]
     public function test_account_with_no_atc_qualification_fails_qualification_restriction()
     {
         $form = Form::whereSlug('atc')->first();
@@ -334,8 +252,258 @@ class FeedbackRestrictionsTest extends TestCase
         ]);
 
         $account = Account::factory()->create();
-        // No ATC sessions
 
         $this->assertFalse($form->isEligibleFor($account));
+    }
+
+    /*
+     * Group (OR) and cross-group (AND) logic
+     */
+
+    #[Test]
+    public function test_grouped_restrictions_are_eligible_when_only_one_alternative_is_satisfied()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 5,
+        ]);
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 10,
+        ]);
+
+        $account = Account::factory()->create();
+
+        $session = new Atc([
+            'account_id' => $account->id,
+            'qualification_id' => 1,
+            'callsign' => 'EGLL_TWR',
+            'facility_type' => Atc::TYPE_TWR,
+            'connected_at' => now()->subHours(12),
+            'disconnected_at' => now()->subHours(1),
+        ]);
+        $session->minutes_online = 660;
+        $session->timestamps = false;
+        $session->save();
+
+        $this->assertTrue($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_grouped_restrictions_are_ineligible_when_no_alternative_is_satisfied()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 5,
+        ]);
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 100,
+        ]);
+
+        $account = Account::factory()->create();
+
+        $session = new Atc([
+            'account_id' => $account->id,
+            'qualification_id' => 1,
+            'callsign' => 'EGLL_TWR',
+            'facility_type' => Atc::TYPE_TWR,
+            'connected_at' => now()->subHours(6),
+            'disconnected_at' => now()->subHours(1),
+        ]);
+        $session->minutes_online = 300;
+        $session->timestamps = false;
+        $session->save();
+
+        $this->assertFalse($form->isEligibleFor($account));
+    }
+
+    #[Test]
+    public function test_different_groups_are_and_ed_together()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 2,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 50,
+        ]);
+
+        $account = Account::factory()->create();
+        $account->qualifications()->attach($qualification->id);
+
+        $this->assertFalse($form->isEligibleFor($account->fresh()));
+    }
+
+    #[Test]
+    public function test_different_groups_all_satisfied_makes_form_eligible()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 2,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 10,
+        ]);
+
+        $account = Account::factory()->create();
+        $account->qualifications()->attach($qualification->id);
+
+        $session = new Atc([
+            'account_id' => $account->id,
+            'qualification_id' => 1,
+            'callsign' => 'EGLL_TWR',
+            'facility_type' => Atc::TYPE_TWR,
+            'connected_at' => now()->subHours(12),
+            'disconnected_at' => now()->subHours(1),
+        ]);
+        $session->minutes_online = 660;
+        $session->timestamps = false;
+        $session->save();
+
+        $this->assertTrue($form->isEligibleFor($account->fresh()));
+    }
+
+    #[Test]
+    public function test_ungrouped_restriction_is_mandatory_alongside_a_satisfied_group()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 500,
+        ]);
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => null,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 50,
+        ]);
+
+        $account = Account::factory()->create();
+        $account->qualifications()->attach($qualification->id);
+
+        $this->assertFalse($form->isEligibleFor($account->fresh()));
+    }
+
+    #[Test]
+    public function test_two_ungrouped_restrictions_are_each_independently_mandatory()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => null,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => null,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 50,
+        ]);
+
+        $account = Account::factory()->create();
+        $account->qualifications()->attach($qualification->id);
+
+        $this->assertFalse($form->isEligibleFor($account->fresh()));
+    }
+
+    #[Test]
+    public function test_unmet_restriction_groups_returns_only_the_failed_group()
+    {
+        $form = Form::whereSlug('atc')->first();
+
+        $qualification = Qualification::ofType('atc')->networkValue(2)->first();
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 1,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 2,
+        ]);
+
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 2,
+            'type' => FormRestrictionType::Hours,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 50,
+        ]);
+        FormRestriction::create([
+            'form_id' => $form->id,
+            'restriction_group' => 2,
+            'type' => FormRestrictionType::Qualification,
+            'subject' => FormRestrictionSubject::Atc,
+            'minimum_value' => 5,
+        ]);
+
+        $account = Account::factory()->create();
+        $account->qualifications()->attach($qualification->id);
+
+        $unmetGroups = $form->unmetRestrictionGroupsFor($account->fresh());
+
+        $this->assertCount(1, $unmetGroups);
+        $this->assertCount(2, $unmetGroups->first());
     }
 }


### PR DESCRIPTION
# Summary of changes
- Adds restrictions to feedback forms
- Allows us to OR or AND restrictions together

Current Restrictions Available:
1. Minimum ATC Qualification
2. Minimum Pilot Qualification
3. Minimum ATC Hours
4. Account age

# Screenshots (if necessary)
<img width="1067" height="324" alt="image" src="https://github.com/user-attachments/assets/56ba8623-75ed-4fe3-9d0c-b0c392286929" />
<img width="746" height="104" alt="image" src="https://github.com/user-attachments/assets/8db12514-69b2-4cde-aea7-a3788f5185ef" />

