### PR TITLE
Fix Secondary Examiner selector on exam accept modal

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -50,12 +50,13 @@ class AppServiceProvider extends ServiceProvider
         });
 
         if ($this->app->runningInConsole()) {
-            $appUrl = Config::get('app.url');
-            $rootUrl = parse_url($appUrl, PHP_URL_SCHEME) === null
-                ? env('APP_PROTOCOL', 'https').'://'.$appUrl
-                : $appUrl;
+            $url = Config::get('app.url');
 
-            URL::forceRootUrl($rootUrl);
+            if (! str_starts_with($url, 'http://') && ! str_starts_with($url, 'https://')) {
+                $url = env('APP_PROTOCOL', 'https').'://'.$url;
+            }
+
+            URL::forceRootUrl($url);
         }
 
         $this->registerValidatorExtensions();

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -50,13 +50,12 @@ class AppServiceProvider extends ServiceProvider
         });
 
         if ($this->app->runningInConsole()) {
-            $url = Config::get('app.url');
+            $appUrl = Config::get('app.url');
+            $rootUrl = parse_url($appUrl, PHP_URL_SCHEME) === null
+                ? env('APP_PROTOCOL', 'https').'://'.$appUrl
+                : $appUrl;
 
-            if (! str_starts_with($url, 'http://') && ! str_starts_with($url, 'https://')) {
-                $url = env('APP_PROTOCOL', 'https').'://'.$url;
-            }
-
-            URL::forceRootUrl($url);
+            URL::forceRootUrl($rootUrl);
         }
 
         $this->registerValidatorExtensions();

--- a/app/Repositories/Cts/ExaminerRepository.php
+++ b/app/Repositories/Cts/ExaminerRepository.php
@@ -9,7 +9,6 @@ use InvalidArgumentException;
 
 class ExaminerRepository
 {
-
     private const EXAMINER_ROLE_MAP = [
         'obs' => ['ATC Examiner (OBS)'],
         'twr' => ['ATC Examiner (TWR)'],

--- a/app/Repositories/Cts/ExaminerRepository.php
+++ b/app/Repositories/Cts/ExaminerRepository.php
@@ -2,75 +2,147 @@
 
 namespace App\Repositories\Cts;
 
-use App\Models\Cts\ExaminerSettings;
+use App\Models\Cts\Member;
+use App\Models\Mship\Account;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 
 class ExaminerRepository
 {
     /**
-     * Core reusable fetcher.
+     * Examiner roles are managed in Core by the Manage Examiners page.
+     *
+     * The short scope names are used by exam bookings and are deliberately
+     * kept separate from the full Spatie role names used by Core accounts.
      */
-    private function _getExaminersByScope(string $scope): Collection
+    private const EXAMINER_ROLE_MAP = [
+        'obs' => ['ATC Examiner (OBS)'],
+        'twr' => ['ATC Examiner (TWR)'],
+        'app' => ['ATC Examiner (APP)'],
+        'ctr' => ['ATC Examiner (CTR)'],
+        'p1' => ['Pilot Examiner (P1)'],
+        'p2' => ['Pilot Examiner (P2)'],
+        'p3' => ['Pilot Examiner (P3)'],
+        'atc' => [
+            'ATC Examiner (OBS)',
+            'ATC Examiner (TWR)',
+            'ATC Examiner (APP)',
+            'ATC Examiner (CTR)',
+        ],
+        'pilot' => [
+            'Pilot Examiner (P1)',
+            'Pilot Examiner (P2)',
+            'Pilot Examiner (P3)',
+        ],
+    ];
+
+    /**
+     * Get Core accounts assigned to examiner roles for the requested scope.
+     *
+     * Examiner role assignments live in the Core database. We then look up
+     * the corresponding CTS member records because the existing CTS exam
+     * tables store CTS member IDs rather than Core account IDs/CIDs.
+     */
+    private function getExaminersByScope(string $scope): Collection
     {
-        // We capitalize here so that the scope methods are readable.
-        $scopeMethod = 'scope'.ucfirst($scope);
-        if (! method_exists(ExaminerSettings::class, $scopeMethod)) {
+
+        // Lookup the supplied scope in EXAMINER_ROLE_MAP
+        // Return null if the scope is not defined in the map
+        $roleNames = self::EXAMINER_ROLE_MAP[$scope] ?? null;
+
+        // Throw an exception if the scope is not recognized
+        if ($roleNames === null) {
             throw new InvalidArgumentException("Unknown scope '{$scope}'.");
         }
 
-        return ExaminerSettings::with('member')
-            ->{$scope}()
-            ->whereHas('member', fn ($q) => $q->where('examiner', true))
-            ->get()
-            ->pluck('member.cid')
-            ->sort()
-            ->values();
+        // Query Core accounts with the specified examiner roles
+        // Return the unique, sorted by name collection of accounts
+        return Account::query()
+            ->role($roleNames)
+            ->get() // Execute the query and retrieve the collection of accounts
+            ->unique('id')
+            ->sortBy('name')
+            ->values(); // Reindex the collection after sorting
     }
 
     public function getExaminerDetailsByScope(string $scope): Collection
     {
-        return ExaminerSettings::with('member')
-            ->{$scope}()
-            ->whereHas('member', fn ($q) => $q->where('examiner', true))
+        // Retrieve Core accounts for the requested scope
+        // Using the private helper method getExaminersByScope()
+        $accounts = $this->getExaminersByScope($scope);
+
+        // Return an empty collection if no accounts were found for the scope
+        if ($accounts->isEmpty()) {
+            return collect();
+        }
+
+        // Member IDs belong to CTS, so this lookup intentionally uses the
+        // CTS model and matches records by the shared VATSIM CID.
+        $members = Member::query()
+            ->whereIn('cid', $accounts->pluck('id')) // Match CTS members by VATSIM CID
             ->get()
-            ->sortBy('member.cid')
-            ->map(function ($examiner) {
-                return [
-                    'cid' => $examiner->member->cid,
-                    'name' => $examiner->member->name,
-                    'id' => $examiner->member->id,
-                ];
-            });
+            ->keyBy('cid'); // Key the collection by VATSIM CID for easy lookup
+
+        // Map Core accounts to CTS member details, filtering out accounts without corresponding CTS members
+        return $accounts
+
+            // Map each Core account to its corresponding CTS member details
+            // this ensures that only Core accounts with corresponding CTS member
+            // records are included in the final collection
+            ->map(
+
+                // Create an anonymous function to map each Core account to its
+                // corresponding CTS member details
+                function (Account $account) use ($members) {
+
+                    // Look up the corresponding CTS member for the current Core account
+                    $member = $members->get($account->id);
+
+                    // A Core examiner without a CTS member cannot be stored in
+                    // practical_examiners, which expects a CTS member ID.
+                    if (! $member) {
+                        return null;
+                    }
+
+                    return [
+                        'cid' => $account->id,
+                        'name' => $account->name,
+                        'id' => $member->id,
+                    ];
+                }
+            )
+            ->filter()
+            ->sortBy('name')
+            ->values();
     }
 
     public function getObsExaminers(): Collection
     {
-        return $this->_getExaminersByScope('obs');
+        return $this->getExaminersByScope('obs')->pluck('id')->values();
     }
 
     public function getTwrExaminers(): Collection
     {
-        return $this->_getExaminersByScope('twr');
+        return $this->getExaminersByScope('twr')->pluck('id')->values();
     }
 
     public function getAppExaminers(): Collection
     {
-        return $this->_getExaminersByScope('app');
+        return $this->getExaminersByScope('app')->pluck('id')->values();
     }
 
     public function getCtrExaminers(): Collection
     {
-        return $this->_getExaminersByScope('ctr');
+        return $this->getExaminersByScope('ctr')->pluck('id')->values();
     }
 
     public function getAtcExaminers(): Collection
     {
-        return $this->_getExaminersByScope('atc');
+        return $this->getExaminersByScope('atc')->pluck('id')->values();
     }
 
     public function getPilotExaminers(): Collection
     {
-        return $this->_getExaminersByScope('pilot');
+        return $this->getExaminersByScope('pilot')->pluck('id')->values();
     }
 }

--- a/app/Repositories/Cts/ExaminerRepository.php
+++ b/app/Repositories/Cts/ExaminerRepository.php
@@ -9,12 +9,7 @@ use InvalidArgumentException;
 
 class ExaminerRepository
 {
-    /**
-     * Examiner roles are managed in Core by the Manage Examiners page.
-     *
-     * The short scope names are used by exam bookings and are deliberately
-     * kept separate from the full Spatie role names used by Core accounts.
-     */
+
     private const EXAMINER_ROLE_MAP = [
         'obs' => ['ATC Examiner (OBS)'],
         'twr' => ['ATC Examiner (TWR)'],
@@ -36,70 +31,46 @@ class ExaminerRepository
         ],
     ];
 
-    /**
-     * Get Core accounts assigned to examiner roles for the requested scope.
-     *
-     * Examiner role assignments live in the Core database. We then look up
-     * the corresponding CTS member records because the existing CTS exam
-     * tables store CTS member IDs rather than Core account IDs/CIDs.
-     */
+    /* Core reusable fetcher. */
     private function getExaminersByScope(string $scope): Collection
     {
 
-        // Lookup the supplied scope in EXAMINER_ROLE_MAP
-        // Return null if the scope is not defined in the map
         $roleNames = self::EXAMINER_ROLE_MAP[$scope] ?? null;
 
-        // Throw an exception if the scope is not recognized
         if ($roleNames === null) {
             throw new InvalidArgumentException("Unknown scope '{$scope}'.");
         }
 
-        // Query Core accounts with the specified examiner roles
-        // Return the unique, sorted by name collection of accounts
         return Account::query()
             ->role($roleNames)
-            ->get() // Execute the query and retrieve the collection of accounts
+            ->get()
             ->unique('id')
             ->sortBy('name')
-            ->values(); // Reindex the collection after sorting
+            ->values();
     }
 
     public function getExaminerDetailsByScope(string $scope): Collection
     {
-        // Retrieve Core accounts for the requested scope
-        // Using the private helper method getExaminersByScope()
+
         $accounts = $this->getExaminersByScope($scope);
 
-        // Return an empty collection if no accounts were found for the scope
         if ($accounts->isEmpty()) {
             return collect();
         }
 
-        // Member IDs belong to CTS, so this lookup intentionally uses the
-        // CTS model and matches records by the shared VATSIM CID.
         $members = Member::query()
-            ->whereIn('cid', $accounts->pluck('id')) // Match CTS members by VATSIM CID
+            ->whereIn('cid', $accounts->pluck('id'))
             ->get()
-            ->keyBy('cid'); // Key the collection by VATSIM CID for easy lookup
+            ->keyBy('cid');
 
-        // Map Core accounts to CTS member details, filtering out accounts without corresponding CTS members
         return $accounts
 
-            // Map each Core account to its corresponding CTS member details
-            // this ensures that only Core accounts with corresponding CTS member
-            // records are included in the final collection
             ->map(
 
-                // Create an anonymous function to map each Core account to its
-                // corresponding CTS member details
                 function (Account $account) use ($members) {
 
-                    // Look up the corresponding CTS member for the current Core account
                     $member = $members->get($account->id);
 
-                    // A Core examiner without a CTS member cannot be stored in
-                    // practical_examiners, which expects a CTS member ID.
                     if (! $member) {
                         return null;
                     }

--- a/tests/Feature/Training/Exams/ExamRequestsTableSecondaryExaminerScopingTest.php
+++ b/tests/Feature/Training/Exams/ExamRequestsTableSecondaryExaminerScopingTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Training\Exams;
 
-use App\Models\Cts\ExaminerSettings;
 use App\Models\Cts\Member;
 use App\Models\Mship\Account;
 use App\Repositories\Cts\ExaminerRepository;
@@ -92,20 +91,21 @@ class ExamRequestsTableSecondaryExaminerScopingTest extends TestCase
         $examinerAccount = Account::factory()->create();
         $examinerMember = Member::factory()->forAccount($examinerAccount)->create(['examiner' => true]);
 
-        ExaminerSettings::create(array_merge([
-            'memberID' => $examinerMember->id,
-            'OBS' => 0,
-            'S1' => 0,
-            'S2' => 0,
-            'S3' => 0,
-            'P1' => 0,
-            'P2' => 0,
-            'P3' => 0,
-            'P4' => 0,
-            'P5' => 0,
-            'lastUpdated' => now(),
-            'updatedBy' => 0,
-        ], $settings));
+        $scopeColumn = array_key_first($settings);
+        $roleName = [
+            'OBS' => 'ATC Examiner (OBS)',
+            'S1' => 'ATC Examiner (TWR)',
+            'S2' => 'ATC Examiner (APP)',
+            'S3' => 'ATC Examiner (CTR)',
+            'P1' => 'Pilot Examiner (P1)',
+            'P2' => 'Pilot Examiner (P2)',
+            'P3' => 'Pilot Examiner (P3)',
+        ][$scopeColumn] ?? throw new \InvalidArgumentException("Unknown test scope '{$scopeColumn}'.");
+
+        // Examiner eligibility is managed in Core through roles. The CTS
+        // member remains necessary because the selector stores its internal
+        // member ID in practical_examiners.other.
+        $examinerAccount->assignRole($roleName);
 
         return $examinerMember;
     }

--- a/tests/Feature/Training/Exams/ExamRequestsTableSecondaryExaminerScopingTest.php
+++ b/tests/Feature/Training/Exams/ExamRequestsTableSecondaryExaminerScopingTest.php
@@ -102,9 +102,6 @@ class ExamRequestsTableSecondaryExaminerScopingTest extends TestCase
             'P3' => 'Pilot Examiner (P3)',
         ][$scopeColumn] ?? throw new \InvalidArgumentException("Unknown test scope '{$scopeColumn}'.");
 
-        // Examiner eligibility is managed in Core through roles. The CTS
-        // member remains necessary because the selector stores its internal
-        // member ID in practical_examiners.other.
         $examinerAccount->assignRole($roleName);
 
         return $examinerMember;

--- a/tests/Feature/TrainingPanel/Exams/ExamRequestsTableTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamRequestsTableTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature\TrainingPanel\Exams;
 use App\Livewire\Training\ExamRequestsTable;
 use App\Models\Cts\Availability;
 use App\Models\Cts\ExamBooking;
-use App\Models\Cts\ExaminerSettings;
 use App\Models\Cts\Member;
 use App\Models\Cts\PracticalExaminers;
 use App\Models\Mship\Account;
@@ -63,27 +62,28 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
     }
 
     /**
-     * Secondary examiner Select options only include members with ExaminerSettings for the given column (S1=TWR, S2=APP, S3=CTR).
+     * Create a CTS member whose Core account has the examiner role matching
+     * the exam scope used by the selector (S1=TWR, S2=APP, S3=CTR).
      */
     protected function createExaminerMemberForScope(string $scopeColumn): Member
     {
         $examinerAccount = Account::factory()->create();
         $examinerMember = Member::factory()->forAccount($examinerAccount)->create(['examiner' => true]);
 
-        ExaminerSettings::create([
-            'memberID' => $examinerMember->id,
-            'OBS' => 0,
-            'S1' => $scopeColumn === 'S1' ? 1 : 0,
-            'S2' => $scopeColumn === 'S2' ? 1 : 0,
-            'S3' => $scopeColumn === 'S3' ? 1 : 0,
-            'P1' => 0,
-            'P2' => 0,
-            'P3' => 0,
-            'P4' => 0,
-            'P5' => 0,
-            'lastUpdated' => now(),
-            'updatedBy' => 0,
-        ]);
+        $roleName = [
+            'OBS' => 'ATC Examiner (OBS)',
+            'S1' => 'ATC Examiner (TWR)',
+            'S2' => 'ATC Examiner (APP)',
+            'S3' => 'ATC Examiner (CTR)',
+            'P1' => 'Pilot Examiner (P1)',
+            'P2' => 'Pilot Examiner (P2)',
+            'P3' => 'Pilot Examiner (P3)',
+        ][$scopeColumn] ?? throw new \InvalidArgumentException("Unknown test scope '{$scopeColumn}'.");
+
+        // The selector reads examiner eligibility from Core roles. The CTS
+        // member is still created because the saved option value must be its
+        // internal ID, not the Core account's VATSIM CID.
+        $examinerAccount->assignRole($roleName);
 
         return $examinerMember;
     }

--- a/tests/Feature/TrainingPanel/Exams/ExamRequestsTableTest.php
+++ b/tests/Feature/TrainingPanel/Exams/ExamRequestsTableTest.php
@@ -80,9 +80,6 @@ class ExamRequestsTableTest extends BaseTrainingPanelTestCase
             'P3' => 'Pilot Examiner (P3)',
         ][$scopeColumn] ?? throw new \InvalidArgumentException("Unknown test scope '{$scopeColumn}'.");
 
-        // The selector reads examiner eligibility from Core roles. The CTS
-        // member is still created because the saved option value must be its
-        // internal ID, not the Core account's VATSIM CID.
         $examinerAccount->assignRole($roleName);
 
         return $examinerMember;

--- a/tests/Unit/CTS/ExaminerRepositoryTest.php
+++ b/tests/Unit/CTS/ExaminerRepositoryTest.php
@@ -2,10 +2,11 @@
 
 namespace Tests\Unit\CTS;
 
-use App\Models\Cts\ExaminerSettings;
 use App\Models\Cts\Member;
+use App\Models\Mship\Account;
 use App\Repositories\Cts\ExaminerRepository;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -26,40 +27,60 @@ class ExaminerRepositoryTest extends TestCase
     #[Test]
     public function it_can_return_a_list_of_atc_examiners()
     {
-        $examiner = ExaminerSettings::factory()->create([
-            'S1' => 1,
-        ]);
+        $account = Account::factory()->create();
+        $account->assignRole('ATC Examiner (TWR)');
+        $member = Member::factory()->forAccount($account)->create();
 
         $examiners = $this->subjectUnderTest->getAtcExaminers();
 
-        $this->assertEquals($examiners->first(), $examiner->member->cid);
+        $this->assertContains($account->id, $examiners->all());
+        $this->assertNotEquals($member->id, $account->id);
     }
 
     #[Test]
     public function it_can_return_a_list_of_pilot_examiners()
     {
-        $examiner = ExaminerSettings::factory()->create([
-            'P1' => 1,
-        ]);
+        $account = Account::factory()->create();
+        $account->assignRole('Pilot Examiner (P1)');
+        Member::factory()->forAccount($account)->create();
 
         $examiners = $this->subjectUnderTest->getPilotExaminers();
 
-        $this->assertEquals($examiners->first(), $examiner->member->cid);
+        $this->assertEquals($account->id, $examiners->first());
     }
 
     #[Test]
-    public function it_does_not_return_an_examiner_if_not_set_as_examiner_on_members_table()
+    public function it_returns_the_cts_member_id_for_examiner_details()
     {
-        ExaminerSettings::factory()->create([
-            'memberID' => Member::factory()->create(['examiner' => 0])->id,
-            'S1' => 1,
-            'P1' => 1,
-        ]);
+        $account = Account::factory()->create();
+        $account->assignRole('ATC Examiner (APP)');
+        $member = Member::factory()->forAccount($account)->create();
 
-        $atcExaminers = $this->subjectUnderTest->getAtcExaminers();
-        $pilotExaminers = $this->subjectUnderTest->getPilotExaminers();
+        $examiners = $this->subjectUnderTest->getExaminerDetailsByScope('app');
 
-        $this->assertNull($atcExaminers->first());
-        $this->assertNull($pilotExaminers->first());
+        $this->assertSame([
+            'cid' => $account->id,
+            'name' => $account->name,
+            'id' => $member->id,
+        ], $examiners->first());
+    }
+
+    #[Test]
+    public function it_excludes_an_examiner_account_without_a_cts_member()
+    {
+        $account = Account::factory()->create();
+        $account->assignRole('ATC Examiner (APP)');
+
+        $examiners = $this->subjectUnderTest->getExaminerDetailsByScope('app');
+
+        $this->assertCount(0, $examiners);
+    }
+
+    #[Test]
+    public function it_rejects_an_unknown_examiner_scope()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->subjectUnderTest->getExaminerDetailsByScope('unknown');
     }
 }


### PR DESCRIPTION
Fixes #5012 

# Summary of changes

This PR fixes an issue where accepting an exam request in the Training Panel used a legacy CTS examinerSettings query to populate the Secondary Examiner selection dropdown. As a result, examiners assigned via the Manage Examiners page (ATC Examiner (TWR), ATC Examiner (APP), etc.) were not appearing in the selection list.

The selection logic in ExaminerRepository.php has been refactored to query Core Account models by their active Spatie roles, and then cross-reference those accounts with CTS Member records using the VATSIM CID to maintain data compatibility with legacy tables.

##Verification & Evidence

1. Managing Examiners

Assigned accounts to ATC Examiner (TWR) and ATC Examiner (APP) roles via the Manage Examiners interface.

<img width="900" height="537" alt="TWR Examiners" src="https://github.com/user-attachments/assets/95b19f1d-df82-4819-90fe-881aa1b960ca" />
_Tower Examiners_

<img width="1260" height="433" alt="APP Examiners" src="https://github.com/user-attachments/assets/556d9ad4-0a36-48e8-8ded-057f56d31c1b" />
_App Examiners_

2. Secondary Examiner Selector Alignment

Verified that when accepting a TWR exam, only accounts with the ATC Examiner (TWR) role are displayed in the dropdown.

<img width="957" height="535" alt="TWR Selection" src="https://github.com/user-attachments/assets/e6a8fa76-bc8c-4e83-bc5c-9f404d316cd2" />

Verified that when accepting an APP exam, only accounts with the ATC Examiner (APP) role are displayed in the dropdown.

<img width="927" height="544" alt="App Selection" src="https://github.com/user-attachments/assets/6a2b5608-8834-45bd-93a5-4a560864db88" />

3. Test Results

Executed php artisan tests:

- `php artisan test tests/Unit/CTS/ExaminerRepositoryTest.php`
- `php artisan test tests/Feature/Training/Exams/ExamRequestsTableSecondaryExaminerScopingTest.php`
- `php artisan test tests/Feature/TrainingPanel/Exams/ExamRequestsTableTest.php`
 
 and verified all tests pass without errors.
<img width="960" height="197" alt="Test1" src="https://github.com/user-attachments/assets/e0f234cd-882b-4705-8a4a-e8bbaccb8f50" />
<img width="954" height="176" alt="Test2" src="https://github.com/user-attachments/assets/fb4a9e6c-7c2a-4976-86aa-0af433b4d486" />
<img width="805" height="385" alt="Test3" src="https://github.com/user-attachments/assets/761283f5-9b5f-44a4-9a72-8ce35f424786" />
