### PR TITLE
Show mentor unavailability when picking up students

### DIFF
--- a/app/Livewire/Training/AcceptedMentoringSessionsTable.php
+++ b/app/Livewire/Training/AcceptedMentoringSessionsTable.php
@@ -163,6 +163,32 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
         );
     }
 
+    protected function getMentorOverlappingSession(Get $get, Session $session): ?Session
+    {
+        $takenFrom = $get('taken_from');
+        $takenTo = $get('taken_to');
+        $availId = $get('selected_availability_id');
+        $ctsMentorId = $session->mentor_id;
+
+        if (! $takenFrom || ! $takenTo || ! $availId || ! $ctsMentorId) {
+            return null;
+        }
+
+        $availability = Availability::find($availId);
+
+        if (! $availability) {
+            return null;
+        }
+
+        return app(MentoringSessionsService::class)->checkForMentorOverlappingSession(
+            $ctsMentorId,
+            $availability->date,
+            $takenFrom,
+            $takenTo,
+            $session->id
+        );
+    }
+
     private function overlapForRecord(Session $record): Session|ExamBooking|null
     {
         return app(MentoringSessionsService::class)->findOverlappingBookingForSession($record);
@@ -431,6 +457,22 @@ class AcceptedMentoringSessionsTable extends Component implements HasActions, Ha
                     ->danger()
                     ->visible(function (Get $get) use ($record) {
                         return $this->getOverlappingBooking($get, $record) !== null;
+                    }),
+
+                Callout::make('mentor_overlapping_session')
+                    ->heading(fn () => app(MentoringSessionsService::class)->mentorOverlapHeading())
+                    ->description(function (Get $get) use ($record) {
+                        $overlap = $this->getMentorOverlappingSession($get, $record);
+
+                        if (! $overlap) {
+                            return '';
+                        }
+
+                        return app(MentoringSessionsService::class)->mentorOverlapDescription($overlap);
+                    })
+                    ->danger()
+                    ->visible(function (Get $get) use ($record) {
+                        return $this->getMentorOverlappingSession($get, $record) !== null;
                     }),
             ])
             ->action(function (array $data, Session $record, MentoringSessionsService $mentoringService) {

--- a/app/Livewire/Training/AvailabilityGantt.php
+++ b/app/Livewire/Training/AvailabilityGantt.php
@@ -22,6 +22,7 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Callout;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Utilities\Get;
+use Illuminate\Support\Collection;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 
@@ -178,6 +179,7 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
     public function render()
     {
         $students = $this->students;
+        $mentorSessions = $this->mentorSessions;
 
         $minHour = 24;
         $maxHour = 0;
@@ -193,6 +195,18 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
                 if ($endHour > $maxHour) {
                     $maxHour = $endHour;
                 }
+            }
+        }
+
+        foreach ($mentorSessions as $session) {
+            $startHour = (int) Carbon::parse($session->taken_from)->format('G');
+            $endHour = (int) Carbon::parse($session->taken_to)->format('G');
+
+            if ($startHour < $minHour) {
+                $minHour = $startHour;
+            }
+            if ($endHour > $maxHour) {
+                $maxHour = $endHour;
             }
         }
 
@@ -218,10 +232,25 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
 
         return view('livewire.training.availability-gantt', [
             'students' => $students,
+            'mentorSessions' => $mentorSessions,
             'hours' => range($startTimelineHour, $endTimelineHour),
             'displayDate' => Carbon::parse($this->date),
             'nowLinePercent' => $nowLinePercent,
         ]);
+    }
+
+    /**
+     * @return Collection<int, Session>
+     */
+    public function getMentorSessionsProperty(): Collection
+    {
+        $ctsMentorId = auth()->user()?->member?->id;
+
+        if (! $ctsMentorId) {
+            return collect();
+        }
+
+        return app(MentoringSessionsService::class)->getMentorSessionsForDate($ctsMentorId, $this->date);
     }
 
     public function acceptSessionAction(): Action
@@ -296,6 +325,7 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
                             ->label('End')
                             ->required()
                             ->searchable()
+                            ->live()
                             ->allowHtml(false)
                             ->searchPrompt('Type a time (e.g. 18:30) to filter the list')
                             ->after('taken_from')
@@ -372,6 +402,22 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
                         ->visible(function (Get $get) use ($availability, $pendingSession) {
                             return $this->getOverlappingBooking($get, $availability, $pendingSession) !== null;
                         }),
+
+                    Callout::make('mentor_overlapping_session')
+                        ->heading(fn () => app(MentoringSessionsService::class)->mentorOverlapHeading())
+                        ->description(function (Get $get) use ($availability) {
+                            $overlap = $this->getMentorOverlappingSession($get, $availability);
+
+                            if (! $overlap) {
+                                return '';
+                            }
+
+                            return app(MentoringSessionsService::class)->mentorOverlapDescription($overlap);
+                        })
+                        ->danger()
+                        ->visible(function (Get $get) use ($availability) {
+                            return $this->getMentorOverlappingSession($get, $availability) !== null;
+                        }),
                 ];
             })
             ->action(function (array $data, array $arguments, MentoringSessionsService $mentoringService) {
@@ -445,6 +491,25 @@ class AvailabilityGantt extends Component implements HasActions, HasForms
             $takenFrom,
             $takenTo,
             $pendingSession->id
+        );
+    }
+
+    protected function getMentorOverlappingSession(Get $get, Availability $availability, ?int $ignoreSessionId = null): ?Session
+    {
+        $takenFrom = $get('taken_from');
+        $takenTo = $get('taken_to');
+        $ctsMentorId = auth()->user()?->member?->id;
+
+        if (! $takenFrom || ! $takenTo || ! $ctsMentorId) {
+            return null;
+        }
+
+        return app(MentoringSessionsService::class)->checkForMentorOverlappingSession(
+            $ctsMentorId,
+            $availability->date,
+            $takenFrom,
+            $takenTo,
+            $ignoreSessionId
         );
     }
 

--- a/app/Services/Training/MentoringSessionsService.php
+++ b/app/Services/Training/MentoringSessionsService.php
@@ -25,6 +25,7 @@ use App\Notifications\Training\Mentoring\MentoringSessionRescheduledStudentNotif
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 
@@ -309,6 +310,60 @@ class MentoringSessionsService
         $staffName = $overlap instanceof Session ? $overlap->mentor?->name : $overlap->examiners?->primaryExaminer?->name;
 
         return "{$staffName} already has a {$type} booked on this position from {$from} to {$to}.";
+    }
+
+    /**
+     * Accepted, non-cancelled mentoring sessions for a mentor on a given date.
+     *
+     * @return Collection<int, Session>
+     */
+    public function getMentorSessionsForDate(int $ctsMentorId, string $date): Collection
+    {
+        return Session::query()
+            ->with('student')
+            ->where('mentor_id', $ctsMentorId)
+            ->where('taken', 1)
+            ->whereDate('taken_date', $date)
+            ->whereNotNull('taken_from')
+            ->whereNotNull('taken_to')
+            ->whereNull('cancelled_datetime')
+            ->orderBy('taken_from')
+            ->get();
+    }
+
+    public function checkForMentorOverlappingSession(
+        int $ctsMentorId,
+        string $date,
+        string $takenFrom,
+        string $takenTo,
+        ?int $ignoreSessionId = null,
+    ): ?Session {
+        return Session::query()
+            ->with('student')
+            ->where('mentor_id', $ctsMentorId)
+            ->where('taken', 1)
+            ->whereDate('taken_date', $date)
+            ->where('taken_from', '<', $takenTo)
+            ->where('taken_to', '>', $takenFrom)
+            ->whereNull('cancelled_datetime')
+            ->when($ignoreSessionId, function ($query, $ignoreSessionId) {
+                $query->where('id', '!=', $ignoreSessionId);
+            })
+            ->first();
+    }
+
+    public function mentorOverlapHeading(): string
+    {
+        return 'You Already Have a Session Booked';
+    }
+
+    public function mentorOverlapDescription(Session $overlap): string
+    {
+        $from = Carbon::parse($overlap->taken_from)->format('H:i');
+        $to = Carbon::parse($overlap->taken_to)->format('H:i');
+        $studentName = $overlap->student?->name ?? 'another student';
+
+        return "You already have a session with {$studentName} on {$overlap->position} from {$from} to {$to}.";
     }
 
     private function validateSessionTimes(Availability $availability, string $takenFrom, string $takenTo): void

--- a/database/seeders/LocalDevelopment/README.md
+++ b/database/seeders/LocalDevelopment/README.md
@@ -142,7 +142,7 @@ php artisan db:seed --class=Database\\Seeders\\LocalDevelopment\\Training\\CtsEx
 | `Concerns\CreatesLinkedAccount` | `firstOrCreate` mship `Account` + CTS `Member` + qualifications |
 | `Concerns\CreatesDevTrainingPlace` | Ad-hoc training place via `TrainingPlaceService` (CTS validations) |
 | `Concerns\SeedsCtsPosition` | `firstOrCreate` core `Position` and CTS `Position` for a callsign |
-| `Concerns\SeedsDevMentoringSessions` | Historical and pending CTS `sessions` for dev students |
+| `Concerns\SeedsDevMentoringSessions` | Historical, pending, accepted-for-date, and conduct CTS `sessions` for dev students |
 
 ## Idempotency
 
@@ -152,9 +152,31 @@ Seeders use `firstOrCreate` / `updateOrCreate` with stable keys (CIDs, callsigns
 
 | Seeder | Purpose |
 |--------|---------|
+| `Database\Seeders\LocalDevelopment\Training\DevMentorConductSeeder` | Mentoring conduct page fixtures for CID `10000005` (or existing account) |
+| `Database\Seeders\LocalDevelopment\Training\DevMentorUnavailabilitySeeder` | TECH-730 GANTT demo: mentor busy today + overlapping/clear student availability |
 | `Database\Seeders\Testing\PositionsAndEndorsementsSeeder` | Used internally by `AtcAndCtsTrainingPositionsSeeder` |
 | `Database\Seeders\Testing\CtsExamSeeder` | Legacy sample CTS exam bookings (unlinked to core accounts) |
 | `Database\Seeders\WaitingListStressSeeder` | Performance testing (~201 accounts on one list) |
+
+### `DevMentorUnavailabilitySeeder`
+
+Seeds **today’s** mentoring GANTT scenarios for stakeholder demos of mentor unavailability (TECH-730). Not run by the training orchestrator — invoke explicitly after `LocalDevelopmentTrainingSeeder`.
+
+| Role | Account | Position | Times | Purpose |
+|------|---------|----------|-------|---------|
+| Already accepted (busy) | `9000012` | `EGKK_TWR` | 18:00–20:00 | **My sessions** lane + busy bands |
+| Overlapping pickup | `9000010` | `EGLL_N_APP` | Availability 17:00–21:00 + pending request | Accept → mentor-busy callout |
+| Clear pickup | `9000011` | `EGKK_TWR` | Availability 14:00–16:00 + pending request | Conflict-free contrast |
+
+Demo mentor defaults to CID `10000005` (`DevTrainingPersonas::MENTOR_CONDUCT_CID`). Override with `DEV_MENTOR_CID=<sandbox-cid>` to attach fixtures to a real sandbox login.
+
+```shell
+php artisan db:seed --class=Database\\Seeders\\LocalDevelopmentTrainingSeeder
+php artisan db:seed --class=Database\\Seeders\\LocalDevelopment\\Training\\DevMentorUnavailabilitySeeder
+# optional: DEV_MENTOR_CID=<sandbox> php artisan db:seed --class=Database\\Seeders\\LocalDevelopment\\Training\\DevMentorUnavailabilitySeeder
+```
+
+Then: Training Panel → Mentoring → date = today → My sessions / busy bands → overlapping green slot (callout) → clear slot (no mentor-busy callout).
 
 ## Tests
 

--- a/database/seeders/LocalDevelopment/Training/Concerns/SeedsDevMentoringSessions.php
+++ b/database/seeders/LocalDevelopment/Training/Concerns/SeedsDevMentoringSessions.php
@@ -152,6 +152,39 @@ trait SeedsDevMentoringSessions
     }
 
     /**
+     * Accepted upcoming mentoring session for a mentor on a specific date (demo / local fixtures).
+     */
+    protected function seedDevAcceptedSessionForDate(
+        Member $student,
+        Member $mentor,
+        string $position,
+        string $date,
+        string $from,
+        string $to,
+    ): Session {
+        return $this->upsertDevMentoringSession(
+            [
+                'student_id' => $student->id,
+                'position' => $position,
+                'mentor_id' => $mentor->id,
+                'taken_date' => $date,
+                'session_done' => 0,
+            ],
+            [
+                'mentor_rating' => 3,
+                'taken' => 1,
+                'taken_time' => now()->subHour(),
+                'taken_from' => $from,
+                'taken_to' => $to,
+                'cancelled_datetime' => null,
+                'filed' => null,
+                'noShow' => 0,
+                'request_time' => now()->subDays(2),
+            ],
+        );
+    }
+
+    /**
      * Accepted session past its scheduled time, awaiting a filed report (conduct page).
      */
     protected function seedDevPendingConductSession(Member $student, Member $mentor, string $position, int $progressSheetId = 1): Session

--- a/database/seeders/LocalDevelopment/Training/DevMentorUnavailabilitySeeder.php
+++ b/database/seeders/LocalDevelopment/Training/DevMentorUnavailabilitySeeder.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\LocalDevelopment\Training;
+
+use App\Models\Cts\Availability;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
+use App\Models\Training\TrainingPosition\TrainingPosition;
+use App\Services\Training\MentorPermissionService;
+use Database\Seeders\LocalDevelopment\Training\Concerns\CreatesLinkedAccount;
+use Database\Seeders\LocalDevelopment\Training\Concerns\SeedsDevMentoringSessions;
+use Illuminate\Database\Seeder;
+use RuntimeException;
+
+/**
+ * Seeds mentoring GANTT fixtures so a mentor can demo TECH-730 mentor unavailability on today's timeline.
+ *
+ * @see database/seeders/LocalDevelopment/README.md
+ */
+class DevMentorUnavailabilitySeeder extends Seeder
+{
+    use CreatesLinkedAccount;
+    use SeedsDevMentoringSessions;
+
+    public function run(): void
+    {
+        $this->ensurePrerequisites();
+
+        $mentor = $this->resolveMentorAccount();
+        $mentorMember = Member::query()->where('cid', $mentor->id)->firstOrFail();
+
+        $busyStudent = Member::query()->where('cid', DevTrainingPersonas::STUDENT_EXAMS_CID)->firstOrFail();
+        $overlappingStudent = Member::query()->where('cid', DevTrainingPersonas::STUDENT_CID)->firstOrFail();
+        $clearStudent = Member::query()->where('cid', DevTrainingPersonas::STUDENT_LOA_CID)->firstOrFail();
+
+        $mentor->givePermissionTo([
+            'training.access',
+            'training.beta',
+            'training.mentors.view.atc',
+        ]);
+
+        $this->assignMentorToPosition($mentor, 'EGKK_TWR', 'S2 Training');
+        $this->assignMentorToPosition($mentor, 'EGLL_N_APP', 'S3 Training');
+
+        $today = now()->format('Y-m-d');
+
+        $this->seedDevAcceptedSessionForDate(
+            $busyStudent,
+            $mentorMember,
+            'EGKK_TWR',
+            $today,
+            '18:00:00',
+            '20:00:00',
+        );
+
+        $this->seedDevMentoringPendingRequest($overlappingStudent, 'EGLL_N_APP');
+        Availability::query()->updateOrCreate(
+            [
+                'student_id' => $overlappingStudent->id,
+                'date' => $today,
+            ],
+            [
+                'from' => '17:00:00',
+                'to' => '21:00:00',
+                'type' => 'S',
+            ],
+        );
+
+        $this->seedDevMentoringPendingRequest($clearStudent, 'EGKK_TWR');
+        Availability::query()->updateOrCreate(
+            [
+                'student_id' => $clearStudent->id,
+                'date' => $today,
+            ],
+            [
+                'from' => '14:00:00',
+                'to' => '16:00:00',
+                'type' => 'S',
+            ],
+        );
+
+        $this->command?->info("Mentor unavailability fixtures seeded for CID {$mentor->id}.");
+        $this->command?->line('Training panel → Mentoring → today: My sessions 18:00–20:00, overlapping pickup on EGLL_N_APP, clear pickup 14:00–16:00.');
+    }
+
+    private function resolveMentorAccount(): Account
+    {
+        $cid = (int) (env('DEV_MENTOR_CID') ?: DevTrainingPersonas::MENTOR_CONDUCT_CID);
+        $existing = Account::query()->find($cid);
+
+        if ($existing !== null) {
+            Member::query()->firstOrCreate(
+                ['cid' => $existing->id],
+                [
+                    'id' => $existing->id,
+                    'name' => $existing->name,
+                    'joined' => now(),
+                    'joined_div' => now(),
+                ],
+            );
+
+            return $existing->fresh();
+        }
+
+        if ($cid !== DevTrainingPersonas::MENTOR_CONDUCT_CID) {
+            throw new RuntimeException(
+                "Account {$cid} (DEV_MENTOR_CID) was not found. Create/login that sandbox account first, or omit DEV_MENTOR_CID.",
+            );
+        }
+
+        return $this->createLinkedAccount(
+            DevTrainingPersonas::MENTOR_CONDUCT_CID,
+            'Dev',
+            'Mentor Conduct',
+            'dev-mentor-conduct@example.test',
+        );
+    }
+
+    private function assignMentorToPosition(Account $mentor, string $callsign, string $category): void
+    {
+        $trainingPosition = DevTrainingFoundation::$trainingPositionsByCallsign[$callsign]
+            ?? TrainingPosition::query()->where('cts_primary_position', $callsign)->firstOrFail();
+
+        app(MentorPermissionService::class)->assignToMentorable(
+            $mentor,
+            $trainingPosition,
+            $mentor,
+            $category,
+        );
+    }
+
+    private function ensurePrerequisites(): void
+    {
+        if (TrainingPosition::query()->where('cts_primary_position', 'EGKK_TWR')->doesntExist()) {
+            throw new RuntimeException(
+                'Run AtcAndCtsTrainingPositionsSeeder (or LocalDevelopmentTrainingSeeder) before DevMentorUnavailabilitySeeder.',
+            );
+        }
+
+        if (TrainingPosition::query()->where('cts_primary_position', 'EGLL_N_APP')->doesntExist()) {
+            throw new RuntimeException(
+                'Run AtcAndCtsTrainingPositionsSeeder (or LocalDevelopmentTrainingSeeder) before DevMentorUnavailabilitySeeder.',
+            );
+        }
+
+        foreach ([
+            DevTrainingPersonas::STUDENT_EXAMS_CID,
+            DevTrainingPersonas::STUDENT_CID,
+            DevTrainingPersonas::STUDENT_LOA_CID,
+        ] as $cid) {
+            if (Member::query()->where('cid', $cid)->doesntExist()) {
+                throw new RuntimeException(
+                    'Run LocalDevelopmentTrainingSeeder (personas + CTS mentoring seeders) before DevMentorUnavailabilitySeeder.',
+                );
+            }
+        }
+    }
+}

--- a/resources/views/livewire/training/availability-gantt-desktop.blade.php
+++ b/resources/views/livewire/training/availability-gantt-desktop.blade.php
@@ -27,7 +27,59 @@
 				$firstHour = $hours[0];
 				$totalHours = count($hours);
 				$totalTimelineMinutes = $totalHours * 60;
+				$timelineStartMinutes = $firstHour * 60;
 			@endphp
+
+			@if ($mentorSessions->isNotEmpty())
+				<div class="flex bg-danger-50/60 dark:bg-danger-400/5 relative min-h-[72px]">
+					<div
+						class="w-64 flex-shrink-0 sticky left-0 z-20 bg-inherit border-r border-gray-200 dark:border-white/10 px-4 py-3 flex flex-col justify-center">
+						<div class="font-medium text-sm text-gray-950 dark:text-white">
+							My sessions
+						</div>
+						<div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+							Your accepted mentoring today
+						</div>
+					</div>
+
+					<div class="flex-1 relative">
+						@if ($nowLinePercent !== null)
+							<div class="absolute inset-y-0 z-30 pointer-events-none" data-gantt-now-line
+								style="left: calc({{ $nowLinePercent }}% - 1px); width: 2px; background-color: #ef4444;"></div>
+						@endif
+
+						<div class="absolute inset-0 flex pointer-events-none">
+							@foreach ($hours as $hour)
+								<div class="flex-1 border-r border-gray-100 dark:border-white/[0.02]"></div>
+							@endforeach
+						</div>
+
+						@foreach ($mentorSessions as $session)
+							@php
+								$start = \Carbon\Carbon::parse($session->taken_from);
+								$end = \Carbon\Carbon::parse($session->taken_to);
+
+								$startMinutesFromMidnight = $start->hour * 60 + $start->minute;
+								$relativeStartMinutes = max(0, $startMinutesFromMidnight - $timelineStartMinutes);
+								$durationMinutes = $start->diffInMinutes($end);
+
+								$leftPercent = ($relativeStartMinutes / $totalTimelineMinutes) * 100;
+								$widthPercent = ($durationMinutes / $totalTimelineMinutes) * 100;
+								$label = trim(($session->position ?? '') . ' · ' . ($session->student?->name ?? 'Student'));
+							@endphp
+
+							<div
+								class="absolute top-2 bottom-2 flex items-center justify-center px-1.5 rounded-md shadow-sm border ring-1 bg-danger-500/90 border-danger-600 dark:border-danger-400 ring-danger-500/30 overflow-hidden pointer-events-none"
+								style="left: {{ $leftPercent }}%; width: {{ $widthPercent }}%;"
+								title="{{ $label }}: {{ $start->format('H:i') }} - {{ $end->format('H:i') }}">
+								<span class="text-[10px] font-medium text-white truncate px-1">
+									{{ $label }}
+								</span>
+							</div>
+						@endforeach
+					</div>
+				</div>
+			@endif
 
 			@foreach ($students as $student)
 				<div class="flex group hover:bg-gray-50/50 dark:hover:bg-white/5 transition duration-75 relative min-h-[72px]">
@@ -100,13 +152,29 @@
 							@endforeach
 						</div>
 
+						@foreach ($mentorSessions as $session)
+							@php
+								$start = \Carbon\Carbon::parse($session->taken_from);
+								$end = \Carbon\Carbon::parse($session->taken_to);
+
+								$startMinutesFromMidnight = $start->hour * 60 + $start->minute;
+								$relativeStartMinutes = max(0, $startMinutesFromMidnight - $timelineStartMinutes);
+								$durationMinutes = $start->diffInMinutes($end);
+
+								$leftPercent = ($relativeStartMinutes / $totalTimelineMinutes) * 100;
+								$widthPercent = ($durationMinutes / $totalTimelineMinutes) * 100;
+							@endphp
+
+							<div class="absolute inset-y-0 z-10 pointer-events-none bg-danger-500/15 dark:bg-danger-400/10"
+								style="left: {{ $leftPercent }}%; width: {{ $widthPercent }}%;"></div>
+						@endforeach
+
 						@foreach ($student->availabilities as $avail)
 							@php
 								$start = \Carbon\Carbon::parse($avail->from);
 								$end = \Carbon\Carbon::parse($avail->to);
 
 								$startMinutesFromMidnight = $start->hour * 60 + $start->minute;
-								$timelineStartMinutes = $firstHour * 60;
 
 								$relativeStartMinutes = max(0, $startMinutesFromMidnight - $timelineStartMinutes);
 								$durationMinutes = $start->diffInMinutes($end);
@@ -116,7 +184,7 @@
 							@endphp
 
 							<button type="button" wire:click="mountAction('acceptSession', { availability_id: {{ $avail->id }} })"
-								class="absolute top-2 bottom-2 flex items-center justify-center px-1.5 rounded-md shadow-sm opacity-90 transition-all border group/block cursor-pointer hover:shadow-md ring-1 bg-success-500 hover:bg-success-600 border-success-600 dark:border-success-400 ring-success-500/30 overflow-hidden"
+								class="absolute top-2 bottom-2 z-20 flex items-center justify-center px-1.5 rounded-md shadow-sm opacity-90 transition-all border group/block cursor-pointer hover:shadow-md ring-1 bg-success-500 hover:bg-success-600 border-success-600 dark:border-success-400 ring-success-500/30 overflow-hidden"
 								style="left: {{ $leftPercent }}%; width: {{ $widthPercent }}%;">
 							</button>
 						@endforeach

--- a/resources/views/livewire/training/availability-gantt-mobile.blade.php
+++ b/resources/views/livewire/training/availability-gantt-mobile.blade.php
@@ -9,6 +9,17 @@
 				Time
 			</div>
 			<div class="flex-1 flex divide-x divide-gray-200 dark:divide-white/10">
+				@if ($mentorSessions->isNotEmpty())
+					<div
+						class="flex-1 min-w-[140px] px-3 py-2 flex flex-col justify-center text-center bg-danger-50/60 dark:bg-danger-400/5">
+						<div class="font-semibold text-xs text-gray-950 dark:text-white truncate">
+							My sessions
+						</div>
+						<div class="text-[10px] text-gray-500 dark:text-gray-400">
+							You
+						</div>
+					</div>
+				@endif
 				@foreach ($students as $student)
 					<div class="flex-1 min-w-[140px] px-3 py-2 flex flex-col justify-center text-center bg-inherit">
 						<div class="font-semibold text-xs text-gray-950 dark:text-white truncate">
@@ -64,6 +75,7 @@
 				$firstHour = $hours[0];
 				$totalHours = count($hours);
 				$totalTimelineMinutes = $totalHours * 60;
+				$timelineStartMinutes = $firstHour * 60;
 				$rowHeightPixel = 64;
 			@endphp
 
@@ -81,9 +93,52 @@
 						style="top: calc({{ $nowLinePercent }}% - 1px); height: 2px; background-color: #ef4444;"></div>
 				@endif
 
+				@if ($mentorSessions->isNotEmpty())
+					<div class="flex-1 min-w-[140px] relative bg-danger-50/40 dark:bg-danger-400/5 group transition duration-75">
+						@foreach ($mentorSessions as $session)
+							@php
+								$start = \Carbon\Carbon::parse($session->taken_from);
+								$end = \Carbon\Carbon::parse($session->taken_to);
+
+								$startMinutesFromMidnight = $start->hour * 60 + $start->minute;
+								$relativeStartMinutes = max(0, $startMinutesFromMidnight - $timelineStartMinutes);
+								$durationMinutes = $start->diffInMinutes($end);
+
+								$topPercent = ($relativeStartMinutes / $totalTimelineMinutes) * 100;
+								$heightPercent = ($durationMinutes / $totalTimelineMinutes) * 100;
+								$label = trim(($session->position ?? '') . ' · ' . ($session->student?->name ?? 'Student'));
+							@endphp
+
+							<div
+								class="absolute left-2 right-2 z-20 flex flex-col items-center justify-center p-1 rounded-md shadow-sm border ring-1 bg-danger-500/90 border-danger-600 dark:border-danger-400 ring-danger-500/30 overflow-hidden text-[10px] text-white font-medium line-clamp-2 pointer-events-none"
+								style="top: {{ $topPercent }}%; height: {{ $heightPercent }}%;"
+								title="{{ $label }}: {{ $start->format('H:i') }} - {{ $end->format('H:i') }}">
+								{{ $label }}
+							</div>
+						@endforeach
+					</div>
+				@endif
+
 				@foreach ($students as $student)
 					<div
 						class="flex-1 min-w-[140px] relative bg-inherit group hover:bg-gray-50/50 dark:hover:bg-white/5 transition duration-75">
+
+						@foreach ($mentorSessions as $session)
+							@php
+								$start = \Carbon\Carbon::parse($session->taken_from);
+								$end = \Carbon\Carbon::parse($session->taken_to);
+
+								$startMinutesFromMidnight = $start->hour * 60 + $start->minute;
+								$relativeStartMinutes = max(0, $startMinutesFromMidnight - $timelineStartMinutes);
+								$durationMinutes = $start->diffInMinutes($end);
+
+								$topPercent = ($relativeStartMinutes / $totalTimelineMinutes) * 100;
+								$heightPercent = ($durationMinutes / $totalTimelineMinutes) * 100;
+							@endphp
+
+							<div class="absolute inset-x-0 z-10 pointer-events-none bg-danger-500/15 dark:bg-danger-400/10"
+								style="top: {{ $topPercent }}%; height: {{ $heightPercent }}%;"></div>
+						@endforeach
 
 						@foreach ($student->availabilities as $avail)
 							@php
@@ -91,7 +146,6 @@
 								$end = \Carbon\Carbon::parse($avail->to);
 
 								$startMinutesFromMidnight = $start->hour * 60 + $start->minute;
-								$timelineStartMinutes = $firstHour * 60;
 
 								$relativeStartMinutes = max(0, $startMinutesFromMidnight - $timelineStartMinutes);
 								$durationMinutes = $start->diffInMinutes($end);
@@ -101,7 +155,7 @@
 							@endphp
 
 							<button type="button" wire:click="mountAction('acceptSession', { availability_id: {{ $avail->id }} })"
-								class="absolute left-2 right-2 flex flex-col items-center justify-center p-1 rounded-md shadow-sm opacity-90 transition-all border group/block ring-1 bg-success-500 hover:bg-success-600 border-success-600 dark:border-success-400 ring-success-500/30 overflow-hidden text-[10px] text-white font-medium line-clamp-2"
+								class="absolute left-2 right-2 z-20 flex flex-col items-center justify-center p-1 rounded-md shadow-sm opacity-90 transition-all border group/block ring-1 bg-success-500 hover:bg-success-600 border-success-600 dark:border-success-400 ring-success-500/30 overflow-hidden text-[10px] text-white font-medium line-clamp-2"
 								style="top: {{ $topPercent }}%; height: {{ $heightPercent }}%;"
 								aria-label="{{ $student->name }}: {{ $start->format('H:i') }} - {{ $end->format('H:i') }}"
 								title="{{ $student->name }}: {{ $start->format('H:i') }} - {{ $end->format('H:i') }}">

--- a/resources/views/livewire/training/availability-gantt.blade.php
+++ b/resources/views/livewire/training/availability-gantt.blade.php
@@ -25,7 +25,7 @@
 	</div>
 
 	{{-- Chart --}}
-	@if ($students->isEmpty())
+	@if ($students->isEmpty() && $mentorSessions->isEmpty())
 		<div class="p-8 text-center border-t border-gray-200 dark:border-white/10 text-gray-500 dark:text-gray-400">
 			<x-filament::icon icon="heroicon-o-calendar" class="mx-auto h-8 w-8 mb-3 text-gray-400" />
 			No availability found for this date.
@@ -34,6 +34,7 @@
 		<div class="hidden lg:!block">
 			@include('livewire.training.availability-gantt-desktop', [
 				'students' => $this->pagedStudents,
+				'mentorSessions' => $mentorSessions,
 				'hours' => $hours,
 				'nowLinePercent' => $nowLinePercent,
 			])
@@ -41,6 +42,7 @@
 		<div class="block lg:!hidden">
 			@include('livewire.training.availability-gantt-mobile', [
 				'students' => $this->pagedStudents,
+				'mentorSessions' => $mentorSessions,
 				'hours' => $hours,
 				'nowLinePercent' => $nowLinePercent,
 			])

--- a/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
+++ b/tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php
@@ -675,4 +675,199 @@ class MentoringPageTest extends BaseTrainingPanelTestCase
 
         Carbon::setTestNow();
     }
+
+    #[Test]
+    public function availability_gantt_shows_my_sessions_lane_when_mentor_has_accepted_session(): void
+    {
+        Carbon::setTestNow(Carbon::today()->setTime(10, 0));
+
+        $busyStudent = Member::factory()->create(['name' => 'Busy Student']);
+        $pickupStudent = Member::factory()->create(['name' => 'Pickup Student']);
+
+        Session::factory()->create([
+            'student_id' => $busyStudent->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGLL_APP',
+            'taken' => 1,
+            'taken_date' => Carbon::today()->format('Y-m-d'),
+            'taken_from' => '18:00:00',
+            'taken_to' => '20:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Session::factory()->create([
+            'student_id' => $pickupStudent->id,
+            'mentor_id' => null,
+            'position' => 'EGLL_APP',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Availability::factory()->create([
+            'student_id' => $pickupStudent->id,
+            'date' => Carbon::today()->format('Y-m-d'),
+            'from' => '14:00:00',
+            'to' => '16:00:00',
+        ]);
+
+        Livewire::actingAs($this->mentor)
+            ->test(AvailabilityGantt::class)
+            ->assertSee('My sessions')
+            ->assertSee('Busy Student');
+
+        Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function availability_gantt_does_not_show_my_sessions_lane_when_mentor_has_no_sessions(): void
+    {
+        $pickupStudent = Member::factory()->create();
+
+        Session::factory()->create([
+            'student_id' => $pickupStudent->id,
+            'mentor_id' => null,
+            'position' => 'EGLL_APP',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Availability::factory()->create([
+            'student_id' => $pickupStudent->id,
+            'date' => Carbon::today()->format('Y-m-d'),
+            'from' => '14:00:00',
+            'to' => '16:00:00',
+        ]);
+
+        Livewire::actingAs($this->mentor)
+            ->test(AvailabilityGantt::class)
+            ->assertDontSee('My sessions');
+    }
+
+    #[Test]
+    public function accept_session_detects_mentor_busy_overlap_for_selected_times(): void
+    {
+        Carbon::setTestNow(Carbon::today()->setTime(10, 0));
+
+        $busyStudent = Member::factory()->create(['name' => 'Already Booked Student']);
+        $pickupStudent = Member::factory()->create(['name' => 'New Pickup Student']);
+
+        Session::factory()->create([
+            'student_id' => $busyStudent->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGKK_TWR',
+            'taken' => 1,
+            'taken_date' => Carbon::today()->format('Y-m-d'),
+            'taken_from' => '18:00:00',
+            'taken_to' => '20:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Session::factory()->create([
+            'student_id' => $pickupStudent->id,
+            'mentor_id' => null,
+            'position' => 'EGLL_APP',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        $availability = Availability::factory()->create([
+            'student_id' => $pickupStudent->id,
+            'date' => Carbon::today()->format('Y-m-d'),
+            'from' => '17:00:00',
+            'to' => '21:00:00',
+        ]);
+
+        $component = Livewire::actingAs($this->mentor)
+            ->test(AvailabilityGantt::class)
+            ->mountAction('acceptSession', ['availability_id' => $availability->id])
+            ->setActionData([
+                'taken_from' => '18:00',
+                'taken_to' => '19:00',
+            ]);
+
+        $this->assertNotEmpty($component->instance()->mountedActions);
+
+        $overlap = $this->invokeMentorOverlappingSession(
+            $component->instance(),
+            ['taken_from' => '18:00', 'taken_to' => '19:00'],
+            $availability,
+        );
+
+        $this->assertInstanceOf(Session::class, $overlap);
+        $this->assertSame('EGKK_TWR', $overlap->position);
+        $this->assertSame('Already Booked Student', $overlap->student?->name);
+
+        Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function accept_session_does_not_detect_mentor_busy_when_times_are_clear(): void
+    {
+        Carbon::setTestNow(Carbon::today()->setTime(10, 0));
+
+        $busyStudent = Member::factory()->create(['name' => 'Already Booked Student']);
+        $pickupStudent = Member::factory()->create(['name' => 'Clear Pickup Student']);
+
+        Session::factory()->create([
+            'student_id' => $busyStudent->id,
+            'mentor_id' => $this->mentorMember->id,
+            'position' => 'EGKK_TWR',
+            'taken' => 1,
+            'taken_date' => Carbon::today()->format('Y-m-d'),
+            'taken_from' => '18:00:00',
+            'taken_to' => '20:00:00',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        Session::factory()->create([
+            'student_id' => $pickupStudent->id,
+            'mentor_id' => null,
+            'position' => 'EGLL_APP',
+            'filed' => null,
+            'cancelled_datetime' => null,
+        ]);
+
+        $availability = Availability::factory()->create([
+            'student_id' => $pickupStudent->id,
+            'date' => Carbon::today()->format('Y-m-d'),
+            'from' => '14:00:00',
+            'to' => '16:00:00',
+        ]);
+
+        $component = Livewire::actingAs($this->mentor)
+            ->test(AvailabilityGantt::class)
+            ->mountAction('acceptSession', ['availability_id' => $availability->id])
+            ->setActionData([
+                'taken_from' => '14:00',
+                'taken_to' => '16:00',
+            ]);
+
+        $overlap = $this->invokeMentorOverlappingSession(
+            $component->instance(),
+            ['taken_from' => '14:00', 'taken_to' => '16:00'],
+            $availability,
+        );
+
+        $this->assertNull($overlap);
+
+        Carbon::setTestNow();
+    }
+
+    /**
+     * @param  array{taken_from: string, taken_to: string}  $times
+     */
+    private function invokeMentorOverlappingSession(AvailabilityGantt $instance, array $times, Availability $availability): ?Session
+    {
+        $get = \Mockery::mock(\Filament\Schemas\Components\Utilities\Get::class);
+        $get->shouldReceive('__invoke')->andReturnUsing(
+            fn (string $key = '', bool $isAbsolute = false) => $times[$key] ?? null,
+        );
+
+        $method = new \ReflectionMethod(AvailabilityGantt::class, 'getMentorOverlappingSession');
+
+        return $method->invoke($instance, $get, $availability);
+    }
 }

--- a/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
+++ b/tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php
@@ -1295,4 +1295,193 @@ class MentoringSessionsServiceTest extends TestCase
 
         $this->assertInstanceOf(ExamBooking::class, $result);
     }
+
+    #[Test]
+    public function get_mentor_sessions_for_date_returns_accepted_sessions_for_that_mentor(): void
+    {
+        $date = Carbon::tomorrow()->format('Y-m-d');
+
+        Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+            'taken_date' => $date,
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'cancelled_datetime' => null,
+        ]);
+
+        Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGKK_TWR',
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+            'taken_date' => $date,
+            'taken_from' => '14:00:00',
+            'taken_to' => '16:00:00',
+            'cancelled_datetime' => null,
+        ]);
+
+        $otherMentor = Member::factory()->create();
+        Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => $otherMentor->id,
+            'taken' => 1,
+            'taken_date' => $date,
+            'taken_from' => '11:00:00',
+            'taken_to' => '13:00:00',
+            'cancelled_datetime' => null,
+        ]);
+
+        $sessions = $this->service->getMentorSessionsForDate($this->mentorMember->id, $date);
+
+        $this->assertCount(2, $sessions);
+        $this->assertTrue($sessions->every(fn (Session $session) => $session->mentor_id === $this->mentorMember->id));
+        $this->assertSame('10:00:00', $sessions->first()->taken_from);
+    }
+
+    #[Test]
+    public function get_mentor_sessions_for_date_excludes_cancelled_sessions(): void
+    {
+        $date = Carbon::tomorrow()->format('Y-m-d');
+
+        Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+            'taken_date' => $date,
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'cancelled_datetime' => now(),
+        ]);
+
+        $sessions = $this->service->getMentorSessionsForDate($this->mentorMember->id, $date);
+
+        $this->assertCount(0, $sessions);
+    }
+
+    #[Test]
+    public function check_for_mentor_overlapping_session_returns_null_when_no_overlap(): void
+    {
+        Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'cancelled_datetime' => null,
+        ]);
+
+        $result = $this->service->checkForMentorOverlappingSession(
+            $this->mentorMember->id,
+            Carbon::tomorrow()->format('Y-m-d'),
+            '14:00',
+            '16:00',
+        );
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function check_for_mentor_overlapping_session_returns_session_when_overlap_exists_on_any_position(): void
+    {
+        Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGKK_TWR',
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'cancelled_datetime' => null,
+        ]);
+
+        $result = $this->service->checkForMentorOverlappingSession(
+            $this->mentorMember->id,
+            Carbon::tomorrow()->format('Y-m-d'),
+            '11:00',
+            '13:00',
+        );
+
+        $this->assertInstanceOf(Session::class, $result);
+        $this->assertSame('EGKK_TWR', $result->position);
+    }
+
+    #[Test]
+    public function check_for_mentor_overlapping_session_ignores_session_when_ignore_id_is_provided(): void
+    {
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'cancelled_datetime' => null,
+        ]);
+
+        $result = $this->service->checkForMentorOverlappingSession(
+            $this->mentorMember->id,
+            Carbon::tomorrow()->format('Y-m-d'),
+            '11:00',
+            '13:00',
+            $session->id,
+        );
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function check_for_mentor_overlapping_session_ignores_other_mentors(): void
+    {
+        $otherMentor = Member::factory()->create();
+
+        Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => $otherMentor->id,
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+            'cancelled_datetime' => null,
+        ]);
+
+        $result = $this->service->checkForMentorOverlappingSession(
+            $this->mentorMember->id,
+            Carbon::tomorrow()->format('Y-m-d'),
+            '11:00',
+            '13:00',
+        );
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function mentor_overlap_description_includes_student_position_and_times(): void
+    {
+        $session = Session::factory()->create([
+            'student_id' => $this->studentMember->id,
+            'position' => 'EGLL_APP',
+            'mentor_id' => $this->mentorMember->id,
+            'taken' => 1,
+            'taken_date' => Carbon::tomorrow()->format('Y-m-d'),
+            'taken_from' => '10:00:00',
+            'taken_to' => '12:00:00',
+        ]);
+        $session->load('student');
+
+        $description = $this->service->mentorOverlapDescription($session);
+
+        $this->assertStringContainsString($this->studentMember->name, $description);
+        $this->assertStringContainsString('EGLL_APP', $description);
+        $this->assertStringContainsString('10:00', $description);
+        $this->assertStringContainsString('12:00', $description);
+    }
 }


### PR DESCRIPTION
## Summary
- Surfaces the viewing mentor’s already-accepted mentoring sessions on the Mentoring availability GANTT (**My sessions** lane + red busy bands) so conflicts are visible while scanning student availability.
- Soft-warns in Accept Session and reschedule modals when chosen times overlap those sessions (same soft pattern as position overlap; does **not** hard-block accept).
- Adds local `DevMentorUnavailabilitySeeder` (+ README runbook) for stakeholder demos on today’s GANTT.

Closes [TECH-730](https://linear.app/vatsimuk/issue/TECH-730/show-mentor-unavailability-when-picking-up-students). Related: [TECH-667](https://linear.app/vatsimuk/issue/TECH-667) (surrounding position/exam visibility — out of scope here).

## Test plan
- [ ] Training Panel → Mentoring: with an accepted session that day, confirm **My sessions** lane and red busy bands appear on desktop and mobile
- [ ] Click a student availability slot that overlaps those times → Accept modal shows mentor-busy danger callout; submit still works
- [ ] Click a non-overlapping slot → no mentor-busy callout
- [ ] Reschedule an accepted session into overlapping times → same soft callout
- [ ] Optional demo seed:
  ```bash
  php artisan db:seed --class=Database\\Seeders\\LocalDevelopmentTrainingSeeder
  php artisan db:seed --class=Database\\Seeders\\LocalDevelopment\\Training\\DevMentorUnavailabilitySeeder
  ```
- [ ] `php artisan test tests/Unit/Training/Mentoring/MentoringSessionsServiceTest.php --filter=mentor`
- [ ] `php artisan test tests/Feature/TrainingPanel/Mentor/MentoringPageTest.php --filter='my_sessions|accept_session_detects|accept_session_does_not_detect'`