### PR TITLE
Fix UTC midnight test runs

### DIFF
--- a/tests/Feature/TrainingPanel/Exams/UpcomingExamsTest.php
+++ b/tests/Feature/TrainingPanel/Exams/UpcomingExamsTest.php
@@ -199,6 +199,7 @@ class UpcomingExamsTest extends BaseTrainingPanelTestCase
     #[Test]
     public function it_does_not_show_exams_today_that_have_already_started(): void
     {
+        $this->travelTo(Carbon::parse('2026-01-01 10:00:00'));
         $this->panelUser->givePermissionTo('training.exams.view-upcoming.*');
 
         $student = $this->createStudent();

--- a/tests/Unit/CTS/BookingsRepositoryTest.php
+++ b/tests/Unit/CTS/BookingsRepositoryTest.php
@@ -33,8 +33,6 @@ class BookingsRepositoryTest extends TestCase
     {
         parent::setUp();
 
-        // These tests offset hours either side of "now" while pinning the date separately, so a
-        // run close to midnight puts the two on different days. Midday keeps them together.
         $this->knownDate = $this->knownDate->copy()->setTime(12, 0);
         $this->travelTo($this->knownDate);
 

--- a/tests/Unit/CTS/BookingsRepositoryTest.php
+++ b/tests/Unit/CTS/BookingsRepositoryTest.php
@@ -33,6 +33,11 @@ class BookingsRepositoryTest extends TestCase
     {
         parent::setUp();
 
+        // These tests offset hours either side of "now" while pinning the date separately, so a
+        // run close to midnight puts the two on different days. Midday keeps them together.
+        $this->knownDate = $this->knownDate->copy()->setTime(12, 0);
+        $this->travelTo($this->knownDate);
+
         $this->subjectUnderTest = resolve(BookingRepository::class);
         $this->today = $this->knownDate->toDateString();
         $this->tomorrow = $this->knownDate->copy()->addDay()->toDateString();


### PR DESCRIPTION
CTS likes to use date and time in different fields - when we travel in the tests around UTC midnight runtime tests get flaky