### PR TITLE
Sync bookings to .net bookings calendar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,8 @@ VATSIM_API_KEY=
 VATSIM_API_BASE=https://apiv2.vatsim.dev/v2/
 
 VATSIM_NET_WEBHOOK_KEY=
+VATSIM_NET_BOOKINGS_URL=https://atc-bookings.vatsim.net/api
+VATSIM_NET_BOOKINGS_KEY=
 
 #VATSIM_DATA_FEED=
 

--- a/app/Jobs/Booking/SyncToVatsimNet.php
+++ b/app/Jobs/Booking/SyncToVatsimNet.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Booking;
+
+use App\Jobs\Concerns\LogsJobFailure;
+use App\Jobs\Job;
+use App\Models\Booking;
+use App\Services\Bookings\VatsimNetBookingSyncService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SyncToVatsimNet extends Job implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, LogsJobFailure, SerializesModels;
+
+    public function __construct(
+        private readonly int $bookingId,
+        private readonly bool $deleted = false,
+        private readonly ?int $remoteId = null,
+    ) {}
+
+    public function handle(VatsimNetBookingSyncService $service): void
+    {
+        if ($this->deleted) {
+            $service->delete($this->remoteId);
+
+            return;
+        }
+
+        $booking = Booking::find($this->bookingId);
+
+        if ($booking === null) {
+            return;
+        }
+
+        $service->sync($booking);
+    }
+
+    protected function logJobContext(): array
+    {
+        return [
+            'booking_id' => $this->bookingId,
+            'deleted' => $this->deleted,
+        ];
+    }
+}

--- a/app/Libraries/VatsimNetBookings.php
+++ b/app/Libraries/VatsimNetBookings.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libraries;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class VatsimNetBookings
+{
+    private string $url;
+
+    private string $key;
+
+    public function __construct()
+    {
+        $this->url = (string) config('services.vatsim-net.bookings.url');
+        $this->key = (string) config('services.vatsim-net.bookings.key');
+    }
+
+    public function create(array $payload): int
+    {
+        $response = $this->client()->post('booking', $payload);
+
+        $this->logFailure('create', $response->status(), $response->body());
+
+        $response->throw();
+
+        $id = (int) $response->json('id');
+
+        if ($id <= 0) {
+            throw new \RuntimeException('VATSIM.net booking create returned an invalid id.');
+        }
+
+        return $id;
+    }
+
+    public function update(int $remoteId, array $payload): void
+    {
+        $response = $this->client()->put("booking/{$remoteId}", $payload);
+
+        $this->logFailure('update', $response->status(), $response->body());
+
+        $response->throw();
+    }
+
+    public function delete(int $remoteId): void
+    {
+        $response = $this->client()->delete("booking/{$remoteId}");
+
+        $this->logFailure('delete', $response->status(), $response->body());
+
+        $response->throw();
+    }
+
+    private function client()
+    {
+        return Http::baseUrl($this->url)
+            ->withToken($this->key)
+            ->acceptJson()
+            ->asJson();
+    }
+
+    private function logFailure(string $method, int $status, string $body): void
+    {
+        if ($status >= 400) {
+            Log::warning('VATSIM.net booking request failed', [
+                'method' => $method,
+                'status' => $status,
+                'body' => $body,
+            ]);
+        }
+    }
+}

--- a/app/Libraries/VatsimNetBookings.php
+++ b/app/Libraries/VatsimNetBookings.php
@@ -59,7 +59,9 @@ class VatsimNetBookings
         return Http::baseUrl($this->url)
             ->withToken($this->key)
             ->acceptJson()
-            ->asJson();
+            ->asJson()
+            ->timeout(15)
+            ->connectTimeout(15);
     }
 
     private function logFailure(string $method, int $status, string $body): void

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -6,13 +6,16 @@ namespace App\Models;
 
 use App\Models\Atc\Position;
 use App\Models\Mship\Account;
+use App\Observers\BookingObserver;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
+#[ObservedBy([BookingObserver::class])]
 class Booking extends Model
 {
     use HasFactory;
@@ -36,11 +39,13 @@ class Booking extends Model
         'bookable_type',
         'bookable_id',
         'cts_booking_id',
+        'vatsim_net_booking_id',
     ];
 
     protected $casts = [
         'starts_at' => 'datetime',
         'ends_at' => 'datetime',
+        'vatsim_net_booking_id' => 'integer',
     ];
 
     public function position(): BelongsTo

--- a/app/Observers/BookingObserver.php
+++ b/app/Observers/BookingObserver.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Jobs\Booking\SyncToVatsimNet;
+use App\Models\Booking;
+
+class BookingObserver
+{
+    private const RELEVANT_FIELDS = [
+        'position_id',
+        'member_id',
+        'starts_at',
+        'ends_at',
+        'type',
+        'cts_booking_id',
+    ];
+
+    public function created(Booking $booking): void
+    {
+        $this->dispatch($booking);
+    }
+
+    public function updated(Booking $booking): void
+    {
+        if ($booking->wasChanged(self::RELEVANT_FIELDS)) {
+            $this->dispatch($booking);
+        }
+    }
+
+    public function deleted(Booking $booking): void
+    {
+        $this->dispatch($booking, deleted: true);
+    }
+
+    private function dispatch(Booking $booking, bool $deleted = false): void
+    {
+        if ($this->shouldSkip($booking)) {
+            return;
+        }
+
+        $remoteId = $booking->vatsim_net_booking_id !== null ? (int) $booking->vatsim_net_booking_id : null;
+
+        SyncToVatsimNet::dispatch($booking->getKey(), $deleted, $remoteId);
+    }
+
+    private function shouldSkip(Booking $booking): bool
+    {
+        if ((string) config('services.vatsim-net.bookings.key') === '') {
+            return true;
+        }
+
+        return $booking->type === Booking::TYPE_EVENT;
+    }
+}

--- a/app/Observers/BookingObserver.php
+++ b/app/Observers/BookingObserver.php
@@ -6,8 +6,9 @@ namespace App\Observers;
 
 use App\Jobs\Booking\SyncToVatsimNet;
 use App\Models\Booking;
+use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
 
-class BookingObserver
+class BookingObserver implements ShouldHandleEventsAfterCommit
 {
     private const RELEVANT_FIELDS = [
         'position_id',

--- a/app/Services/Bookings/VatsimNetBookingSyncService.php
+++ b/app/Services/Bookings/VatsimNetBookingSyncService.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Bookings;
+
+use App\Libraries\VatsimNetBookings;
+use App\Models\Booking;
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\Session;
+
+class VatsimNetBookingSyncService
+{
+    public function __construct(
+        private readonly VatsimNetBookings $bookings,
+    ) {}
+
+    public function sync(Booking $booking): void
+    {
+        $payload = $this->payload($booking);
+
+        if ($payload === null) {
+            return;
+        }
+
+        if ($booking->vatsim_net_booking_id !== null) {
+            $this->bookings->update((int) $booking->vatsim_net_booking_id, $payload);
+
+            return;
+        }
+
+        $remoteId = $this->bookings->create($payload);
+
+        $booking->updateQuietly(['vatsim_net_booking_id' => $remoteId]);
+    }
+
+    public function delete(?int $remoteId): void
+    {
+        if ($remoteId === null) {
+            return;
+        }
+
+        $this->bookings->delete($remoteId);
+    }
+
+    private function payload(Booking $booking): ?array
+    {
+        if ($booking->type === Booking::TYPE_EVENT) {
+            return null;
+        }
+
+        $position = $booking->position;
+
+        if ($position === null || $position->isVirtual()) {
+            return null;
+        }
+
+        $cid = $this->resolveControllerCid($booking);
+
+        if ($cid === null) {
+            return null;
+        }
+
+        return [
+            'callsign' => $booking->ctsBooking?->position ?? $position->callsign,
+            'cid' => $cid,
+            'type' => $this->mapType($booking->type),
+            'start' => $booking->starts_at->format('Y-m-d H:i:s'),
+            'end' => $booking->ends_at->format('Y-m-d H:i:s'),
+        ];
+    }
+
+    private function resolveControllerCid(Booking $booking): ?int
+    {
+        return match ($booking->type) {
+            Booking::TYPE_STANDARD => $booking->member_id !== null ? (int) $booking->member_id : null,
+            Booking::TYPE_EXAM => $this->resolveExamCid($booking),
+            Booking::TYPE_MENTORING => $this->resolveMentoringCid($booking),
+            default => null,
+        };
+    }
+
+    private function resolveExamCid(Booking $booking): ?int
+    {
+        $exam = $booking->bookable;
+
+        if (! $exam instanceof ExamBooking) {
+            return null;
+        }
+
+        $account = $exam->loadMissing('examiners.primaryExaminer')->examiners?->primaryExaminer?->account;
+
+        return $account?->id;
+    }
+
+    private function resolveMentoringCid(Booking $booking): ?int
+    {
+        $session = $booking->bookable;
+
+        if (! $session instanceof Session) {
+            return null;
+        }
+
+        $account = $session->loadMissing('mentor')->mentor?->account;
+
+        return $account?->id;
+    }
+
+    private function mapType(string $type): string
+    {
+        return match ($type) {
+            Booking::TYPE_STANDARD => 'booking',
+            Booking::TYPE_EXAM => 'exam',
+            Booking::TYPE_MENTORING => 'mentoring',
+            default => 'booking',
+        };
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -90,6 +90,10 @@ return [
             'secret' => env('VATSIM_OAUTH_SECRET'),
             'scopes' => explode(',', env('VATSIM_OAUTH_SCOPES', '')),
         ],
+        'bookings' => [
+            'url' => env('VATSIM_NET_BOOKINGS_URL', 'https://atc-bookings.vatsim.net/api'),
+            'key' => env('VATSIM_NET_BOOKINGS_KEY', ''),
+        ],
     ],
 
     'gander-oceanic' => [

--- a/database/migrations/2026_09_05_000001_add_vatsim_net_booking_id_to_bookings_table.php
+++ b/database/migrations/2026_09_05_000001_add_vatsim_net_booking_id_to_bookings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            $table->unsignedBigInteger('vatsim_net_booking_id')->nullable()->after('cts_booking_id')->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            $table->dropColumn('vatsim_net_booking_id');
+        });
+    }
+};

--- a/tests/Unit/Jobs/Booking/SyncToVatsimNetTest.php
+++ b/tests/Unit/Jobs/Booking/SyncToVatsimNetTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Jobs\Booking;
+
+use App\Jobs\Booking\SyncToVatsimNet;
+use App\Models\Booking;
+use App\Services\Bookings\VatsimNetBookingSyncService;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SyncToVatsimNetTest extends TestCase
+{
+    #[Test]
+    public function it_skips_when_the_booking_no_longer_exists(): void
+    {
+        Http::fake();
+
+        $job = new SyncToVatsimNet(999999);
+
+        $job->handle(app(VatsimNetBookingSyncService::class));
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function it_syncs_an_existing_booking(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response(['id' => 5], 201)]);
+
+        $booking = Booking::factory()->create();
+
+        $job = new SyncToVatsimNet($booking->id);
+
+        $job->handle(app(VatsimNetBookingSyncService::class));
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST');
+    }
+
+    #[Test]
+    public function it_deletes_the_remote_booking_when_marked_deleted(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response('', 204)]);
+
+        $job = new SyncToVatsimNet(123, true, 456);
+
+        $job->handle(app(VatsimNetBookingSyncService::class));
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://atc-bookings.vatsim.net/api/booking/456' && $request->method() === 'DELETE');
+    }
+}

--- a/tests/Unit/Libraries/VatsimNetBookingsTest.php
+++ b/tests/Unit/Libraries/VatsimNetBookingsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Libraries;
+
+use App\Libraries\VatsimNetBookings;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class VatsimNetBookingsTest extends TestCase
+{
+    private VatsimNetBookings $library;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['services.vatsim-net.bookings.url' => 'https://atc-bookings.vatsim.net/api']);
+        config(['services.vatsim-net.bookings.key' => 'test-key']);
+
+        $this->library = app(VatsimNetBookings::class);
+    }
+
+    #[Test]
+    public function it_creates_a_booking_and_returns_the_remote_id(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response(['id' => 123], 201)]);
+
+        $id = $this->library->create([
+            'callsign' => 'LON_CTR',
+            'cid' => 1240411,
+            'type' => 'booking',
+            'start' => '2026-01-01 12:00:00',
+            'end' => '2026-01-01 14:00:00',
+        ]);
+
+        $this->assertSame(123, $id);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://atc-bookings.vatsim.net/api/booking'
+                && $request->method() === 'POST'
+                && $request->hasHeader('Authorization', 'Bearer test-key')
+                && $request['callsign'] === 'LON_CTR'
+                && $request['cid'] === 1240411;
+        });
+    }
+
+    #[Test]
+    public function it_updates_a_booking(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response(['id' => 123], 200)]);
+
+        $this->library->update(123, ['callsign' => 'LON_CTR', 'cid' => 1240411, 'type' => 'booking', 'start' => '2026-01-01 12:00:00', 'end' => '2026-01-01 14:00:00']);
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://atc-bookings.vatsim.net/api/booking/123' && $request->method() === 'PUT');
+    }
+
+    #[Test]
+    public function it_deletes_a_booking(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response('', 204)]);
+
+        $this->library->delete(123);
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://atc-bookings.vatsim.net/api/booking/123' && $request->method() === 'DELETE');
+    }
+
+    #[Test]
+    public function it_throws_on_a_failed_response(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response(['message' => 'nope'], 422)]);
+
+        $this->expectException(RequestException::class);
+
+        $this->library->create(['callsign' => 'LON_CTR', 'cid' => 1, 'type' => 'booking', 'start' => 'x', 'end' => 'y']);
+    }
+
+    #[Test]
+    public function it_throws_when_create_returns_no_valid_id(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response([], 201)]);
+
+        $this->expectException(\RuntimeException::class);
+
+        $this->library->create(['callsign' => 'LON_CTR', 'cid' => 1, 'type' => 'booking', 'start' => 'x', 'end' => 'y']);
+    }
+}

--- a/tests/Unit/Models/BookingVatsimNetIdTest.php
+++ b/tests/Unit/Models/BookingVatsimNetIdTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\Booking;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BookingVatsimNetIdTest extends TestCase
+{
+    #[Test]
+    public function it_persists_and_casts_the_vatsim_net_booking_id(): void
+    {
+        $booking = Booking::factory()->create(['vatsim_net_booking_id' => 42]);
+
+        $this->assertSame(42, $booking->vatsim_net_booking_id);
+        $this->assertDatabaseHas('bookings', ['id' => $booking->id, 'vatsim_net_booking_id' => 42]);
+    }
+
+    #[Test]
+    public function it_defaults_the_vatsim_net_booking_id_to_null(): void
+    {
+        $booking = Booking::factory()->create();
+
+        $this->assertNull($booking->vatsim_net_booking_id);
+    }
+}

--- a/tests/Unit/Observers/BookingObserverTest.php
+++ b/tests/Unit/Observers/BookingObserverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Observers;
+
+use App\Jobs\Booking\SyncToVatsimNet;
+use App\Models\Booking;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Bus;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BookingObserverTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['services.vatsim-net.bookings.key' => 'test-key']);
+    }
+
+    #[Test]
+    public function it_dispatches_when_a_booking_is_created(): void
+    {
+        Bus::fake();
+
+        Booking::factory()->create();
+
+        Bus::assertDispatched(SyncToVatsimNet::class);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_when_no_api_key_is_configured(): void
+    {
+        config(['services.vatsim-net.bookings.key' => '']);
+
+        Bus::fake();
+
+        Booking::factory()->create();
+
+        Bus::assertNotDispatched(SyncToVatsimNet::class);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_for_event_bookings(): void
+    {
+        Bus::fake();
+
+        Booking::factory()->forEvent()->create();
+
+        Bus::assertNotDispatched(SyncToVatsimNet::class);
+    }
+
+    #[Test]
+    public function it_dispatches_when_a_relevant_field_changes(): void
+    {
+        Bus::fake();
+        $booking = Booking::factory()->create();
+
+        Bus::fake();
+
+        $booking->update(['starts_at' => Carbon::tomorrow()->setHour(15)]);
+
+        Bus::assertDispatched(SyncToVatsimNet::class);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_when_only_an_irrelevant_field_changes(): void
+    {
+        Bus::fake();
+        $booking = Booking::factory()->create();
+
+        Bus::fake();
+
+        $booking->update(['vatsim_net_booking_id' => 42]);
+
+        Bus::assertNotDispatched(SyncToVatsimNet::class);
+    }
+
+    #[Test]
+    public function it_dispatches_when_a_booking_is_deleted(): void
+    {
+        Bus::fake();
+        $booking = Booking::factory()->create(['vatsim_net_booking_id' => 77]);
+
+        Bus::fake();
+
+        $booking->delete();
+
+        Bus::assertDispatched(SyncToVatsimNet::class);
+    }
+}

--- a/tests/Unit/Services/Bookings/VatsimNetBookingSyncServiceTest.php
+++ b/tests/Unit/Services/Bookings/VatsimNetBookingSyncServiceTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Bookings;
+
+use App\Models\Atc\Position;
+use App\Models\Booking;
+use App\Models\Cts\ExamBooking;
+use App\Models\Cts\Member;
+use App\Models\Cts\PracticalExaminers;
+use App\Models\Cts\Session;
+use App\Models\Mship\Account;
+use App\Services\Bookings\VatsimNetBookingSyncService;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class VatsimNetBookingSyncServiceTest extends TestCase
+{
+    private VatsimNetBookingSyncService $service;
+
+    private Account $examiner;
+
+    private Account $mentor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = app(VatsimNetBookingSyncService::class);
+    }
+
+    #[Test]
+    public function it_creates_a_remote_booking_and_stores_the_id(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response(['id' => 999], 201)]);
+
+        $position = Position::factory()->create(['callsign' => 'EGKK_TWR']);
+        $member = Account::factory()->create();
+
+        $booking = Booking::factory()->create([
+            'position_id' => $position->id,
+            'member_id' => $member->id,
+            'type' => Booking::TYPE_STANDARD,
+        ]);
+
+        $this->service->sync($booking);
+
+        $this->assertSame(999, $booking->fresh()->vatsim_net_booking_id);
+
+        Http::assertSent(fn ($request) => $request['callsign'] === 'EGKK_TWR'
+            && $request['cid'] === $member->id
+            && $request['type'] === 'booking');
+    }
+
+    #[Test]
+    public function it_updates_when_a_remote_id_already_exists(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response(['id' => 77], 200)]);
+
+        $position = Position::factory()->create(['callsign' => 'EGKK_TWR']);
+        $booking = Booking::factory()->create([
+            'position_id' => $position->id,
+            'type' => Booking::TYPE_STANDARD,
+            'vatsim_net_booking_id' => 77,
+        ]);
+
+        $this->service->sync($booking);
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://atc-bookings.vatsim.net/api/booking/77' && $request->method() === 'PUT');
+    }
+
+    #[Test]
+    public function it_resolves_the_examiner_for_exam_bookings(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response(['id' => 1], 201)]);
+
+        $booking = $this->makeExamBooking();
+
+        $this->service->sync($booking);
+
+        Http::assertSent(fn ($request) => $request['cid'] === $this->examiner->id && $request['type'] === 'exam');
+    }
+
+    #[Test]
+    public function it_resolves_the_mentor_for_mentoring_bookings(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response(['id' => 1], 201)]);
+
+        $booking = $this->makeMentoringBooking();
+
+        $this->service->sync($booking);
+
+        Http::assertSent(fn ($request) => $request['cid'] === $this->mentor->id && $request['type'] === 'mentoring');
+    }
+
+    #[Test]
+    public function it_skips_event_bookings(): void
+    {
+        Http::fake();
+
+        $booking = Booking::factory()->forEvent()->create();
+
+        $this->service->sync($booking);
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function it_skips_virtual_positions(): void
+    {
+        Http::fake();
+
+        $position = Position::factory()->create(['virtual' => true]);
+        $booking = Booking::factory()->create([
+            'position_id' => $position->id,
+            'type' => Booking::TYPE_STANDARD,
+        ]);
+
+        $this->service->sync($booking);
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function it_skips_when_there_is_no_position(): void
+    {
+        Http::fake();
+
+        $booking = Booking::factory()->create([
+            'position_id' => null,
+            'type' => Booking::TYPE_EXAM,
+        ]);
+
+        $this->service->sync($booking);
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function it_deletes_by_remote_id(): void
+    {
+        Http::fake(['atc-bookings.vatsim.net/*' => Http::response('', 204)]);
+
+        $this->service->delete(123);
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://atc-bookings.vatsim.net/api/booking/123' && $request->method() === 'DELETE');
+    }
+
+    #[Test]
+    public function it_does_nothing_when_delete_has_no_remote_id(): void
+    {
+        Http::fake();
+
+        $this->service->delete(null);
+
+        Http::assertNothingSent();
+    }
+
+    private function makeExamBooking(): Booking
+    {
+        $this->examiner = Account::factory()->create();
+        $student = Account::factory()->create();
+        $position = Position::factory()->create(['callsign' => 'EGKK_TWR']);
+
+        $examinerMember = Member::factory()->forAccount($this->examiner)->create();
+        $studentMember = Member::factory()->forAccount($student)->create();
+
+        $exam = ExamBooking::factory()->create([
+            'student_id' => $studentMember->id,
+            'position_1' => 'EGKK_TWR',
+            'taken' => 1,
+            'finished' => ExamBooking::NOT_FINISHED_FLAG,
+        ]);
+
+        PracticalExaminers::create([
+            'examid' => $exam->id,
+            'senior' => $examinerMember->id,
+            'other' => null,
+            'trainee' => null,
+        ]);
+
+        return Booking::factory()->forExam()->create([
+            'position_id' => $position->id,
+            'member_id' => $student->id,
+            'bookable_type' => ExamBooking::class,
+            'bookable_id' => $exam->id,
+        ]);
+    }
+
+    private function makeMentoringBooking(): Booking
+    {
+        $this->mentor = Account::factory()->create();
+        $student = Account::factory()->create();
+        $position = Position::factory()->create(['callsign' => 'EGLL_APP']);
+
+        $mentorMember = Member::factory()->forAccount($this->mentor)->create();
+        $studentMember = Member::factory()->forAccount($student)->create();
+
+        $session = Session::factory()->create([
+            'student_id' => $studentMember->id,
+            'mentor_id' => $mentorMember->id,
+            'position' => 'EGLL_APP',
+        ]);
+
+        return Booking::factory()->forMentoring()->create([
+            'position_id' => $position->id,
+            'member_id' => $student->id,
+            'bookable_type' => Session::class,
+            'bookable_id' => $session->id,
+        ]);
+    }
+}


### PR DESCRIPTION
We add every booking which has a calsign existing in the `positions` table so that we don't push SB sessions.
Identified by the extra field for each booking, handles all CRUD operations by hooking into the relevant eloquent methods.