### PR TITLE
Add scrolling to bookings via url param

### DIFF
--- a/app/Livewire/Bookings/Calendar.php
+++ b/app/Livewire/Bookings/Calendar.php
@@ -110,13 +110,22 @@ class Calendar extends Component
     {
         $this->selectedDate = Carbon::today();
 
-        if ($year) {
+        $bookingId = request()->input('booking_id');
+        $booking = ctype_digit((string) $bookingId) ? Booking::find((int) $bookingId) : null;
+
+        if ($booking) {
+            $this->selectedDate = $booking->starts_at->copy()->startOfDay();
+        } elseif ($year) {
             $day = request()->input('day', 1);
             $this->selectedDate = Carbon::create($year, $month ?? $this->selectedDate->month, (int) $day);
         }
 
         $this->timelinePositions = [];
         $this->refreshData();
+
+        if ($booking) {
+            $this->dispatch('scroll-to-booking', source: 'core', id: $booking->id, ctsBookingId: null, instant: true);
+        }
     }
 
     public function render()

--- a/tests/Feature/Bookings/CalendarTest.php
+++ b/tests/Feature/Bookings/CalendarTest.php
@@ -44,6 +44,41 @@ class CalendarTest extends TestCase
     }
 
     #[Test]
+    public function it_jumps_to_and_scrolls_to_a_booking_id_without_needing_a_date(): void
+    {
+        $booking = Booking::factory()->create(['starts_at' => Carbon::create(2026, 9, 3, 10), 'ends_at' => Carbon::create(2026, 9, 3, 12)]);
+
+        Livewire::withQueryParams(['booking_id' => (string) $booking->id])
+            ->test(Calendar::class)
+            ->assertSet('selectedDate', Carbon::create(2026, 9, 3))
+            ->assertDispatched('scroll-to-booking', source: 'core', id: $booking->id, ctsBookingId: null, instant: true);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_scroll_to_booking_without_a_booking_id(): void
+    {
+        Livewire::test(Calendar::class)
+            ->assertNotDispatched('scroll-to-booking');
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_scroll_to_booking_for_a_non_numeric_booking_id(): void
+    {
+        Livewire::withQueryParams(['booking_id' => 'abc'])
+            ->test(Calendar::class)
+            ->assertNotDispatched('scroll-to-booking');
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_scroll_to_booking_for_an_unknown_booking_id(): void
+    {
+        Livewire::withQueryParams(['booking_id' => '999999999'])
+            ->test(Calendar::class)
+            ->assertSet('selectedDate', Carbon::today())
+            ->assertNotDispatched('scroll-to-booking');
+    }
+
+    #[Test]
     public function it_shows_the_weekday_before_the_selected_date(): void
     {
         Livewire::test(Calendar::class, ['year' => 2026, 'month' => 7])


### PR DESCRIPTION
Added `booking_id` query param which accepts core booking ID and scrolls + highlights it