### PR TITLE
fix: improve header styling on feedback resource page

### DIFF
--- a/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
+++ b/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
@@ -55,17 +55,17 @@ class FeedbackResource extends Resource
                 Section::make('Feedback Details')
                     ->heading(fn ($record) => $record->form?->name.' - '.$record->id)
                     ->columnSpanFull()
-                    ->columns(2)
+                    ->columns(fn () => self::canSeeSubmitter() ? 3 : 2)
                     ->schema([
                         TextEntry::make('subject_details')
                             ->label('Subject')
                             ->html()
                             ->state(function ($record) {
                                 $name = $record->account?->name;
-                                $qualification = $record->accountAtcQualification?->name ?? 'Not Found';
+                                $qualification = $record->accountAtcQualification?->code ?? 'Not Found';
 
                                 return Blade::render(
-                                    '{{ $name }} <x-filament::badge size="sm" color="info" class="ml-2">{{ $qualification }}</x-filament::badge>',
+                                    '{{ $name }}<x-filament::badge size="sm" color="info" class="ml-2">{{ $qualification }}</x-filament::badge>',
                                     [
                                         'name' => $name,
                                         'qualification' => $qualification,

--- a/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
+++ b/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
@@ -13,7 +13,6 @@ use App\Models\Mship\Qualification;
 use Filament\Actions\BulkAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\ViewAction;
-use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
@@ -22,6 +21,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\FontWeight;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
@@ -120,23 +120,7 @@ class FeedbackResource extends Resource
 
                 Section::make('Answers')
                     ->columnSpanFull()
-                    ->schema([
-                        Repeater::make('Answers')
-                            ->relationship('answers')
-                            ->label('')
-                            ->schema([
-                                TextEntry::make('question')
-                                    ->label('Question')
-                                    ->state(fn ($record) => $record->question?->question),
-
-                                TextEntry::make('response')
-                                    ->label('Answer')
-                                    ->suffixAction(CopyAction::make()
-                                        ->copyable(fn ($record) => $record->response)
-                                        ->successNotificationMessage('Copied!'))
-                                    ->state(fn ($record) => $record->response),
-                            ]),
-                    ]),
+                    ->schema(fn ($record) => self::answerPageFieldsets($record)),
             ]);
     }
 
@@ -351,5 +335,36 @@ class FeedbackResource extends Resource
             ->title("{$count} feedback record(s) {$successLabel} successfully.")
             ->success()
             ->send();
+    }
+
+    private static function answerPageFieldsets($record): array
+    {
+        $answersByPage = $record->answers()
+            ->with('question')
+            ->get()
+            ->filter(fn ($answer) => $answer->question !== null)
+            ->sortBy(fn ($answer) => $answer->question->sequence)
+            ->groupBy(fn ($answer) => $answer->question->page);
+
+        return $answersByPage
+            ->sortKeys()
+            ->map(function ($answers, $page) {
+                return Fieldset::make("Page {$page}")
+                    ->columnSpanFull()
+                    ->extraAttributes(['class' => '[&>legend]:hidden'])
+                    ->schema(
+                        $answers->map(fn ($answer) => TextEntry::make("answer_{$answer->id}")
+                            ->label($answer->question->question)
+                            ->columnSpanFull()
+                            ->state($answer->response)
+                            ->weight(FontWeight::Light)
+                            ->suffixAction(CopyAction::make()
+                                ->copyable(fn () => $answer->response)
+                                ->successNotificationMessage('Copied!'))
+                        )->all()
+                    );
+            })
+            ->values()
+            ->all();
     }
 }

--- a/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
+++ b/app/Filament/Admin/Resources/Feedback/FeedbackResource.php
@@ -30,6 +30,7 @@ use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Blade;
 use Webbingbrasil\FilamentCopyActions\Actions\CopyAction;
 
 class FeedbackResource extends Resource
@@ -51,29 +52,36 @@ class FeedbackResource extends Resource
     {
         return $schema
             ->components([
-                TextEntry::make('ID')
-                    ->label('ID')
-                    ->state(fn ($record) => $record->id),
+                Section::make('Feedback Details')
+                    ->heading(fn ($record) => $record->form?->name.' - '.$record->id)
+                    ->columnSpanFull()
+                    ->columns(2)
+                    ->schema([
+                        TextEntry::make('subject_details')
+                            ->label('Subject')
+                            ->html()
+                            ->state(function ($record) {
+                                $name = $record->account?->name;
+                                $qualification = $record->accountAtcQualification?->name ?? 'Not Found';
 
-                TextEntry::make('Form Name')
-                    ->state(fn ($record) => $record->form?->name),
+                                return Blade::render(
+                                    '{{ $name }} <x-filament::badge size="sm" color="info" class="ml-2">{{ $qualification }}</x-filament::badge>',
+                                    [
+                                        'name' => $name,
+                                        'qualification' => $qualification,
+                                    ]
+                                );
+                            }),
 
-                TextEntry::make('account.name')
-                    ->label('Subject')
-                    ->state(fn ($record) => $record->account?->name),
+                        TextEntry::make('submitter.name')
+                            ->label('Submitted by')
+                            ->visible(self::canSeeSubmitter())
+                            ->state(fn ($record) => $record->submitter?->name),
 
-                TextEntry::make('accountAtcQualification.name')
-                    ->label('Subject\'s ATC Qualification')
-                    ->state(fn ($record) => $record->accountAtcQualification?->name ?? 'Not Found'),
-
-                TextEntry::make('submitter.name')
-                    ->label('Submitted by')
-                    ->visible(self::canSeeSubmitter())
-                    ->state(fn ($record) => $record->submitter?->name),
-
-                TextEntry::make('created_at')
-                    ->label('Submitted at')
-                    ->state(fn ($record) => $record->created_at->format('d/m/Y H:i')),
+                        TextEntry::make('created_at')
+                            ->label('Submitted at')
+                            ->state(fn ($record) => $record->created_at->format('d/m/Y H:i')),
+                    ]),
 
                 Fieldset::make('Sent Information')->columnSpanFull()
                     ->schema([


### PR DESCRIPTION
# Summary of changes
- All the information shown is still the same, just displayed in a better way

# Screenshots (if necessary)
Before:
<img width="826" height="354" alt="image" src="https://github.com/user-attachments/assets/fab4c46c-c555-4612-bb8f-731eab2b2eaa" />

After:
<img width="836" height="664" alt="image" src="https://github.com/user-attachments/assets/f6be29eb-d47d-4fed-8733-06819f1b7242" />
